### PR TITLE
feat: Implement real-time microphone transcription with local Whisper…

### DIFF
--- a/LiveCaptionsTranslator.csproj
+++ b/LiveCaptionsTranslator.csproj
@@ -36,6 +36,9 @@
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="WPF-UI" Version="4.0.1" />
+		<PackageReference Include="NAudio" Version="2.2.1" />
+		<PackageReference Include="Whisper.net" Version="1.5.0" />
+		<PackageReference Include="Whisper.net.Runtime" Version="1.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Translator.cs
+++ b/src/Translator.cs
@@ -14,8 +14,9 @@ namespace LiveCaptionsTranslator
         private static Caption? caption = null;
         private static Setting? setting = null;
 
-        private static readonly Queue<string> pendingTextQueue = new();
+        public static readonly Queue<string> pendingTextQueue = new();
         private static readonly TranslationTaskQueue translationTaskQueue = new();
+        public static AutoResetEvent RecordingStatusChanged { get; } = new AutoResetEvent(true);
 
         public static AutomationElement? Window
         {
@@ -50,6 +51,8 @@ namespace LiveCaptionsTranslator
 
             while (true)
             {
+                RecordingStatusChanged.WaitOne();
+
                 if (Window == null)
                 {
                     Thread.Sleep(2000);

--- a/src/windows/MainWindow.xaml
+++ b/src/windows/MainWindow.xaml
@@ -71,6 +71,14 @@
                             Icon="{ui:SymbolIcon Pin16,
                                                  Filled=True}"
                             ToolTip="Always on Top" />
+                        <ui:Button
+                            x:Name="RecordButton"
+                            Margin="0,0,5,0"
+                            Appearance="Transparent"
+                            Click="RecordButton_Click"
+                            Icon="{ui:SymbolIcon Microphone24,
+                                                 Filled=False}"
+                            ToolTip="Record Audio" />
                     </StackPanel>
                 </ui:TitleBar.TrailingContent>
             </ui:TitleBar>


### PR DESCRIPTION
… model

This commit introduces a new feature that allows users to transcribe audio directly from their microphone in real-time.

Key changes:
- Adds a record button to the main window's title bar to start and stop microphone recording.
- Integrates the `NAudio` library for capturing audio input.
- Integrates the `Whisper.net` library for local, real-time speech-to-text transcription.
- Implements an automatic downloader for the Whisper `ggml-base.bin` model, which is triggered if the model is not found locally.
- The transcription is processed in real-time by streaming audio chunks to the Whisper processor.
- Uses an `AutoResetEvent` to efficiently pause the original Live Captions `SyncLoop` during microphone recording, preventing busy-waiting and reducing CPU usage.
- Updates the UI to provide feedback on the recording status.