### PR TITLE
fix: Use CsvHelper for CSV export

### DIFF
--- a/LiveCaptionsTranslator.csproj
+++ b/LiveCaptionsTranslator.csproj
@@ -31,6 +31,7 @@
 		
 		<PackageReference Include="Interop.UIAutomationClient" Version="10.19041.0" />
 		
+		<PackageReference Include="CsvHelper" Version="33.0.1" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.1" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/models/TranslationHistoryEntry.cs
+++ b/src/models/TranslationHistoryEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace LiveCaptionsTranslator.models
+﻿using CsvHelper.Configuration.Attributes;
+
+namespace LiveCaptionsTranslator.models
 {
     public class TranslationHistoryEntry
     {
         public required string Timestamp { get; set; }
+        [Ignore]
         public required string TimestampFull { get; set; }
         public required string SourceText { get; set; }
         public required string TranslatedText { get; set; }

--- a/src/utils/HistoryLogger.cs
+++ b/src/utils/HistoryLogger.cs
@@ -227,9 +227,9 @@ namespace LiveCaptionsTranslator.utils
             }
 
             var csv = new StringBuilder();
-            csv.AppendLine("Timestamp,SourceText,TranslatedText,TargetLanguage,ApiUsed");
+            csv.AppendLine("Timestamp	SourceText	TranslatedText	TargetLanguage	ApiUsed");
             foreach (var entry in history)
-                csv.AppendLine($"{entry.Timestamp},{entry.SourceText},{entry.TranslatedText},{entry.TargetLanguage},{entry.ApiUsed}");
+                csv.AppendLine($"{entry.Timestamp}	{entry.SourceText}	{entry.TranslatedText}	{entry.TargetLanguage}	{entry.ApiUsed}");
 
             await File.WriteAllTextAsync(filePath, csv.ToString());
         }

--- a/src/utils/HistoryLogger.cs
+++ b/src/utils/HistoryLogger.cs
@@ -1,6 +1,9 @@
 ﻿using System.IO;
 using System.Text;
+using System.Globalization;
 using Microsoft.Data.Sqlite;
+using CsvHelper;
+using CsvHelper.Configuration;
 
 using LiveCaptionsTranslator.models;
 
@@ -226,12 +229,9 @@ namespace LiveCaptionsTranslator.utils
                 }
             }
 
-            var csv = new StringBuilder();
-            csv.AppendLine("Timestamp	SourceText	TranslatedText	TargetLanguage	ApiUsed");
-            foreach (var entry in history)
-                csv.AppendLine($"{entry.Timestamp}	{entry.SourceText}	{entry.TranslatedText}	{entry.TargetLanguage}	{entry.ApiUsed}");
-
-            await File.WriteAllTextAsync(filePath, csv.ToString());
+            using var writer = new StreamWriter(filePath, false, new UTF8Encoding(true));
+            using var csvWriter = new CsvWriter(writer, CultureInfo.InvariantCulture);
+            await csvWriter.WriteRecordsAsync(history, token);
         }
 
         // DEPRECATED


### PR DESCRIPTION
## Problem Description

When trying to export to CSV, since the text in the file contains many punctuation including commas, the CSV gets all confused.

I rewrote the `ExportToCSV` method and use `CsvHelper` to save the standardized csv format now.

## Related Issues

#197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV export is more reliable: correct escaping of commas/quotes, standardized headers, and UTF‑8 with BOM for better compatibility with spreadsheet apps.

* **Chores**
  * Added a third-party CSV library to support robust export handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->