### PR TITLE
Changed history export file name base on datetime.now

### DIFF
--- a/src/HistoryPage.xaml.cs
+++ b/src/HistoryPage.xaml.cs
@@ -98,7 +98,7 @@ namespace LiveCaptionsTranslator
             {
                 Filter = "CSV (*.csv)|*.csv|All file (*.*)|*.*",
                 DefaultExt = ".csv",
-                FileName = "exported_data.csv",
+                FileName = $"exported_{DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}.csv",
                 InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
             };
             


### PR DESCRIPTION
Windows keeps asking me to replace the old export file, and I have to change the name in the saving dialog by myself.