### PR TITLE
fix: change the way to adjust background opacity to make it able to invisible on high contrast content

### DIFF
--- a/src/SubtitleWindow.xaml
+++ b/src/SubtitleWindow.xaml
@@ -35,10 +35,6 @@
             x:Name="BorderBackground"
             Margin="5"
             Background="#80000000"
-            CornerRadius="8" />
-        <Border
-            Margin="5"
-            Background="Transparent"
             CornerRadius="8"
             MouseLeftButtonDown="Border_MouseLeftButtonDown">
             <Grid>

--- a/src/SubtitleWindow.xaml
+++ b/src/SubtitleWindow.xaml
@@ -107,7 +107,7 @@
                     Orientation="Horizontal">
                     <ui:Button
                         x:Name="FontIncrease"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="FontIncrease_Click"
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon fontIncrease20,
@@ -115,7 +115,7 @@
                         ToolTip="Font Increase" />
                     <ui:Button
                         x:Name="FontDecrease"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="FontDecrease_Click"
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon fontDecrease20,
@@ -123,7 +123,7 @@
                         ToolTip="Font Decrease" />
                     <ui:Button
                         x:Name="FontColorCycle"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="FontColorCycle_Click"
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon color16,
@@ -131,7 +131,7 @@
                         ToolTip="Font Color" />
                     <ui:Button
                         x:Name="FontBold"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="FontBold_Click"
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon textBold16,
@@ -139,7 +139,7 @@
                         ToolTip="Font Bold" />
                     <ui:Button
                         x:Name="FontShadow"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="FontShadow_Click"
                         Icon="{ui:SymbolIcon squareShadow12,
                                              Filled=False}"
@@ -147,7 +147,7 @@
                     <ui:Button
                         x:Name="OpacityIncrease"
                         Margin="5,0,0,0"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="OpacityIncrease_Click"
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon arrowAutofitUp20,
@@ -155,7 +155,7 @@
                         ToolTip="Opacity Increase" />
                     <ui:Button
                         x:Name="OpacityDecrease"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="OpacityDecrease_Click"
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon arrowAutofitDown20,
@@ -163,7 +163,7 @@
                         ToolTip="Opacity Decrease" />
                     <ui:Button
                         x:Name="BackgroundColorCycle"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="BackgroundColorCycle_Click"
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon color16,
@@ -172,7 +172,7 @@
                     <ui:Button
                         x:Name="ClickThrough"
                         Margin="5,0,0,0"
-                        Background="#80AAAAAA"
+                        Background="#FFAAAAAA"
                         Click="ClickThrough_Click"
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon lockClosed16,

--- a/src/SubtitleWindow.xaml.cs
+++ b/src/SubtitleWindow.xaml.cs
@@ -49,6 +49,9 @@ namespace LiveCaptionsTranslator
             this.OriginalCaption.Foreground = ColorList[App.Setting.SubtitleWindow.FontColor];
             this.BorderBackground.Background = ColorList[App.Setting.SubtitleWindow.BackgroundColor];
             this.BorderBackground.Opacity = App.Setting.SubtitleWindow.Opacity;
+
+            ApplyFontSize();
+            ApplyBackgroundOpacity();
         }
 
         private void Border_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/src/SubtitleWindow.xaml.cs
+++ b/src/SubtitleWindow.xaml.cs
@@ -223,9 +223,9 @@ namespace LiveCaptionsTranslator
             App.Setting.SubtitleWindow.FontBold++;
             if (App.Setting.SubtitleWindow.FontBold > (isTranslationOnly ? 2 : 3))
                 App.Setting.SubtitleWindow.FontBold = 1;
-            this.OriginalCaption.FontWeight = 
+            this.OriginalCaption.FontWeight =
                 (App.Setting.SubtitleWindow.FontBold == 3 ? FontWeights.Bold : FontWeights.Regular);
-            this.TranslatedCaption.FontWeight = 
+            this.TranslatedCaption.FontWeight =
                 (App.Setting.SubtitleWindow.FontBold >= 2 ? FontWeights.Bold : FontWeights.Regular);
         }
 
@@ -234,9 +234,9 @@ namespace LiveCaptionsTranslator
             App.Setting.SubtitleWindow.FontShadow++;
             if (App.Setting.SubtitleWindow.FontShadow > (isTranslationOnly ? 2 : 3))
                 App.Setting.SubtitleWindow.FontShadow = 1;
-            this.OriginalCaptionShadow.Opacity = 
+            this.OriginalCaptionShadow.Opacity =
                 (App.Setting.SubtitleWindow.FontShadow == 3 ? 1.0 : 0.0);
-            this.TranslatedCaptionShadow.Opacity = 
+            this.TranslatedCaptionShadow.Opacity =
                 (App.Setting.SubtitleWindow.FontShadow >= 2 ? 1.0 : 0.0);
         }
 
@@ -251,18 +251,21 @@ namespace LiveCaptionsTranslator
 
         private void OpacityIncrease_Click(object sender, RoutedEventArgs e)
         {
-            App.Setting.SubtitleWindow.Opacity += 0.05;
-            if (App.Setting.SubtitleWindow.Opacity >= 1)
-                App.Setting.SubtitleWindow.Opacity = 1.0; // Opacity = 0 make Border unhove
-            BorderBackground.Opacity = App.Setting.SubtitleWindow.Opacity;
+            if (App.Setting.SubtitleWindow.Opacity + 20 < 251)
+                App.Setting.SubtitleWindow.Opacity += 20;
+            else
+                App.Setting.SubtitleWindow.Opacity = 251;
+            ApplyBackgroundOpacity();
         }
 
         private void OpacityDecrease_Click(object sender, RoutedEventArgs e)
         {
-            App.Setting.SubtitleWindow.Opacity -= 0.05;
-            if (App.Setting.SubtitleWindow.Opacity <= 0)
-                App.Setting.SubtitleWindow.Opacity = 0.01;
-            BorderBackground.Opacity = App.Setting.SubtitleWindow.Opacity;
+            if (App.Setting.SubtitleWindow.Opacity - 20 > 1)
+                App.Setting.SubtitleWindow.Opacity -= 20;
+            else
+                App.Setting.SubtitleWindow.Opacity = 1;
+
+            ApplyBackgroundOpacity();
         }
 
         private void BackgroundColorCycle_Click(object sender, RoutedEventArgs e)
@@ -279,6 +282,12 @@ namespace LiveCaptionsTranslator
             var hwnd = new WindowInteropHelper(this).Handle;
             SetWindowExTransparent(hwnd);
             ControlPanel.Visibility = Visibility.Collapsed;
+        }
+
+        private void ApplyBackgroundOpacity()
+        {
+            Color color = ((SolidColorBrush)BorderBackground.Background).Color;
+            BorderBackground.Background = new SolidColorBrush(Color.FromArgb(App.Setting.SubtitleWindow.Opacity, color.R, color.G, color.B));
         }
     }
 }

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -142,7 +142,7 @@ namespace LiveCaptionsTranslator.models
                 FontBold = 1,
                 FontShadow = 1,
                 BackgroundColor = 8,
-                Opacity = 0.5
+                Opacity = 151
             };
             windowBounds = new Dictionary<string, string>
             {
@@ -288,7 +288,7 @@ namespace LiveCaptionsTranslator.models
         private int fontBold;
         private int fontShadow;
         private int backgroundColor;
-        private double opacity;
+        private byte opacity;
 
         public int FontSize
         {
@@ -335,7 +335,7 @@ namespace LiveCaptionsTranslator.models
                 OnPropertyChanged("BackgroundColor");
             }
         }
-        public double Opacity
+        public byte Opacity
         {
             get => opacity;
             set


### PR DESCRIPTION
Better invisibility for overlay background, ex: 1% opacity of black overlay background on white content.

_BREAKING CHANGE_: **App.Setting.SubtitleWindow.Opacity** - double > byte