### PR TITLE
perf: fix FindElement memory leak by FindFirst

### DIFF
--- a/src/utils/LiveCaptionsHandler.cs
+++ b/src/utils/LiveCaptionsHandler.cs
@@ -82,26 +82,28 @@ namespace LiveCaptionsTranslator.utils
             return AutomationElement.RootElement.FindFirst(TreeScope.Children, condition);
         }
 
-        public static AutomationElement? FindElementByAId(AutomationElement window, string automationId)
+        public static AutomationElement? FindElementByAId(
+            AutomationElement window, 
+            string automationId,
+            CancellationToken cancellationToken = default)
         {
-            var treeWalker = TreeWalker.RawViewWalker;
-            var stack = new Stack<AutomationElement>();
-            stack.Push(window);
+            if (window == null) return null;
 
-            while (stack.Count > 0)
+            try
             {
-                var element = stack.Pop();
-                if (element.Current.AutomationId.CompareTo(automationId) == 0)
-                    return element;
-
-                var child = treeWalker.GetFirstChild(element);
-                while (child != null)
-                {
-                    stack.Push(child);
-                    child = treeWalker.GetNextSibling(child);
-                }
+                PropertyCondition condition = new PropertyCondition(
+                    AutomationElement.AutomationIdProperty,
+                    automationId);
+                return window.FindFirst(TreeScope.Descendants, condition);
             }
-            return null;
+            catch (Exception) when (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
         public static void PrintAllElementsAId(AutomationElement window)


### PR DESCRIPTION
Fix memory leaked issue using .NET build in method instead of DFS