### PR TITLE
fix: history doesn't work

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -45,7 +45,7 @@ jobs:
         run: dotnet test --verbosity normal
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LiveCaptionsTranslator
           path: ./publish

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: LiveCaptionsTranslator
           path: ./release

--- a/LiveCaptionsTranslator.csproj
+++ b/LiveCaptionsTranslator.csproj
@@ -30,7 +30,7 @@
 		
 		<PackageReference Include="Interop.UIAutomationClient" Version="10.19041.0" />
 		
-		<PackageReference Include="System.Data.SQLite" Version="1.0.119" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.1" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="WPF-UI" Version="3.0.5" />

--- a/LiveCaptionsTranslator.csproj
+++ b/LiveCaptionsTranslator.csproj
@@ -7,7 +7,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>
-		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
 		<PublishReadyToRun>false</PublishReadyToRun>
 		<PublishSingleFile>true</PublishSingleFile>
 		<SelfContained>false</SelfContained>

--- a/src/history/HistoryLogger.cs
+++ b/src/history/HistoryLogger.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.SQLite;
+﻿using Microsoft.Data.Sqlite;
 
 namespace LiveCaptionsTranslator.models
 {
@@ -13,11 +13,11 @@ namespace LiveCaptionsTranslator.models
 
     public static class SQLiteHistoryLogger
     {
-        private static readonly string ConnectionString = "Data Source=translation_history.db;Version=3;";
+        private static readonly string ConnectionString = "Data Source=translation_history.db;";
 
         static SQLiteHistoryLogger()
         {
-            using (var connection = new SQLiteConnection(ConnectionString))
+            using (var connection = new SqliteConnection(ConnectionString))
             {
                 connection.Open();
                 string createTableQuery = @"
@@ -29,7 +29,7 @@ namespace LiveCaptionsTranslator.models
                         TargetLanguage TEXT,
                         ApiUsed TEXT
                     )";
-                using (var command = new SQLiteCommand(createTableQuery, connection))
+                using (var command = new SqliteCommand(createTableQuery, connection))
                 {
                     command.ExecuteNonQuery();
                 }
@@ -39,14 +39,14 @@ namespace LiveCaptionsTranslator.models
         public static async Task LogTranslation(string sourceText, string translatedText, string targetLanguage,
             string apiUsed)
         {
-            using (var connection = new SQLiteConnection(ConnectionString))
+            using (var connection = new SqliteConnection(ConnectionString))
             {
                 await connection.OpenAsync();
                 string insertQuery = @"
                     INSERT INTO TranslationHistory (Timestamp, SourceText, TranslatedText, TargetLanguage, ApiUsed)
                     VALUES (@Timestamp, @SourceText, @TranslatedText, @TargetLanguage, @ApiUsed)";
 
-                using (var command = new SQLiteCommand(insertQuery, connection))
+                using (var command = new SqliteCommand(insertQuery, connection))
                 {
                     command.Parameters.AddWithValue("@Timestamp", DateTime.Now);
                     command.Parameters.AddWithValue("@SourceText", sourceText);
@@ -62,14 +62,14 @@ namespace LiveCaptionsTranslator.models
         {
             var history = new List<TranslationHistoryEntry>();
 
-            using (var connection = new SQLiteConnection(ConnectionString))
+            using (var connection = new SqliteConnection(ConnectionString))
             {
                 await connection.OpenAsync();
                 string selectQuery = @"
                     SELECT Timestamp, SourceText, TranslatedText, TargetLanguage, ApiUsed 
                     FROM TranslationHistory ORDER BY Timestamp DESC";
 
-                using (var command = new SQLiteCommand(selectQuery, connection))
+                using (var command = new SqliteCommand(selectQuery, connection))
                 using (var reader = await command.ExecuteReaderAsync())
                 {
                     while (await reader.ReadAsync())
@@ -92,9 +92,9 @@ namespace LiveCaptionsTranslator.models
         {
             await Task.Run(() =>
             {
-                using var connection = new SQLiteConnection(ConnectionString);
+                using var connection = new SqliteConnection(ConnectionString);
                 connection.Open();
-                using var command = new SQLiteCommand("DELETE FROM TranslationHistory", connection);
+                using var command = new SqliteCommand("DELETE FROM TranslationHistory", connection);
                 command.ExecuteNonQuery();
             });
         }


### PR DESCRIPTION
This PR contains:
- fix: fix arm64 history issue by migrating from `System.Data.SQLite` to `Microsoft.Data.Sqlite`
- chore: add win-arm64 as a supported RuntimeIdentifier in order to support arm64 develop better
- chore: update GitHub CI upload/download :)

Known Issue:
- When the database grows too **LARGE** ——_in my case 200KB_ (are we redefining large?) ——the application may freeze  when use history function.
- Some users have reported that the application becomes unresponsive when opening for the first time. I can reproduce this several days ago but now not. I think migrate to `Microsoft.Data.Sqlite` _might_ solve this. 
- The application currently does not log events, making debugging more difficult. As mentioned above, we don't know what caused app stuck.