### PR TITLE
feat: added overlay subtitle control panel

### DIFF
--- a/src/SubtitleWindow.xaml
+++ b/src/SubtitleWindow.xaml
@@ -59,7 +59,7 @@
                     Grid.Row="0"
                     Margin="5,3,5,1"
                     Padding="8"
-                    VerticalAlignment="Stretch"
+                    VerticalAlignment="Top"
                     Background="Transparent"
                     BorderThickness="0">
                     <TextBlock
@@ -74,7 +74,7 @@
                     Grid.Row="1"
                     Margin="5,1,5,3"
                     Padding="8"
-                    VerticalAlignment="Stretch"
+                    VerticalAlignment="Top"
                     Background="Transparent"
                     BorderThickness="0">
                     <TextBlock

--- a/src/SubtitleWindow.xaml
+++ b/src/SubtitleWindow.xaml
@@ -13,6 +13,8 @@
     MinHeight="135"
     AllowsTransparency="True"
     Background="Transparent"
+    MouseEnter="Window_MouseEnter"
+    MouseLeave="Window_MouseLeave"
     ResizeMode="CanResize"
     ShowInTaskbar="False"
     Topmost="True"
@@ -30,6 +32,7 @@
 
     <Grid>
         <Border
+            x:Name="BorderBackground"
             Margin="5"
             Background="#80000000"
             CornerRadius="8"
@@ -77,6 +80,64 @@
                         Style="{StaticResource CaptionBlockStyle}"
                         Text="{Binding DisplayTranslatedCaption, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:Card>
+
+                <StackPanel
+                    x:Name="ControlPanel"
+                    Grid.Row="1"
+                    Margin="0,0,10,10"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Bottom"
+                    Orientation="Horizontal">
+                    <ui:Button
+                        x:Name="FontIncrease"
+                        Background="#B2FFFFFF"
+                        Click="FontIncrease_Click"
+                        Icon="{ui:SymbolIcon fontIncrease20,
+                                             Filled=False}"
+                        ToolTip="Font Increase" />
+                    <ui:Button
+                        x:Name="FontDecrease"
+                        Background="#B2FFFFFF"
+                        Click="FontDecrease_Click"
+                        Icon="{ui:SymbolIcon fontDecrease20,
+                                             Filled=False}"
+                        ToolTip="Font Decrease" />
+                    <ui:Button
+                        x:Name="FontColorCycle"
+                        Background="#B2FFFFFF"
+                        Click="FontColorCycle_Click"
+                        Icon="{ui:SymbolIcon color16,
+                                             Filled=False}"
+                        ToolTip="Font Color" />
+                    <ui:Button
+                        x:Name="FontBold"
+                        Background="#B2FFFFFF"
+                        Click="FontBold_Click"
+                        Icon="{ui:SymbolIcon textBold16,
+                                             Filled=False}"
+                        ToolTip="Font Bold" />
+                    <ui:Button
+                        x:Name="OpacityIncrease"
+                        Background="#B2FFFFFF"
+                        Click="OpacityIncrease_Click"
+                        Icon="{ui:SymbolIcon arrowAutofitUp20,
+                                             Filled=False}"
+                        ToolTip="Opacity Increase" />
+                    <ui:Button
+                        x:Name="OpacityDecrease"
+                        Background="#B2FFFFFF"
+                        Click="OpacityDecrease_Click"
+                        Icon="{ui:SymbolIcon arrowAutofitDown20,
+                                             Filled=False}"
+                        ToolTip="Opacity Decrease" />
+                    <ui:Button
+                        x:Name="ClickThrough"
+                        Background="#B2FFFFFF"
+                        Click="ClickThrough_Click"
+                        Icon="{ui:SymbolIcon cursorHoverOff16,
+                                             Filled=False}"
+                        ToolTip="Click Through" />
+                </StackPanel>
             </Grid>
         </Border>
 

--- a/src/SubtitleWindow.xaml
+++ b/src/SubtitleWindow.xaml
@@ -67,7 +67,16 @@
                         FontSize="15"
                         Foreground="#FFFFFFFF"
                         Style="{StaticResource CaptionBlockStyle}"
-                        Text="{Binding DisplayOriginalCaption, UpdateSourceTrigger=PropertyChanged}" />
+                        Text="{Binding DisplayOriginalCaption, UpdateSourceTrigger=PropertyChanged}">
+                        <TextBlock.Effect>
+                            <DropShadowEffect
+                                x:Name="OriginalCaptionShadow"
+                                BlurRadius="5"
+                                Direction="0"
+                                ShadowDepth="0"
+                                Color="Black" />
+                        </TextBlock.Effect>
+                    </TextBlock>
                 </ui:Card>
                 <ui:Card
                     x:Name="TranslatedCaptionCard"
@@ -82,7 +91,16 @@
                         FontSize="18"
                         Foreground="#FFFFFFFF"
                         Style="{StaticResource CaptionBlockStyle}"
-                        Text="{Binding DisplayTranslatedCaption, UpdateSourceTrigger=PropertyChanged}" />
+                        Text="{Binding DisplayTranslatedCaption, UpdateSourceTrigger=PropertyChanged}">
+                        <TextBlock.Effect>
+                            <DropShadowEffect
+                                x:Name="TranslatedCaptionShadow"
+                                BlurRadius="5"
+                                Direction="0"
+                                ShadowDepth="0"
+                                Color="Black" />
+                        </TextBlock.Effect>
+                    </TextBlock>
                 </ui:Card>
 
                 <StackPanel
@@ -121,7 +139,15 @@
                                              Filled=False}"
                         ToolTip="Font Bold" />
                     <ui:Button
+                        x:Name="FontShadow"
+                        Background="#B2FFFFFF"
+                        Click="FontShadow_Click"
+                        Icon="{ui:SymbolIcon squareShadow12,
+                                             Filled=False}"
+                        ToolTip="Font Shadow" />
+                    <ui:Button
                         x:Name="OpacityIncrease"
+                        Margin="5,0,0,0"
                         Background="#B2FFFFFF"
                         Click="OpacityIncrease_Click"
                         Icon="{ui:SymbolIcon arrowAutofitUp20,
@@ -143,6 +169,7 @@
                         ToolTip="Font Color" />
                     <ui:Button
                         x:Name="ClickThrough"
+                        Margin="5,0,0,0"
                         Background="#B2FFFFFF"
                         Click="ClickThrough_Click"
                         Icon="{ui:SymbolIcon cursorHoverOff16,

--- a/src/SubtitleWindow.xaml
+++ b/src/SubtitleWindow.xaml
@@ -35,6 +35,10 @@
             x:Name="BorderBackground"
             Margin="5"
             Background="#80000000"
+            CornerRadius="8" />
+        <Border
+            Margin="5"
+            Background="Transparent"
             CornerRadius="8"
             Cursor="SizeAll"
             MouseLeftButtonDown="Border_MouseLeftButtonDown">
@@ -130,6 +134,13 @@
                         Icon="{ui:SymbolIcon arrowAutofitDown20,
                                              Filled=False}"
                         ToolTip="Opacity Decrease" />
+                    <ui:Button
+                        x:Name="BackgroundColorCycle"
+                        Background="#B2FFFFFF"
+                        Click="BackgroundColorCycle_Click"
+                        Icon="{ui:SymbolIcon color16,
+                                             Filled=False}"
+                        ToolTip="Font Color" />
                     <ui:Button
                         x:Name="ClickThrough"
                         Background="#B2FFFFFF"

--- a/src/SubtitleWindow.xaml.cs
+++ b/src/SubtitleWindow.xaml.cs
@@ -41,11 +41,15 @@ namespace LiveCaptionsTranslator
             Loaded += (s, e) => App.Captions.PropertyChanged += TranslatedChanged;
             Unloaded += (s, e) => App.Captions.PropertyChanged -= TranslatedChanged;
 
-            ApplyFontSize();
-            TranslatedCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
-            OriginalCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
-            BorderBackground.Background = ColorList[App.Settings.OverlayBackgroundColor];
-            BorderBackground.Opacity = App.Settings.OverlayOpacity;
+            this.OriginalCaption.FontWeight = (App.Settings.OverlayFontBold == 3 ? FontWeights.Bold : FontWeights.Regular);
+            this.TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold >= 2 ? FontWeights.Bold : FontWeights.Regular);
+            this.OriginalCaptionShadow.Opacity = (App.Settings.OverlayFontShadow == 3 ? 1.0 : 0.0);
+            this.TranslatedCaptionShadow.Opacity = (App.Settings.OverlayFontShadow >= 2 ? 1.0 : 0.0);
+
+            this.TranslatedCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
+            this.OriginalCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
+            this.BorderBackground.Background = ColorList[App.Settings.OverlayBackgroundColor];
+            this.BorderBackground.Opacity = App.Settings.OverlayOpacity;
         }
 
         private void Border_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -147,11 +151,6 @@ namespace LiveCaptionsTranslator
                     this.TranslatedCaption.FontSize = this.OriginalCaption.FontSize + 4;
                 }), DispatcherPriority.Background);
             }
-
-            this.OriginalCaption.FontWeight = (App.Settings.OverlayFontBold == 3 ? FontWeights.Bold : FontWeights.Regular);
-            this.TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold >= 2 ? FontWeights.Bold : FontWeights.Regular);
-            this.OriginalCaptionShadow.Opacity = (App.Settings.OverlayFontShadow == 3 ? 1.0 : 0.0);
-            this.TranslatedCaptionShadow.Opacity = (App.Settings.OverlayFontShadow >= 2 ? 1.0 : 0.0);
         }
 
         public void ResizeForTranslationOnly()
@@ -258,7 +257,8 @@ namespace LiveCaptionsTranslator
             App.Settings.OverlayFontBold++;
             if (App.Settings.OverlayFontBold > (isTranslationOnly ? 2 : 3))
                 App.Settings.OverlayFontBold = 1;
-            ApplyFontSize();
+            this.OriginalCaption.FontWeight = (App.Settings.OverlayFontBold == 3 ? FontWeights.Bold : FontWeights.Regular);
+            this.TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold >= 2 ? FontWeights.Bold : FontWeights.Regular);
         }
         private void BackgroundColorCycle_Click(object sender, RoutedEventArgs e)
         {
@@ -274,7 +274,8 @@ namespace LiveCaptionsTranslator
             App.Settings.OverlayFontShadow++;
             if (App.Settings.OverlayFontShadow > (isTranslationOnly ? 2 : 3))
                 App.Settings.OverlayFontShadow = 1;
-            ApplyFontSize();
+            this.OriginalCaptionShadow.Opacity = (App.Settings.OverlayFontShadow == 3 ? 1.0 : 0.0);
+            this.TranslatedCaptionShadow.Opacity = (App.Settings.OverlayFontShadow >= 2 ? 1.0 : 0.0);
         }
     }
 }

--- a/src/SubtitleWindow.xaml.cs
+++ b/src/SubtitleWindow.xaml.cs
@@ -44,6 +44,7 @@ namespace LiveCaptionsTranslator
             ApplyFontSize();
             TranslatedCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
             OriginalCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
+            BorderBackground.Background = ColorList[App.Settings.OverlayBackgroundColor];
             BorderBackground.Opacity = App.Settings.OverlayOpacity;
         }
 
@@ -149,6 +150,8 @@ namespace LiveCaptionsTranslator
 
             this.OriginalCaption.FontWeight = (App.Settings.OverlayFontBold == 3 ? FontWeights.Bold : FontWeights.Regular);
             this.TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold >= 2 ? FontWeights.Bold : FontWeights.Regular);
+            this.OriginalCaptionShadow.Opacity = (App.Settings.OverlayFontShadow == 3 ? 1.0 : 0.0);
+            this.TranslatedCaptionShadow.Opacity = (App.Settings.OverlayFontShadow >= 2 ? 1.0 : 0.0);
         }
 
         public void ResizeForTranslationOnly()
@@ -219,21 +222,18 @@ namespace LiveCaptionsTranslator
 
         private void OpacityIncrease_Click(object sender, RoutedEventArgs e)
         {
-            if (App.Settings.OverlayOpacity + 0.05 < 1)
-            {
-                App.Settings.OverlayOpacity += 0.05;
-                BorderBackground.Opacity = App.Settings.OverlayOpacity;
-            }
+            App.Settings.OverlayOpacity += 0.05;
+            if (App.Settings.OverlayOpacity >= 1)
+                App.Settings.OverlayOpacity = 1.0; // Opacity = 0 make Border unhove
+            BorderBackground.Opacity = App.Settings.OverlayOpacity;
         }
 
         private void OpacityDecrease_Click(object sender, RoutedEventArgs e)
         {
-            if (App.Settings.OverlayOpacity - 0.05 > 0.05)
-            {
-
-                App.Settings.OverlayOpacity -= 0.05;
-                BorderBackground.Opacity = App.Settings.OverlayOpacity;
-            }
+            App.Settings.OverlayOpacity -= 0.05;
+            if (App.Settings.OverlayOpacity <= 0)
+                App.Settings.OverlayOpacity = 0.01;
+            BorderBackground.Opacity = App.Settings.OverlayOpacity;
         }
 
         private void FontColorCycle_Click(object sender, RoutedEventArgs e)
@@ -256,7 +256,7 @@ namespace LiveCaptionsTranslator
         private void FontBold_Click(object sender, RoutedEventArgs e)
         {
             App.Settings.OverlayFontBold++;
-            if (App.Settings.OverlayFontBold > 3)
+            if (App.Settings.OverlayFontBold > (isTranslationOnly ? 2 : 3))
                 App.Settings.OverlayFontBold = 1;
             ApplyFontSize();
         }
@@ -267,6 +267,14 @@ namespace LiveCaptionsTranslator
                 App.Settings.OverlayBackgroundColor = 1;
             BorderBackground.Background = ColorList[App.Settings.OverlayBackgroundColor];
             BorderBackground.Opacity = App.Settings.OverlayOpacity;
+        }
+
+        private void FontShadow_Click(object sender, RoutedEventArgs e)
+        {
+            App.Settings.OverlayFontShadow++;
+            if (App.Settings.OverlayFontShadow > (isTranslationOnly ? 2 : 3))
+                App.Settings.OverlayFontShadow = 1;
+            ApplyFontSize();
         }
     }
 }

--- a/src/SubtitleWindow.xaml.cs
+++ b/src/SubtitleWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows;
@@ -15,11 +14,13 @@ namespace LiveCaptionsTranslator
     {
         private Dictionary<int, Brush> ColorList = new Dictionary<int, Brush> {
             {1, Brushes.White},
-            {2, Brushes.Black},
-            {3, Brushes.Yellow},
-            {4, Brushes.Blue},
-            {5, Brushes.LawnGreen},
-            {6, Brushes.Red},
+            {2, Brushes.Yellow},
+            {3, Brushes.LimeGreen},
+            {4, Brushes.Aqua},
+            {5, Brushes.Blue},
+            {6, Brushes.DeepPink},
+            {7, Brushes.Red},
+            {8, Brushes.Black},
         };
         private bool isTranslationOnly = false;
         public bool IsTranslationOnly
@@ -176,12 +177,10 @@ namespace LiveCaptionsTranslator
 
         protected async override void OnSourceInitialized(EventArgs e)
         {
-            int opacity = App.Settings.OverlayOpacity;
-
             TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold ? FontWeights.Bold : FontWeights.Regular);
             TranslatedCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
             OriginalCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
-            BorderBackground.Background = new SolidColorBrush(Color.FromArgb((byte)opacity, (byte)0, (byte)0, (byte)0));
+            BorderBackground.Opacity = App.Settings.OverlayOpacity;
         }
 
         private void Window_MouseEnter(object sender, MouseEventArgs e)
@@ -206,20 +205,20 @@ namespace LiveCaptionsTranslator
 
         private void OpacityIncrease_Click(object sender, RoutedEventArgs e)
         {
-            if (App.Settings.OverlayOpacity + 10 < 255)
+            if (App.Settings.OverlayOpacity + 0.05 < 1)
             {
-                App.Settings.OverlayOpacity += 10;
-                BorderBackground.Background = new SolidColorBrush(Color.FromArgb((byte)App.Settings.OverlayOpacity, (byte)0, (byte)0, (byte)0));
+                App.Settings.OverlayOpacity += 0.05;
+                BorderBackground.Opacity = App.Settings.OverlayOpacity;
             }
         }
 
         private void OpacityDecrease_Click(object sender, RoutedEventArgs e)
         {
-            if (App.Settings.OverlayOpacity - 10 > 0)
+            if (App.Settings.OverlayOpacity - 0.05 > 0.05)
             {
 
-                App.Settings.OverlayOpacity -= 10;
-                BorderBackground.Background = new SolidColorBrush(Color.FromArgb((byte)App.Settings.OverlayOpacity, (byte)0, (byte)0, (byte)0));
+                App.Settings.OverlayOpacity -= 0.05;
+                BorderBackground.Opacity = App.Settings.OverlayOpacity;
             }
         }
 
@@ -244,6 +243,14 @@ namespace LiveCaptionsTranslator
         {
             App.Settings.OverlayFontBold = !App.Settings.OverlayFontBold;
             TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold ? FontWeights.Bold : FontWeights.Regular);
+        }
+        private void BackgroundColorCycle_Click(object sender, RoutedEventArgs e)
+        {
+            App.Settings.OverlayBackgroundColor++;
+            if (App.Settings.OverlayBackgroundColor > ColorList.Count)
+                App.Settings.OverlayBackgroundColor = 1;
+            BorderBackground.Background = ColorList[App.Settings.OverlayBackgroundColor];
+            BorderBackground.Opacity = App.Settings.OverlayOpacity;
         }
     }
 }

--- a/src/SubtitleWindow.xaml.cs
+++ b/src/SubtitleWindow.xaml.cs
@@ -40,6 +40,12 @@ namespace LiveCaptionsTranslator
 
             Loaded += (s, e) => App.Captions.PropertyChanged += TranslatedChanged;
             Unloaded += (s, e) => App.Captions.PropertyChanged -= TranslatedChanged;
+
+            ApplyFontSize();
+            TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold ? FontWeights.Bold : FontWeights.Regular);
+            TranslatedCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
+            OriginalCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
+            BorderBackground.Opacity = App.Settings.OverlayOpacity;
         }
 
         private void Border_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -120,20 +126,24 @@ namespace LiveCaptionsTranslator
         {
             if (e.PropertyName == nameof(App.Captions.DisplayTranslatedCaption))
             {
-                if (Encoding.UTF8.GetByteCount(App.Captions.DisplayTranslatedCaption) >= 160)
+                ApplyFontSize();
+            }
+        }
+        private void ApplyFontSize()
+        {
+            if (Encoding.UTF8.GetByteCount(App.Captions.DisplayTranslatedCaption) >= 160)
+            {
+                Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    Dispatcher.BeginInvoke(new Action(() =>
-                    {
-                        this.TranslatedCaption.FontSize = App.Settings.OverlayFontSize;
-                    }), DispatcherPriority.Background);
-                }
-                else
+                    this.TranslatedCaption.FontSize = App.Settings.OverlayFontSize;
+                }), DispatcherPriority.Background);
+            }
+            else
+            {
+                Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    Dispatcher.BeginInvoke(new Action(() =>
-                    {
-                        this.TranslatedCaption.FontSize = App.Settings.OverlayFontSize + 3;
-                    }), DispatcherPriority.Background);
-                }
+                    this.TranslatedCaption.FontSize = App.Settings.OverlayFontSize + 3;
+                }), DispatcherPriority.Background);
             }
         }
 
@@ -175,14 +185,6 @@ namespace LiveCaptionsTranslator
             SetWindowLong(hwnd, GWL_EXSTYLE, extendedStyle | WS_EX_TRANSPARENT);
         }
 
-        protected async override void OnSourceInitialized(EventArgs e)
-        {
-            TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold ? FontWeights.Bold : FontWeights.Regular);
-            TranslatedCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
-            OriginalCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
-            BorderBackground.Opacity = App.Settings.OverlayOpacity;
-        }
-
         private void Window_MouseEnter(object sender, MouseEventArgs e)
         {
             ControlPanel.Visibility = Visibility.Visible;
@@ -195,12 +197,20 @@ namespace LiveCaptionsTranslator
 
         private void FontIncrease_Click(object sender, RoutedEventArgs e)
         {
-            App.Settings.OverlayFontSize++;
+            if (App.Settings.OverlayFontSize + 1 < 60)
+            {
+                App.Settings.OverlayFontSize++;
+                ApplyFontSize();
+            }
         }
 
         private void FontDecrease_Click(object sender, RoutedEventArgs e)
         {
-            App.Settings.OverlayFontSize--;
+            if (App.Settings.OverlayFontSize - 1 > 8)
+            {
+                App.Settings.OverlayFontSize--;
+                ApplyFontSize();
+            }
         }
 
         private void OpacityIncrease_Click(object sender, RoutedEventArgs e)

--- a/src/SubtitleWindow.xaml.cs
+++ b/src/SubtitleWindow.xaml.cs
@@ -42,7 +42,6 @@ namespace LiveCaptionsTranslator
             Unloaded += (s, e) => App.Captions.PropertyChanged -= TranslatedChanged;
 
             ApplyFontSize();
-            TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold ? FontWeights.Bold : FontWeights.Regular);
             TranslatedCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
             OriginalCaption.Foreground = ColorList[App.Settings.OverlayFontColor];
             BorderBackground.Opacity = App.Settings.OverlayOpacity;
@@ -135,16 +134,21 @@ namespace LiveCaptionsTranslator
             {
                 Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    this.TranslatedCaption.FontSize = App.Settings.OverlayFontSize;
+                    this.OriginalCaption.FontSize = App.Settings.OverlayFontSize;
+                    this.TranslatedCaption.FontSize = this.OriginalCaption.FontSize + 4;
                 }), DispatcherPriority.Background);
             }
             else
             {
                 Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    this.TranslatedCaption.FontSize = App.Settings.OverlayFontSize + 3;
+                    this.OriginalCaption.FontSize = App.Settings.OverlayFontSize + 3;
+                    this.TranslatedCaption.FontSize = this.OriginalCaption.FontSize + 4;
                 }), DispatcherPriority.Background);
             }
+
+            this.OriginalCaption.FontWeight = (App.Settings.OverlayFontBold == 3 ? FontWeights.Bold : FontWeights.Regular);
+            this.TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold >= 2 ? FontWeights.Bold : FontWeights.Regular);
         }
 
         public void ResizeForTranslationOnly()
@@ -251,8 +255,10 @@ namespace LiveCaptionsTranslator
 
         private void FontBold_Click(object sender, RoutedEventArgs e)
         {
-            App.Settings.OverlayFontBold = !App.Settings.OverlayFontBold;
-            TranslatedCaption.FontWeight = (App.Settings.OverlayFontBold ? FontWeights.Bold : FontWeights.Regular);
+            App.Settings.OverlayFontBold++;
+            if (App.Settings.OverlayFontBold > 3)
+                App.Settings.OverlayFontBold = 1;
+            ApplyFontSize();
         }
         private void BackgroundColorCycle_Click(object sender, RoutedEventArgs e)
         {

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -22,9 +22,10 @@ namespace LiveCaptionsTranslator.models
         private int maxSyncInterval = 5;
 
         private int overlayFontSize = 15;
-        private int overlayOpacity = 100;
+        private double overlayOpacity = 0.5;
         private int overlayFontColor = 1;
         private bool overlayFontBold = false;
+        private int overlayBackgroundColor = 1;
 
         private Dictionary<string, string> windowBounds;
         private bool topmost = true;
@@ -83,7 +84,7 @@ namespace LiveCaptionsTranslator.models
                 OnPropertyChanged("OverlayFontSize");
             }
         }
-        public int OverlayOpacity
+        public double OverlayOpacity
         {
             get => overlayOpacity;
             set
@@ -108,6 +109,15 @@ namespace LiveCaptionsTranslator.models
             {
                 overlayFontBold = value;
                 OnPropertyChanged("OverlayFontBold");
+            }
+        }
+        public int OverlayBackgroundColor
+        {
+            get => overlayBackgroundColor;
+            set
+            {
+                overlayBackgroundColor = value;
+                OnPropertyChanged("OverlayBackgroundColor");
             }
         }
         public string Prompt

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -26,7 +26,7 @@ namespace LiveCaptionsTranslator.models
         private int overlayFontColor = 1;
         private int overlayFontBold = 1;
         private int overlayFontShadow = 1;
-        private int overlayBackgroundColor = 1;
+        private int overlayBackgroundColor = 8;
 
         private Dictionary<string, string> windowBounds;
         private bool topmost = true;

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -24,7 +24,7 @@ namespace LiveCaptionsTranslator.models
         private int overlayFontSize = 15;
         private double overlayOpacity = 0.5;
         private int overlayFontColor = 1;
-        private bool overlayFontBold = false;
+        private int overlayFontBold = 1;
         private int overlayBackgroundColor = 1;
 
         private Dictionary<string, string> windowBounds;
@@ -102,7 +102,7 @@ namespace LiveCaptionsTranslator.models
                 OnPropertyChanged("OverlayFontColor");
             }
         }
-        public bool OverlayFontBold
+        public int OverlayFontBold
         {
             get => overlayFontBold;
             set

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -21,6 +21,11 @@ namespace LiveCaptionsTranslator.models
         private int maxIdleInterval = 20;
         private int maxSyncInterval = 5;
 
+        private int overlayFontSize = 15;
+        private int overlayOpacity = 100;
+        private int overlayFontColor = 1;
+        private bool overlayFontBold = false;
+
         private Dictionary<string, string> windowBounds;
         private bool topmost = true;
 
@@ -67,6 +72,42 @@ namespace LiveCaptionsTranslator.models
             {
                 maxSyncInterval = value;
                 OnPropertyChanged("MaxSyncInterval");
+            }
+        }
+        public int OverlayFontSize
+        {
+            get => overlayFontSize;
+            set
+            {
+                overlayFontSize = value;
+                OnPropertyChanged("OverlayFontSize");
+            }
+        }
+        public int OverlayOpacity
+        {
+            get => overlayOpacity;
+            set
+            {
+                overlayOpacity = value;
+                OnPropertyChanged("OverlayOpacity");
+            }
+        }
+        public int OverlayFontColor
+        {
+            get => overlayFontColor;
+            set
+            {
+                overlayFontColor = value;
+                OnPropertyChanged("OverlayFontColor");
+            }
+        }
+        public bool OverlayFontBold
+        {
+            get => overlayFontBold;
+            set
+            {
+                overlayFontBold = value;
+                OnPropertyChanged("OverlayFontBold");
             }
         }
         public string Prompt

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -25,6 +25,7 @@ namespace LiveCaptionsTranslator.models
         private double overlayOpacity = 0.5;
         private int overlayFontColor = 1;
         private int overlayFontBold = 1;
+        private int overlayFontShadow = 1;
         private int overlayBackgroundColor = 1;
 
         private Dictionary<string, string> windowBounds;
@@ -109,6 +110,15 @@ namespace LiveCaptionsTranslator.models
             {
                 overlayFontBold = value;
                 OnPropertyChanged("OverlayFontBold");
+            }
+        }
+        public int OverlayFontShadow
+        {
+            get => overlayFontShadow;
+            set
+            {
+                overlayFontShadow = value;
+                OnPropertyChanged("OverlayFontShdow");
             }
         }
         public int OverlayBackgroundColor


### PR DESCRIPTION
- Font size
- Font color cycle
- Font bold cycle
- Font drop shadow cycle
- Background opacity
- Background color cycle
- Click through mode (Disable by cycle reopen subtile mode.)

> Color reference by Youtube CC
> ![image](https://github.com/user-attachments/assets/18ed3fb6-0880-4cef-97c0-e13c5da7999b)

> Control Panel default shows because too low background opacity make it hard to find position of overlay.
> User have to move cursor pass the overlay to hide it.

> [VerticalAlignment to top prevent form text to get cutoff.](https://github.com/SakiRinn/LiveCaptions-Translator/pull/78/commits/93bb9b43dc6ab98d73c1995722c77bd1da157aa0)
> If user increase font size, long sentences will cut off at the edge of the screen.