### PR TITLE
fix: correct binding for DeepL API key in settings

### DIFF
--- a/src/windows/SettingWindow.xaml
+++ b/src/windows/SettingWindow.xaml
@@ -668,7 +668,7 @@
                                                     Height="30"
                                                     Padding="10,4,10,7"
                                                     FontSize="13.3"
-                                                    Text="{Binding Configs[DeepL].ApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                    Text="{Binding [DeepL].ApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                             </StackPanel>
                                         </Grid>
                                     </StackPanel>


### PR DESCRIPTION
fix #155 #156
Change `SettingWindow.xaml` file. Config DeepL config using `[DeepL].ApiKey`.