### PR TITLE
Support baidu translation api

### DIFF
--- a/src/models/TranslateAPIConfig.cs
+++ b/src/models/TranslateAPIConfig.cs
@@ -306,4 +306,67 @@ namespace LiveCaptionsTranslator.models
             public string result { get; set; }
         }
     }
+
+    public class BaiduConfig : TranslateAPIConfig
+    {
+        public class TransResult
+        {
+            public string src {  get; set; }
+            public string dst { get; set; }
+        }
+
+        public class TranslationResult
+        {
+            public string error_code { get; set; }
+            public string from { get; set; }
+            public string to { get; set; }
+            public List<TransResult> trans_result { get; set; }
+        }
+
+        [JsonIgnore]
+        public override Dictionary<string, string> SupportedLanguages { get; } = new()
+        {
+            { "zh-CN", "zh" }, 
+            { "zh-TW", "cht" }, 
+            { "en-US", "en" },      
+            { "ja-JP", "jp" },      
+            { "ko-KR", "kor" },     
+            { "fr-FR", "fra" },      
+            { "th-TH", "th" },
+        };
+
+        private string appId = "";
+        private string appSecret = "";
+        private string apiUrl = "https://fanyi-api.baidu.com/api/trans/vip/translate";
+
+        public string AppId
+        {
+            get => appId;
+            set
+            {
+                appId = value;
+                OnPropertyChanged("AppId");
+            }
+        }
+
+        public string AppSecret
+        {
+            get => appSecret;
+            set
+            {
+                appSecret = value;
+                OnPropertyChanged("AppSecret");
+            }
+        }
+
+        public string ApiUrl
+        {
+            get => apiUrl;
+            set
+            {
+                apiUrl = value;
+                OnPropertyChanged("ApiUrl");
+            }
+        }
+    }
 }

--- a/src/windows/SettingWindow.xaml
+++ b/src/windows/SettingWindow.xaml
@@ -143,6 +143,19 @@
                             <TextBlock VerticalAlignment="Center" Text="MTranServer" />
                         </StackPanel>
                     </ui:Button>
+
+					<ui:Button
+                        x:Name="BaiduButton"
+                        Margin="10,5,10,0"
+                        Padding="10"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Left"
+                        Click="NavigationButton_Click"
+                        Tag="Baidu">
+						<StackPanel Orientation="Horizontal">
+							<TextBlock VerticalAlignment="Center" Text="Baidu" />
+						</StackPanel>
+					</ui:Button>
                 </StackPanel>
             </Border>
             <ScrollViewer
@@ -557,6 +570,66 @@
                                 </Grid>
                             </ui:Card>
                         </StackPanel>
+
+						<StackPanel x:Name="BaiduSection" Margin="20">
+							<TextBlock
+                                Margin="10"
+                                FontSize="20"
+                                FontWeight="Medium"
+                                Text="Baidu" />
+							<ui:Card Padding="15">
+								<Grid x:Name="BaiduGrid">
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+									</Grid.RowDefinitions>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+									</Grid.ColumnDefinitions>
+
+									<StackPanel
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        Margin="15,0,0,0"
+                                        Orientation="Vertical">
+										<ui:TextBlock Margin="2.5,0,0,5" Text="API Url" />
+										<ui:TextBox
+                                            Width="130"
+                                            Height="30"
+                                            Padding="10,4,10,7"
+                                            FontSize="13.3"
+                                            Text="{Binding Configs[Baidu].ApiUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+									</StackPanel>
+									<StackPanel
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        Margin="15,10,0,0"
+                                        Orientation="Vertical">
+										<ui:TextBlock Margin="2.5,0,0,5" Text="APP ID" />
+										<ui:TextBox
+                                            Width="130"
+                                            Height="30"
+                                            Padding="10,4,10,7"
+                                            FontSize="13.3"
+                                            Text="{Binding Configs[Baidu].AppId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+									</StackPanel>
+									<StackPanel
+                                        Grid.Row="1"
+                                        Grid.Column="1"
+                                        Margin="15,10,0,0"
+                                        Orientation="Vertical">
+										<ui:TextBlock Margin="2.5,0,0,5" Text="APP Secret" />
+										<ui:TextBox
+                                            Width="200"
+                                            Height="30"
+                                            Padding="10,4,10,7"
+                                            FontSize="13.3"
+                                            Text="{Binding Configs[Baidu].AppSecret, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+									</StackPanel>
+								</Grid>
+							</ui:Card>
+						</StackPanel>
                     </StackPanel>
                 </StackPanel>
             </ScrollViewer>

--- a/src/windows/SettingWindow.xaml.cs
+++ b/src/windows/SettingWindow.xaml.cs
@@ -23,6 +23,7 @@ namespace LiveCaptionsTranslator
             DeepLButton.Background = new SolidColorBrush(Colors.Transparent);
             YoudaoButton.Background = new SolidColorBrush(Colors.Transparent);
             MTranServerButton.Background = new SolidColorBrush(Colors.Transparent);
+            BaiduButton.Background = new SolidColorBrush(Colors.Transparent);
 
             Loaded += (sender, args) =>
             {
@@ -45,7 +46,8 @@ namespace LiveCaptionsTranslator
                 { "OpenRouter", OpenRouterSection },
                 { "DeepL", DeepLSection },
                 { "Youdao", YoudaoSection },
-                { "MTranServer", MTranServerSection }
+                { "MTranServer", MTranServerSection },
+                { "Baidu", BaiduSection },
             };
         }
 


### PR DESCRIPTION
Added support for [Baidu Translate](https://fanyi-api.baidu.com/product/11). For verified individual accounts, Baidu Translate provides a monthly free quota of 1 million characters. The implementation is based on the existing code for Youdao Translate, with necessary adjustments made to adapt it for Baidu's API.