### PR TITLE
feat: support LibreTranslate API

### DIFF
--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -153,7 +153,8 @@ namespace LiveCaptionsTranslator.models
                 { "OpenRouter", [new OpenRouterConfig()] },
                 { "Youdao", [new YoudaoConfig()] },
                 { "MTranServer", [new MTranServerConfig()] },
-                { "Baidu", [new BaiduConfig()] }
+                { "Baidu", [new BaiduConfig()] },
+                { "LibreTranslate", [new LibreTranslateConfig()] }
             };
 
             double screenWidth = System.Windows.SystemParameters.PrimaryScreenWidth;

--- a/src/models/TranslateAPIConfig.cs
+++ b/src/models/TranslateAPIConfig.cs
@@ -373,4 +373,58 @@ namespace LiveCaptionsTranslator.models
             }
         }
     }
+
+    public class LibreTranslateConfig : TranslateAPIConfig
+    {
+        [JsonIgnore]
+        public new static Dictionary<string, string> SupportedLanguages => new()
+        {
+            { "zh-CN", "zh" },
+            { "zh-TW", "zh" },
+            { "en-US", "en" },
+            { "en-GB", "en" },
+            { "ja-JP", "ja" },
+            { "ko-KR", "ko" },
+            { "fr-FR", "fr" },
+            { "th-TH", "th" },
+        };
+
+        private string apiKey = "";
+        private string apiUrl = "http://localhost:5000/translate";
+        private string sourceLanguage = "en";
+
+        public string ApiKey
+        {
+            get => apiKey;
+            set
+            {
+                apiKey = value;
+                OnPropertyChanged("ApiKey");
+            }
+        }
+        public string ApiUrl
+        {
+            get => apiUrl;
+            set
+            {
+                apiUrl = value;
+                OnPropertyChanged("ApiUrl");
+            }
+        }
+
+        public string SourceLanguage
+        {
+            get => sourceLanguage;
+            set
+            {
+                sourceLanguage = value;
+                OnPropertyChanged("SourceLanguage");
+            }
+        }
+
+        public class Response
+        {
+            public string translatedText { get; set; }
+        }
+    }
 }


### PR DESCRIPTION
add support the LibreTranslate API to [LiveCaptions-Translator]
- [LibreTranslate] https://libretranslate.com/
- [LiveCaptions-Translator] (https://github.com/waytislao/LiveCaptions-Translator)

### new configure
- use api_url: http://localhost:5000/translate

```
{
		q: "Text for testing",
		source: "en",
		target: "th",
		format: "text",
		api_key: ""
}
```