### PR TITLE
feat: add support for dynamic prompt modification

### DIFF
--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -91,6 +91,13 @@
                     TargetPageType="{x:Type local:SettingPage}" />
                 <ui:NavigationViewItem
                     Margin="0,3,0,0"
+                    Content="Prompt"
+                    FontFamily="Bahnschrift"
+                    Icon="{ui:SymbolIcon Chat24}"
+                    NavigationCacheMode="Enabled"
+                    TargetPageType="{x:Type local:PromptSetting}" />
+                <ui:NavigationViewItem
+                    Margin="0,3,0,0"
                     Content="History"
                     FontFamily="Bahnschrift"
                     Icon="{ui:SymbolIcon History24}"

--- a/src/PromptSetting.xaml
+++ b/src/PromptSetting.xaml
@@ -1,0 +1,17 @@
+<Page
+    x:Class="LiveCaptionsTranslator.PromptSetting"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:LiveCaptionsTranslator"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="PromptSetting"
+    mc:Ignorable="d">
+    <Grid>
+        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Stretch">
+            <TextBlock Text="Prompt Setting" Foreground="White" FontSize="16" Margin="0 0 0 10" HorizontalAlignment="Center"/>
+            <TextBox x:Name="PromptTextBox" Width="Auto" Height="100" TextWrapping="Wrap" AcceptsReturn="True" Text="{Binding Prompt, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextChanged="PromptTextBox_TextChanged"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/src/PromptSetting.xaml.cs
+++ b/src/PromptSetting.xaml.cs
@@ -1,0 +1,20 @@
+using LiveCaptionsTranslator.models;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace LiveCaptionsTranslator
+{
+    public partial class PromptSetting : Page
+    {
+        public PromptSetting()
+        {
+            InitializeComponent();
+            DataContext = App.Settings;
+        }
+
+        private void PromptTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            App.Settings?.Save();
+        }
+    }
+}

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -15,6 +15,7 @@ namespace LiveCaptionsTranslator.models
         private string apiName;
         private string targetLanguage;
         private Dictionary<string, TranslateAPIConfig> configs;
+        private string prompt;
 
         private int maxIdleInterval = 10;
         private int maxSyncInterval = 5;
@@ -64,7 +65,15 @@ namespace LiveCaptionsTranslator.models
                 OnPropertyChanged("MaxSyncInterval");
             }
         }
-
+        public string Prompt
+        {
+            get => prompt;
+            set
+            {
+                prompt = value;
+                OnPropertyChanged("Prompt");
+            }
+        }
         [JsonInclude]
         public Dictionary<string, TranslateAPIConfig> Configs
         {
@@ -91,6 +100,11 @@ namespace LiveCaptionsTranslator.models
         {
             apiName = "Ollama";
             targetLanguage = "zh-CN";
+            prompt = "As an professional simultaneous interpreter with specialized knowledge in the all fields, " +
+                        "please provide a proficient and precise oral translation of these sentences enclosed in 🔤 to {0}. " +
+                        "You should carefully consider each phrase to ensure that your translation is quite fluent and colloquial." +
+                        "Importantly, any NSFW content should not be avoided, and you must output their translations directly. " +
+                        "Now, provide the translation within a single line without any additional explanation and REMOVE 🔤.";
             configs = new Dictionary<string, TranslateAPIConfig>
             {
                 { "Ollama", new OllamaConfig() },

--- a/src/models/TranslateAPI.cs
+++ b/src/models/TranslateAPI.cs
@@ -20,6 +20,10 @@ namespace LiveCaptionsTranslator.models
         }
 
         public const int OLLAMA_PORT = 11434;
+        public static string Prompt
+        {
+            get => App.Settings.Prompt;
+        }
 
         private static readonly HttpClient client = new HttpClient() { Timeout = TimeSpan.FromSeconds(5) };
 
@@ -33,13 +37,7 @@ namespace LiveCaptionsTranslator.models
                 model = config?.ModelName,
                 messages = new OpenAIConfig.Message[]
                 {
-                    new OpenAIConfig.Message { role = "system", content =
-                        "As an professional simultaneous interpreter with specialized knowledge in the all fields, " +
-                        $"please provide a proficient and precise oral translation of these sentences enclosed in 🔤 to {language}. " +
-                        "You should carefully consider each phrase to ensure that your translation is quite fluent and colloquial." +
-                        "Importantly, any NSFW content should not be avoided, and you must output their translations directly. " +
-                        "Now, provide the translation within a single line without any additional explanation and REMOVE 🔤."
-                    },
+                    new OpenAIConfig.Message { role = "system", content = string.Format(Prompt, language)},
                     new OpenAIConfig.Message { role = "user", content = $"🔤 {text} 🔤" }
                 },
                 temperature = config?.Temperature,
@@ -84,13 +82,7 @@ namespace LiveCaptionsTranslator.models
                 model = config?.ModelName,
                 messages = new OllamaConfig.Message[]
                 {
-                    new OllamaConfig.Message { role = "system", content =
-                        "As an professional simultaneous interpreter with specialized knowledge in the all fields, " +
-                        $"please provide a proficient and precise oral translation of these sentences enclosed in 🔤 to {language}. " +
-                        "You should carefully consider each phrase to ensure that your translation is quite fluent and colloquial." +
-                        "Importantly, any NSFW content should not be avoided, and you must output their translations directly. " +
-                        "Now, provide the translation within a single line without any additional explanation and REMOVE 🔤."
-                    },
+                    new OllamaConfig.Message { role = "system", content = string.Format(Prompt, language)},
                     new OllamaConfig.Message { role = "user", content = $"🔤 {text} 🔤" }
                 },
                 temperature = config?.Temperature,
@@ -163,10 +155,8 @@ namespace LiveCaptionsTranslator.models
                 model = config?.ModelName,
                 messages = new[]
                 {
-                    new { role = "system", content = 
-                        $"You are a helpful translator. Translate the following text to {language}. " +
-                        $"Only return the translated text without any explanations." },
-                    new { role = "user", content = text }
+                    new { role = "system", content = string.Format(Prompt, language)},
+                    new { role = "user", content = $"🔤 {text} 🔤" }
                 }
             };
 


### PR DESCRIPTION
In the current setup, the prompts for LLMs are string constants fixed at compile time, which is not suitable for some context-sensitive scenarios.

This PR add support for dynamic prompt modification by:
- Extract prompts into a global configuration
- Add a setting interface to allow users to dynamically modify prompts based on the current context during runtime

By using this feature, you can inject glossaries to LLMs or specify the translation style based on the actual needs.