### PR TITLE
feat: improve history capture and added caption log card

### DIFF
--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -39,6 +39,14 @@
                 <ui:TitleBar.TrailingContent>
                     <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                         <ui:Button
+                            x:Name="captionLog"
+                            Margin="0,0,5,0"
+                            Appearance="Transparent"
+                            Click="CaptionLog_OnClickButton_Click"
+                            Icon="{ui:SymbolIcon History24,
+                                                 Filled=False}"
+                            ToolTip="Caption Log" />
+                        <ui:Button
                             x:Name="logOnly"
                             Margin="0,0,5,0"
                             Appearance="Transparent"

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace LiveCaptionsTranslator
             var windowState = WindowHandler.LoadState(this, App.Settings);
             WindowHandler.RestoreState(this, windowState);
             ToggleTopmost(App.Settings.TopMost);
+            EnableCaptionLog(App.Settings.CaptionLogEnable);
         }
 
         private void TopmostButton_Click(object sender, RoutedEventArgs e)
@@ -105,6 +106,28 @@ namespace LiveCaptionsTranslator
             Topmost = enable;
             symbolIcon.Filled = enable;
             App.Settings.TopMost = enable;
+        }
+
+        private void CaptionLog_OnClickButton_Click(object sender, RoutedEventArgs e)
+        {
+            App.Settings.CaptionLogEnable = !App.Settings.CaptionLogEnable;
+            EnableCaptionLog(App.Settings.CaptionLogEnable);
+        }
+
+        private void EnableCaptionLog(bool enable)
+        {
+            if (captionLog.Icon is SymbolIcon icon)
+            {
+                if (enable)
+                {
+                    icon.Symbol = SymbolRegular.History24;
+                }
+                else
+                {
+                    icon.Symbol = SymbolRegular.HistoryDismiss24;
+                    App.Captions.ClearCaptionLog();
+                }
+            }
         }
     }
 }

--- a/src/models/Caption.cs
+++ b/src/models/Caption.cs
@@ -44,6 +44,14 @@ namespace LiveCaptionsTranslator.models
             }
         }
 
+        private readonly Queue<CaptionLogItem> captionLog = new(6);
+        public class CaptionLogItem
+        {
+            public string OriginalCaptionLog { get; set; }
+            public string TranslatedCaptionLog { get; set; }
+        }
+        public IEnumerable<CaptionLogItem> CaptionHistory => captionLog.Reverse();
+
         private Caption() { }
 
         public static Caption GetInstance()
@@ -63,6 +71,8 @@ namespace LiveCaptionsTranslator.models
         {
             int idleCount = 0;
             int syncCount = 0;
+            string originalLatest = "originalLatest";
+            string captionLatest = "";
 
             while (true)
             {
@@ -72,6 +82,8 @@ namespace LiveCaptionsTranslator.models
                     continue;
                 }
 
+                // Is caption textbox change to another sentence
+                bool captionTrim = false;
                 // Get the text recognized by LiveCaptions.
                 string fullText = string.Empty;
                 try
@@ -108,11 +120,17 @@ namespace LiveCaptionsTranslator.models
                     // If the last sentence is too short, extend it by adding the previous sentence when displayed.
                     if (lastEOSIndex > 0 && Encoding.UTF8.GetByteCount(latestCaption) < 12)
                     {
+                        captionTrim = true;
                         lastEOSIndex = fullText[0..lastEOSIndex].LastIndexOfAny(PUNC_EOS);
                         DisplayOriginalCaption = fullText.Substring(lastEOSIndex + 1);
                     }
                     // If the last sentence is too long, truncate it when displayed.
-                    DisplayOriginalCaption = ShortenDisplaySentence(DisplayOriginalCaption, 160);
+                    string newDOC = ShortenDisplaySentence(DisplayOriginalCaption, 160);
+                    if (DisplayOriginalCaption != newDOC)
+                    {
+                        captionTrim = true;
+                    }
+                    DisplayOriginalCaption = newDOC;
                 }
 
                 // OriginalCaption: The sentence to be really translated.
@@ -129,9 +147,29 @@ namespace LiveCaptionsTranslator.models
                         syncCount = 0;
                         TranslateFlag = true;
                         EOSFlag = true;
+                        captionTrim = true;
                     }
                     else
                         EOSFlag = false;
+
+                    if (DisplayOriginalCaption != OriginalCaption)
+                        captionTrim = true;
+
+                    // Push current caption to history without waiting for async
+                    if (captionTrim)
+                    {
+                        string displayOG = StringTrim(DisplayOriginalCaption, 0, DisplayOriginalCaption.LastIndexOfAny(PUNC_EOS) + 1);
+                        string oc = captionLatest;
+                        string _oc = StringTrim(oc, 3, oc.Length - 3).ToLower();
+                        string _ol = StringTrim(originalLatest, 3, originalLatest.Length - 3).ToLower();
+                        if (_oc != _ol) // Prevent from spamming
+                        {
+                            originalLatest = oc;
+                            var historyTask = Task.Run(() => HistoryCapture(displayOG));
+                        }
+                    }
+                    else
+                        captionLatest = DisplayOriginalCaption;
                 }
                 else
                     idleCount++;
@@ -146,6 +184,64 @@ namespace LiveCaptionsTranslator.models
                 }
                 Thread.Sleep(25);
             }
+        }
+
+        private string StringTrim(string text, int start, int length)
+        {
+            try
+            {
+                return text.Substring(start, length);
+            }
+            catch
+            {
+                return text;
+            }
+        }
+
+        private async Task HistoryCapture(string original)
+        {
+            string unixTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
+            string translated = "[Paused]";
+            string targetLanguage = App.Settings.TargetLanguage;
+            string apiName = App.Settings.ApiName;
+            bool captionLog = App.Settings.CaptionLogEnable;
+
+            // Insert history database
+            try
+            {
+                if (LogOnlyFlag) // Log only mode no translate
+                {
+                    SQLiteHistoryLogger.LogTranslation(unixTime, original, "N/A", "N/A", "LogOnly");
+                }
+                else
+                {
+                    translated = await Translator.Translate(original);
+                    SQLiteHistoryLogger.LogTranslation(unixTime, original, translated, targetLanguage, apiName);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Error] Logging history failed: {ex.Message}");
+            }
+
+            // Add caption log card
+            if (captionLog)
+            {
+                if (this.captionLog.Count >= App.Settings.CaptionLogMax + 1)
+                    this.captionLog.Dequeue();
+                this.captionLog.Enqueue(new CaptionLogItem
+                {
+                    OriginalCaptionLog = original,
+                    TranslatedCaptionLog = translated
+                });
+                OnPropertyChanged(nameof(CaptionHistory));
+            }
+        }
+
+        public void ClearCaptionLog()
+        {
+            captionLog.Clear();
+            OnPropertyChanged(nameof(CaptionHistory));
         }
 
         public async Task Translate()
@@ -163,30 +259,18 @@ namespace LiveCaptionsTranslator.models
                 {
                     var originalSnapshot = OriginalCaption;
 
-                    // If the old sentence is the prefix of the new sentence,
-                    // overwrite the previous entry when logging.
-                    string lastLoggedOriginal = await SQLiteHistoryLogger.LoadLatestSourceText();
-                    bool isOverWrite = !string.IsNullOrEmpty(lastLoggedOriginal)
-                        && originalSnapshot.StartsWith(lastLoggedOriginal);
-
                     // Log Only
                     if (LogOnlyFlag)
                     {
                         // Do not translate
                         TranslatedCaption = string.Empty;
                         DisplayTranslatedCaption = "[Paused]";
-                        // Log
-                        var LogOnlyTask = Task.Run(
-                            () => Translator.LogOnly(originalSnapshot, isOverWrite));
                     }
                     else
                     {
                         // Translate and display
                         TranslatedCaption = await Translator.Translate(originalSnapshot);
                         DisplayTranslatedCaption = ShortenDisplaySentence(TranslatedCaption, 240);
-                        // Log
-                        var LogTask = Task.Run(
-                            () => Translator.Log(originalSnapshot, TranslatedCaption, App.Settings, isOverWrite));
                     }
 
                     TranslateFlag = false;

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -24,6 +24,9 @@ namespace LiveCaptionsTranslator.models
         private Dictionary<string, string> windowBounds;
         private bool topmost = true;
 
+        private bool captionLogEnable = true;
+        private int captionLogMax = 0;
+
         private Dictionary<string, TranslateAPIConfig> configs;
         private TranslateAPIConfig? currentAPIConfig;
 
@@ -69,6 +72,27 @@ namespace LiveCaptionsTranslator.models
                 OnPropertyChanged("MaxSyncInterval");
             }
         }
+
+        public bool CaptionLogEnable
+        {
+            get => captionLogEnable;
+            set
+            {
+                captionLogEnable = value;
+                OnPropertyChanged("CaptionLogEnable");
+            }
+        }
+
+        public int CaptionLogMax
+        {
+            get => captionLogMax;
+            set
+            {
+                captionLogMax = value;
+                OnPropertyChanged("CaptionLogMax");
+            }
+        }
+
         public string Prompt
         {
             get => prompt;

--- a/src/pages/CaptionPage.xaml
+++ b/src/pages/CaptionPage.xaml
@@ -10,10 +10,10 @@
     Title="CaptionPage"
     mc:Ignorable="d">
 
-    <Grid>
+    <Grid Margin="15,10,15,15">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.Resources>
             <Style x:Key="CaptionBlockStyle" TargetType="TextBlock">
@@ -22,33 +22,103 @@
             </Style>
         </Grid.Resources>
 
+        <Grid Grid.Row="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <ui:Card
+                Grid.Row="0"
+                Padding="8"
+                VerticalAlignment="Stretch">
+                <TextBlock
+                    x:Name="OriginalCaption"
+                    Background="Transparent"
+                    Cursor="Hand"
+                    FontSize="15"
+                    MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
+                    Style="{StaticResource CaptionBlockStyle}"
+                    Text="{Binding DisplayOriginalCaption, UpdateSourceTrigger=PropertyChanged}"
+                    ToolTip="Click To Copy" />
+            </ui:Card>
+            <ui:Card
+                Grid.Row="1"
+                Margin="0,3,0,0"
+                Padding="8"
+                VerticalAlignment="Stretch">
+                <TextBlock
+                    x:Name="TranslatedCaption"
+                    Background="Transparent"
+                    Cursor="Hand"
+                    FontSize="18"
+                    MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
+                    Style="{StaticResource CaptionBlockStyle}"
+                    Text="{Binding DisplayTranslatedCaption, UpdateSourceTrigger=PropertyChanged}"
+                    ToolTip="Click To Copy" />
+            </ui:Card>
+        </Grid>
+
         <ui:Card
-            Grid.Row="0"
-            Margin="15,3,20,1"
-            Padding="8"
-            VerticalAlignment="Stretch">
-            <TextBlock
-                x:Name="OriginalCaption"
-                Cursor="Hand"
-                FontSize="15"
-                MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
-                Style="{StaticResource CaptionBlockStyle}"
-                Text="{Binding DisplayOriginalCaption, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="Click to copy" />
-        </ui:Card>
-        <ui:Card
+            x:Name="CaptionLogCard"
             Grid.Row="1"
-            Margin="15,1,20,3"
+            Margin="0,3,0,5"
             Padding="8"
-            VerticalAlignment="Stretch">
-            <TextBlock
-                x:Name="TranslatedCaption"
-                Cursor="Hand"
-                FontSize="18"
-                MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
-                Style="{StaticResource CaptionBlockStyle}"
-                Text="{Binding DisplayTranslatedCaption, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="Click to copy" />
+            VerticalAlignment="Top"
+            Background="Transparent"
+            BorderBrush="#00000000">
+            <ItemsControl
+                MinHeight="50"
+                ItemsSource="{Binding CaptionHistory}"
+                VirtualizingPanel.IsVirtualizing="True">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border
+                            Margin="0,0,0,5"
+                            Padding="10,5,10,5"
+                            BorderBrush="#20000000"
+                            BorderThickness="0,1,0,0">
+                            <Grid Grid.Row="0">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <ui:Card
+                                    Grid.Row="0"
+                                    Padding="8"
+                                    VerticalAlignment="Stretch">
+                                    <TextBlock
+                                        x:Name="OriginalCaptionLog"
+                                        Background="Transparent"
+                                        Cursor="Hand"
+                                        FontSize="12"
+                                        MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
+                                        Style="{StaticResource CaptionBlockStyle}"
+                                        Text="{Binding OriginalCaptionLog}"
+                                        ToolTip="Click To Copy" />
+                                </ui:Card>
+                                <ui:Card
+                                    Grid.Row="1"
+                                    Margin="0,3,0,0"
+                                    Padding="8"
+                                    VerticalAlignment="Stretch">
+                                    <TextBlock
+                                        x:Name="TranslatedCaptionLog"
+                                        Background="Transparent"
+                                        Cursor="Hand"
+                                        FontSize="16"
+                                        MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
+                                        Style="{StaticResource CaptionBlockStyle}"
+                                        Text="{Binding TranslatedCaptionLog}"
+                                        ToolTip="Click To Copy" />
+                                </ui:Card>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </ui:Card>
+
     </Grid>
 </Page>

--- a/src/pages/SettingPage.xaml
+++ b/src/pages/SettingPage.xaml
@@ -16,6 +16,7 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
         <StackPanel Grid.Column="0" Orientation="Vertical">
@@ -136,7 +137,28 @@
             </StackPanel>
         </StackPanel>
 
-        <Grid x:Name="OpenAIGrid" Grid.Column="2">
+        <StackPanel Grid.Column="2" Orientation="Vertical">
+            <StackPanel Margin="15,0,0,0" Orientation="Vertical">
+                <TextBlock Margin="2.5,0,0,5" Text="Max Caption Log" />
+                <ComboBox
+                    x:Name="captionLogMax"
+                    Width="150"
+                    Height="30"
+                    Padding="10,4,10,7"
+                    FontSize="13.3"
+                    SelectedIndex="{Binding CaptionLogMax, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    SelectionChanged="captionLogMax_SelectionChanged">
+                    <ComboBoxItem Content="1" />
+                    <ComboBoxItem Content="2" />
+                    <ComboBoxItem Content="3" />
+                    <ComboBoxItem Content="4" />
+                    <ComboBoxItem Content="5" />
+                    <ComboBoxItem Content="6" />
+                </ComboBox>
+            </StackPanel>
+        </StackPanel>
+
+        <Grid x:Name="OpenAIGrid" Grid.Column="3">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -205,7 +227,7 @@
             </StackPanel>
         </Grid>
 
-        <Grid x:Name="OllamaGrid" Grid.Column="2">
+        <Grid x:Name="OllamaGrid" Grid.Column="3">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -265,7 +287,7 @@
             </StackPanel>
         </Grid>
 
-        <Grid x:Name="OpenRouterGrid" Grid.Column="2">
+        <Grid x:Name="OpenRouterGrid" Grid.Column="3">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/pages/SettingPage.xaml.cs
+++ b/src/pages/SettingPage.xaml.cs
@@ -92,6 +92,10 @@ namespace LiveCaptionsTranslator
             FrequencyInfoFlyout.Hide();
         }
 
+        private void captionLogMax_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            App.Captions.ClearCaptionLog();
+        }
         private void LoadAPISetting()
         {
             string targetLang = App.Settings.TargetLanguage;

--- a/src/utils/HistoryLogger.cs
+++ b/src/utils/HistoryLogger.cs
@@ -31,7 +31,7 @@ namespace LiveCaptionsTranslator.utils
             }
         }
 
-        public static async Task LogTranslation(string sourceText, string translatedText, string targetLanguage,
+        public static async Task LogTranslation(string unixTime, string sourceText, string translatedText, string targetLanguage,
             string apiUsed)
         {
             using (var connection = new SqliteConnection(CONNECTION_STRING))
@@ -43,7 +43,7 @@ namespace LiveCaptionsTranslator.utils
 
                 using (var command = new SqliteCommand(insertQuery, connection))
                 {
-                    command.Parameters.AddWithValue("@Timestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+                    command.Parameters.AddWithValue("@Timestamp", unixTime);
                     command.Parameters.AddWithValue("@SourceText", sourceText);
                     command.Parameters.AddWithValue("@TranslatedText", translatedText);
                     command.Parameters.AddWithValue("@TargetLanguage", targetLanguage);

--- a/src/utils/Translator.cs
+++ b/src/utils/Translator.cs
@@ -29,48 +29,5 @@ namespace LiveCaptionsTranslator.utils
             }
             return translatedText;
         }
-
-        public static async Task Log(string originalText, string translatedText, 
-            Setting? setting = null, bool isOverWrite = false)
-        {
-            string targetLanguage, apiName;
-            if (setting != null)
-            {
-                targetLanguage = App.Settings.TargetLanguage;
-                apiName = App.Settings.ApiName;
-            } 
-            else
-            {
-                targetLanguage = "N/A";
-                apiName = "N/A";
-            }
-
-            try
-            {
-                if (isOverWrite)
-                    await SQLiteHistoryLogger.DeleteLatestTranslation();
-                await SQLiteHistoryLogger.LogTranslation(originalText, translatedText, targetLanguage, apiName);
-                TranslationLogged?.Invoke();
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"[Error] Logging history failed: {ex.Message}");
-            }
-        }
-
-        public static async Task LogOnly(string originalText, bool isOverWrite = false)
-        {
-            try
-            {
-                if (isOverWrite)
-                    await SQLiteHistoryLogger.DeleteLatestTranslation();
-                await SQLiteHistoryLogger.LogTranslation(originalText, "N/A", "N/A", "LogOnly");
-                TranslationLogged?.Invoke();
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"[Error] Logging history failed: {ex.Message}");
-            }
-        }
     }
 }


### PR DESCRIPTION
- Improved how history has to be captured.
- Re-translate the full caption after getting captured.
- Added card to display previous max 6 captions (setting).
- Added title bar button to toggle caption log feature.

![image](https://github.com/user-attachments/assets/36093fb4-be8f-4572-b880-be17199b94e6)