### PR TITLE
Fix empty reference problem and optimize paging and query logic, #167, #201

### DIFF
--- a/src/models/Caption.cs
+++ b/src/models/Caption.cs
@@ -107,7 +107,7 @@ namespace LiveCaptionsTranslator.models
                 .Take(count)
                 .Reverse()
                 .Select(entry =>
-                    entry.TranslatedText.Contains("[ERROR]") || entry.TranslatedText.Contains("[WARNING]")
+                    entry == null || entry.TranslatedText.Contains("[ERROR]") || entry.TranslatedText.Contains("[WARNING]")
                         ? "" : entry.TranslatedText)
                 .Aggregate((accu, cur) =>
                 {


### PR DESCRIPTION
经过我的debug，一共有两个地方可能会导致翻译不刷新的问题，简单描述就是翻译API因为网络问题返回了空值导致的。

Following my debugging, I've identified two areas that could lead to the translation failing to update. In essence, this occurs when the translation API returns an empty value due to network problems.