### PR TITLE
fix: Rework GetCaptions() to not FindElementByAId every time

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -11,6 +11,7 @@ namespace LiveCaptionsTranslator
         private static AutomationElement? window = null;
         private static Caption? captions = null;
         private static Setting? settings = null;
+        public static bool IsClose = false;
 
         public static AutomationElement? Window
         {
@@ -43,6 +44,7 @@ namespace LiveCaptionsTranslator
         {
             if (window != null)
             {
+                IsClose = true;
                 LiveCaptionsHandler.RestoreLiveCaptions(window);
                 LiveCaptionsHandler.KillLiveCaptions(window);
             }

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -31,8 +31,6 @@ namespace LiveCaptionsTranslator
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
 
             window = LiveCaptionsHandler.LaunchLiveCaptions();
-            LiveCaptionsHandler.FixLiveCaptions(window);
-            LiveCaptionsHandler.HideLiveCaptions(window);
 
             captions = Caption.GetInstance();
             settings = Setting.Load();

--- a/src/models/Caption.cs
+++ b/src/models/Caption.cs
@@ -305,14 +305,11 @@ namespace LiveCaptionsTranslator.models
         {
             if (captionsTextBlock == null)
                 captionsTextBlock = LiveCaptionsHandler.FindElementByAId(window, "CaptionsTextBlock");
-            try
-            {
-                return captionsTextBlock?.Current.Name ?? string.Empty;
-            }
-            catch
-            {
+            if (captionsTextBlock == null) { 
+                Thread.Sleep(1500);
                 return string.Empty;
             }
+            return captionsTextBlock?.Current.Name ?? string.Empty;
         }
 
         private static string ShortenDisplaySentence(string displaySentence, int maxByteLength)

--- a/src/models/Caption.cs
+++ b/src/models/Caption.cs
@@ -256,10 +256,13 @@ namespace LiveCaptionsTranslator.models
             {
                 if (App.Window == null)
                 {
-                    DisplayTranslatedCaption = "[WARNING] LiveCaptions was unexpectedly closed, restarting...";
-                    App.Window = LiveCaptionsHandler.LaunchLiveCaptions();
-                    DisplayTranslatedCaption = "";
-                    captionsTextBlock = null;
+                    if (!App.IsClose)
+                    {
+                        DisplayTranslatedCaption = "[WARNING] LiveCaptions was unexpectedly closed, restarting...";
+                        App.Window = LiveCaptionsHandler.LaunchLiveCaptions();
+                        DisplayTranslatedCaption = "";
+                        captionsTextBlock = null;
+                    }
                 }
                 else if (LogOnlyFlag)
                 {

--- a/src/utils/LiveCaptionsHandler.cs
+++ b/src/utils/LiveCaptionsHandler.cs
@@ -23,6 +23,10 @@ namespace LiveCaptionsTranslator.utils
                 if (attemptCount > 10000)
                     throw new Exception("Failed to launch!");
             }
+
+            LiveCaptionsHandler.FixLiveCaptions(window);
+            LiveCaptionsHandler.HideLiveCaptions(window);
+
             return window;
         }
 

--- a/src/utils/LiveCaptionsHandler.cs
+++ b/src/utils/LiveCaptionsHandler.cs
@@ -94,11 +94,18 @@ namespace LiveCaptionsTranslator.utils
                 if (element.Current.AutomationId.CompareTo(automationId) == 0)
                     return element;
 
-                var child = treeWalker.GetFirstChild(element);
-                while (child != null)
+                try
                 {
-                    stack.Push(child);
-                    child = treeWalker.GetNextSibling(child);
+                    var child = treeWalker.GetFirstChild(element);
+                    while (child != null)
+                    {
+                        stack.Push(child);
+                        child = treeWalker.GetNextSibling(child);
+                    }
+                }
+                catch
+                {
+
                 }
             }
             return null;

--- a/src/utils/LiveCaptionsHandler.cs
+++ b/src/utils/LiveCaptionsHandler.cs
@@ -94,12 +94,12 @@ namespace LiveCaptionsTranslator.utils
 
             while (stack.Count > 0)
             {
-                var element = stack.Pop();
-                if (element.Current.AutomationId.CompareTo(automationId) == 0)
-                    return element;
-
                 try
                 {
+                    var element = stack.Pop();
+                    if (element.Current.AutomationId.CompareTo(automationId) == 0)
+                        return element;
+
                     var child = treeWalker.GetFirstChild(element);
                     while (child != null)
                     {


### PR DESCRIPTION
- Prevent memory leak caused by **GetCaptions()**, due to **LiveCaptionsHandler.FindElementByAId**
   - After running a few hours, it made **LiveCaption.exe** take 2 GB of memory and made itself consume more memory.
   - ![image](https://github.com/user-attachments/assets/05fac730-cbe1-482d-a39f-a78a93cb2b3a)
- Inserted **FixLiveCaptions()** and **HideLiveCaptions()** to **LaunchLiveCaptions()** easy for restart handdle
- Added exceptions to **FindElementByAId**, try to kill **LiveCaption.exe** by task manager and not restart sometime.