### PR TITLE
fix: LiveCaption.exe not restarting properly

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -31,8 +31,6 @@ namespace LiveCaptionsTranslator
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
 
             window = LiveCaptionsHandler.LaunchLiveCaptions();
-            LiveCaptionsHandler.FixLiveCaptions(window);
-            LiveCaptionsHandler.HideLiveCaptions(window);
 
             caption = Caption.GetInstance();
             setting = Setting.Load();

--- a/src/models/Caption.cs
+++ b/src/models/Caption.cs
@@ -75,6 +75,10 @@ namespace LiveCaptionsTranslator.models
                 string fullText = string.Empty;
                 try
                 {
+                    // Check LiveCaptions.exe still alive
+                    var info = App.Window.Current;
+                    var name = info.Name;
+                    
                     fullText = LiveCaptionsHandler.GetCaptions(App.Window);     // 10-20ms
                 }
                 catch (ElementNotAvailableException ex)

--- a/src/utils/LiveCaptionsHandler.cs
+++ b/src/utils/LiveCaptionsHandler.cs
@@ -23,6 +23,10 @@ namespace LiveCaptionsTranslator.utils
                 if (attemptCount > 10000)
                     throw new Exception("Failed to launch!");
             }
+
+            LiveCaptionsHandler.FixLiveCaptions(window);
+            LiveCaptionsHandler.HideLiveCaptions(window);
+
             return window;
         }
 


### PR DESCRIPTION
After trying to kill **LiveCaption.exe** using Task Manager, it turned out that the restarting handle not working properly.
Sometimes no restart.
If restarted but not hide the **LiveCaption.exe**.