### PR TITLE
Feature/issue 94

### DIFF
--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -143,6 +143,7 @@ namespace LiveCaptionsTranslator.models
                 { "OpenAI", new OpenAIConfig() },
                 { "DeepL", new DeepLConfig() },
                 { "OpenRouter", new OpenRouterConfig() },
+                { "MTranServer", new MTranServerConfig() },
             };
         }
 

--- a/src/models/TranslateAPIConfig.cs
+++ b/src/models/TranslateAPIConfig.cs
@@ -254,4 +254,56 @@ namespace LiveCaptionsTranslator.models
         }
     }
 
+    public class MTranServerConfig : TranslateAPIConfig
+    {
+        [JsonIgnore]
+        public override Dictionary<string, string> SupportedLanguages { get; } = new()
+        {
+            { "zh-CN", "zh" },
+            { "zh-TW", "zh" },
+            { "en-US", "en" },
+            { "en-GB", "en" },
+            { "ja-JP", "ja" },
+            { "ko-KR", "ko" },
+            { "fr-FR", "fr" },
+        };
+
+        private string apiKey = "";
+        private string apiUrl = "http://localhost:8989/translate";
+        private string sourceLanguage = "en";
+
+        public string ApiKey
+        {
+            get => apiKey;
+            set
+            {
+                apiKey = value;
+                OnPropertyChanged("ApiKey");
+            }
+        }
+        public string ApiUrl
+        {
+            get => apiUrl;
+            set
+            {
+                apiUrl = value;
+                OnPropertyChanged("ApiUrl");
+            }
+        }
+
+        public string SourceLanguage 
+        {
+            get => sourceLanguage;
+            set
+            {
+                sourceLanguage = value;
+                OnPropertyChanged("SourceLanguage");
+            }
+        }
+
+        public class Response
+        {
+            public string result { get; set; }
+        }
+    }
 }

--- a/src/windows/SettingWindow.xaml
+++ b/src/windows/SettingWindow.xaml
@@ -130,6 +130,19 @@
 						</StackPanel>
 					</ui:Button>
 					
+
+                    <ui:Button
+                        x:Name="MTranServerButton"
+                        Margin="10,5,10,0"
+                        Padding="10"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Left"
+                        Click="NavigationButton_Click"
+                        Tag="MTranServer">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock VerticalAlignment="Center" Text="MTranServer" />
+                        </StackPanel>
+                    </ui:Button>
                 </StackPanel>
             </Border>
             <ScrollViewer
@@ -480,6 +493,70 @@
 							</ui:Card>
 						</StackPanel>
 						
+
+                        <StackPanel x:Name="MTranServerSection" Margin="20">
+                            <TextBlock
+                                Margin="10"
+                                FontSize="20"
+                                FontWeight="Medium"
+                                Text="MTranServer" />
+                            <ui:Card Padding="15">
+                                <Grid x:Name="MTranServerGrid">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <StackPanel
+                                        Grid.Row="0"
+                                        Margin="15,10,0,0"
+                                        Orientation="Vertical">
+                                        <ui:TextBlock Margin="2.5,0,0,5" Text="Source Language" />
+                                        <ComboBox
+                                            Width="200"
+                                            Height="30"
+                                            Padding="10,4,10,7"
+                                            FontSize="13.3"
+                                            IsEditable="True"
+                                            Text="{Binding Configs[MTranServer].SourceLanguage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                                            <ComboBoxItem Content="en" />
+                                            <ComboBoxItem Content="ja" />
+                                            <ComboBoxItem Content="fr" />
+                                            <ComboBoxItem Content="ko" />
+                                            <ComboBoxItem Content="de" />
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <StackPanel
+                                        Grid.Row="1"
+                                        Margin="15,10,0,0"
+                                        Orientation="Vertical">
+                                        <ui:TextBlock Margin="2.5,0,0,5" Text="API Url" />
+                                        <ui:TextBox
+                                            Width="200"
+                                            Height="30"
+                                            Padding="10,4,10,7"
+                                            FontSize="13.3"
+                                            Text="{Binding Configs[MTranServer].ApiUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    </StackPanel>
+                                    <StackPanel
+                                        Grid.Row="2"
+                                        Margin="15,10,0,0"
+                                        Orientation="Vertical">
+                                        <ui:TextBlock Margin="2.5,0,0,5" Text="API Key" />
+                                        <ui:TextBox
+                                            Width="200"
+                                            Height="30"
+                                            Padding="10,4,10,7"
+                                            FontSize="13.3"
+                                            Text="{Binding Configs[MTranServer].ApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    </StackPanel>
+                                </Grid>
+                            </ui:Card>
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
             </ScrollViewer>

--- a/src/windows/SettingWindow.xaml.cs
+++ b/src/windows/SettingWindow.xaml.cs
@@ -22,6 +22,8 @@ namespace LiveCaptionsTranslator
             OpenRouterButton.Background = new SolidColorBrush(Colors.Transparent);
             DeepLButton.Background = new SolidColorBrush(Colors.Transparent);
             YoudaoButton.Background = new SolidColorBrush(Colors.Transparent);
+            MTranServerButton.Background = new SolidColorBrush(Colors.Transparent);
+
             Loaded += (sender, args) =>
             {
                 SystemThemeWatcher.Watch(this, WindowBackdropType.Mica, true);
@@ -42,7 +44,8 @@ namespace LiveCaptionsTranslator
                 { "OpenAI", OpenAISection },
                 { "OpenRouter", OpenRouterSection },
                 { "DeepL", DeepLSection },
-                { "Youdao", YoudaoSection }
+                { "Youdao", YoudaoSection },
+                { "MTranServer", MTranServerSection }
             };
         }
 


### PR DESCRIPTION
由于我不知道如何获取 LiveCaptions 的源语言所以目前在 MTranServer 方法中，源语言 (from) 是硬编码为 "en"。可能需要通过 UI Automation 获取或者寻找系统 API来获取源语言或者从捕获的原文本中判断语言。
Due to not knowing how to obtain the source language for LiveCaptions, I'm currently hardcoding the source language (from) as "en" in the MTranServer method. It might be necessary to use UI Automation to retrieve this information, find a system API to get the source language, or determine the language by analyzing the captured original text.