### PR TITLE
feat(i18n): add localization support

### DIFF
--- a/LiveCaptionsTranslator.csproj
+++ b/LiveCaptionsTranslator.csproj
@@ -12,6 +12,7 @@
 		<PublishSingleFile>true</PublishSingleFile>
 		<SelfContained>false</SelfContained>
 		<IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
+		<EnableDefaultPageItems>false</EnableDefaultPageItems>
 
 		<Title>LiveCaptions Translator</Title>
 		<Description>A real-time speech translation tool based on Windows LiveCaptions.</Description>
@@ -39,33 +40,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Page Update="src\localization\en-us.xaml" />
-		<Page Update="src\localization\zh-cn.xaml" />
-		<Page Update="src\localization\ar.xaml" />
-		<Page Update="src\localization\bn.xaml" />
-		<Page Update="src\localization\zh-tw.xaml" />
-		<Page Update="src\localization\cs-cz.xaml" />
-		<Page Update="src\localization\de-de.xaml" />
-		<Page Update="src\localization\es-mx.xaml" />
-		<Page Update="src\localization\fr-fr.xaml" />
-		<Page Update="src\localization\it-it.xaml" />
-		<Page Update="src\localization\ja-jp.xaml" />
-		<Page Update="src\localization\ko-kr.xaml" />
-		<Page Update="src\localization\lt-lt.xaml" />
-		<Page Update="src\localization\nl-nl.xaml" />
-		<Page Update="src\localization\pl-pl.xaml" />
-		<Page Update="src\localization\pt-br.xaml" />
-		<Page Update="src\localization\pt-pt.xaml" />
-		<Page Update="src\localization\ru-ru.xaml" />
-		<Page Update="src\localization\sv-se.xaml" />
-		<Page Update="src\localization\tr-tr.xaml" />
-		<Page Update="src\localization\vi-vn.xaml" />
+		<Page Include="src\**\*.xaml" Exclude="src\App.xaml" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <None Update="Properties\AssemblyInfo.tt">
-	    <Generator>TextTemplatingFileGenerator</Generator>
-	    <LastGenOutput>AssemblyInfo.cs</LastGenOutput>
+		<Generator>TextTemplatingFileGenerator</Generator>
+		<LastGenOutput>AssemblyInfo.cs</LastGenOutput>
 	  </None>
 	</ItemGroup>
 
@@ -75,9 +56,9 @@
 
 	<ItemGroup>
 	  <Compile Update="Properties\AssemblyInfo.cs">
-	    <DesignTime>True</DesignTime>
-	    <AutoGen>True</AutoGen>
-	    <DependentUpon>AssemblyInfo.tt</DependentUpon>
+		<DesignTime>True</DesignTime>
+		<AutoGen>True</AutoGen>
+		<DependentUpon>AssemblyInfo.tt</DependentUpon>
 	  </Compile>
 	</ItemGroup>
 

--- a/LiveCaptionsTranslator.csproj
+++ b/LiveCaptionsTranslator.csproj
@@ -39,6 +39,30 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Page Update="src\localization\en-us.xaml" />
+		<Page Update="src\localization\zh-cn.xaml" />
+		<Page Update="src\localization\ar.xaml" />
+		<Page Update="src\localization\bn.xaml" />
+		<Page Update="src\localization\zh-tw.xaml" />
+		<Page Update="src\localization\cs-cz.xaml" />
+		<Page Update="src\localization\de-de.xaml" />
+		<Page Update="src\localization\es-mx.xaml" />
+		<Page Update="src\localization\fr-fr.xaml" />
+		<Page Update="src\localization\it-it.xaml" />
+		<Page Update="src\localization\ja-jp.xaml" />
+		<Page Update="src\localization\ko-kr.xaml" />
+		<Page Update="src\localization\lt-lt.xaml" />
+		<Page Update="src\localization\nl-nl.xaml" />
+		<Page Update="src\localization\pl-pl.xaml" />
+		<Page Update="src\localization\pt-br.xaml" />
+		<Page Update="src\localization\pt-pt.xaml" />
+		<Page Update="src\localization\ru-ru.xaml" />
+		<Page Update="src\localization\sv-se.xaml" />
+		<Page Update="src\localization\tr-tr.xaml" />
+		<Page Update="src\localization\vi-vn.xaml" />
+	</ItemGroup>
+
+	<ItemGroup>
 	  <None Update="Properties\AssemblyInfo.tt">
 	    <Generator>TextTemplatingFileGenerator</Generator>
 	    <LastGenOutput>AssemblyInfo.cs</LastGenOutput>

--- a/src/App.xaml
+++ b/src/App.xaml
@@ -11,6 +11,27 @@
             <ResourceDictionary.MergedDictionaries>
                 <ui:ThemesDictionary Theme="Dark" />
                 <ui:ControlsDictionary />
+                <ResourceDictionary Source="localization/zh-cn.xaml" />
+                <ResourceDictionary Source="localization/ar.xaml" />
+                <ResourceDictionary Source="localization/bn.xaml" />
+                <ResourceDictionary Source="localization/zh-tw.xaml" />
+                <ResourceDictionary Source="localization/cs-cz.xaml" />
+                <ResourceDictionary Source="localization/de-de.xaml" />
+                <ResourceDictionary Source="localization/es-mx.xaml" />
+                <ResourceDictionary Source="localization/fr-fr.xaml" />
+                <ResourceDictionary Source="localization/it-it.xaml" />
+                <ResourceDictionary Source="localization/ja-jp.xaml" />
+                <ResourceDictionary Source="localization/ko-kr.xaml" />
+                <ResourceDictionary Source="localization/lt-lt.xaml" />
+                <ResourceDictionary Source="localization/nl-nl.xaml" />
+                <ResourceDictionary Source="localization/pl-pl.xaml" />
+                <ResourceDictionary Source="localization/pt-br.xaml" />
+                <ResourceDictionary Source="localization/pt-pt.xaml" />
+                <ResourceDictionary Source="localization/ru-ru.xaml" />
+                <ResourceDictionary Source="localization/sv-se.xaml" />
+                <ResourceDictionary Source="localization/tr-tr.xaml" />
+                <ResourceDictionary Source="localization/vi-vn.xaml" />
+                <ResourceDictionary Source="localization/en-us.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <FontFamily x:Key="SegoeFluentIcons">pack://application:,,,/;component/Fonts/#Segoe Fluent Icons</FontFamily>
         </ResourceDictionary>

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -9,11 +9,75 @@ namespace LiveCaptionsTranslator
         App()
         {
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+
+            // Ensure UI language is applied on startup.
+            ApplyPersistedUiLanguage();
+
             Translator.Setting?.Save();
 
             Task.Run(() => Translator.SyncLoop());
             Task.Run(() => Translator.TranslateLoop());
             Task.Run(() => Translator.DisplayLoop());
+        }
+
+        private static void ApplyPersistedUiLanguage()
+        {
+            var fileName = Translator.Setting?.UiLanguageFileName;
+            if (string.IsNullOrWhiteSpace(fileName))
+                fileName = "en-us.xaml";
+
+            var merged = Current.Resources.MergedDictionaries;
+
+            // Always keep en-us as the LAST dictionary.
+            // Any incomplete language dictionaries should be placed BEFORE en-us
+            // so missing keys automatically fall back to en-us.
+            var enIndex = FindDictionaryIndex(merged, "localization/en-us.xaml");
+            if (enIndex is null)
+                return; // app.xaml must include en-us
+
+            // Move selected language dictionary just BEFORE en-us (not after).
+            var langIndex = FindDictionaryIndex(merged, $"localization/{fileName}");
+            if (langIndex is null)
+                return; // unknown language dictionary not merged
+
+            // If selected is en-us, just ensure it's last.
+            if (fileName.Equals("en-us.xaml", StringComparison.OrdinalIgnoreCase))
+            {
+                var en = merged[enIndex.Value];
+                merged.RemoveAt(enIndex.Value);
+                merged.Add(en);
+                return;
+            }
+
+            // Recompute enIndex if it shifts.
+            enIndex = FindDictionaryIndex(merged, "localization/en-us.xaml");
+            if (enIndex is null)
+                return;
+
+            var lang = merged[langIndex.Value];
+            merged.RemoveAt(langIndex.Value);
+
+            // Recompute enIndex again after removal.
+            enIndex = FindDictionaryIndex(merged, "localization/en-us.xaml");
+            if (enIndex is null)
+                return;
+
+            merged.Insert(enIndex.Value, lang);
+        }
+
+        private static int? FindDictionaryIndex(System.Collections.Generic.IList<ResourceDictionary> merged, string contains)
+        {
+            for (int i = 0; i < merged.Count; i++)
+            {
+                var src = merged[i].Source?.ToString();
+                if (src is null)
+                    continue;
+
+                if (src.Contains(contains, StringComparison.OrdinalIgnoreCase))
+                    return i;
+            }
+
+            return null;
         }
 
         private static void OnProcessExit(object sender, EventArgs e)

--- a/src/Translator.cs
+++ b/src/Translator.cs
@@ -246,9 +246,11 @@ namespace LiveCaptionsTranslator
             {
                 var sw = Setting.MainWindow.LatencyShow ? Stopwatch.StartNew() : null;
 
+                // Ensure we don't reference removed Caption.ContextPreviousCaption after reverting Caption.cs
+                // Use the restored AwareContextsCaption for context-aware translation.
                 if (Setting.ContextAware && !TranslateAPI.IsLLMBased)
                 {
-                    translatedText = await TranslateAPI.TranslateFunction($"{Caption.ContextPreviousCaption} 🔤{text}🔤", token);
+                    translatedText = await TranslateAPI.TranslateFunction($"{Caption.AwareContextsCaption} 🔤{text}🔤", token);
                     translatedText = RegexPatterns.TargetSentence().Match(translatedText).Groups[1].Value;
                 }
                 else
@@ -305,8 +307,8 @@ namespace LiveCaptionsTranslator
                 SnackbarHost.Show(
                     L("T2", "Error!"),
                     string.Format(L("T3", "Logging history failed: {0}"), ex.Message),
-                    "error",
-                    2);
+                    SnackbarType.Error,
+                    timeout: 2);
             }
         }
 
@@ -328,8 +330,8 @@ namespace LiveCaptionsTranslator
                 SnackbarHost.Show(
                     L("T2", "Error!"),
                     string.Format(L("T3", "Logging history failed: {0}"), ex.Message),
-                    "error",
-                    2);
+                    SnackbarType.Error,
+                    timeout: 2);
             }
         }
 

--- a/src/apis/TranslateAPI.cs
+++ b/src/apis/TranslateAPI.cs
@@ -61,10 +61,9 @@ namespace LiveCaptionsTranslator.apis
                 new BaseLLMConfig.Message { role = "system", content = string.Format(Prompt, language) },
                 new BaseLLMConfig.Message { role = "user", content = $"🔤 {text} 🔤" }
             };
-            
             if (Translator.Setting.ContextAware)
             {
-                foreach (var entry in Translator.Caption.AwareContexts)
+                foreach (var entry in Translator.Caption.DisplayLogCards)
                 {
                     string translatedText = entry.TranslatedText;
                     if (translatedText.Contains("[ERROR]") || translatedText.Contains("[WARNING]"))
@@ -140,10 +139,9 @@ namespace LiveCaptionsTranslator.apis
                 new BaseLLMConfig.Message { role = "system", content = string.Format(Prompt, language) },
                 new BaseLLMConfig.Message { role = "user", content = $"🔤 {text} 🔤" }
             };
-            
             if (Translator.Setting.ContextAware)
             {
-                foreach (var entry in Translator.Caption.AwareContexts)
+                foreach (var entry in Translator.Caption.DisplayLogCards)
                 {
                     string translatedText = entry.TranslatedText;
                     if (translatedText.Contains("[ERROR]") || translatedText.Contains("[WARNING]"))
@@ -203,10 +201,9 @@ namespace LiveCaptionsTranslator.apis
                 new BaseLLMConfig.Message { role = "system", content = string.Format(Prompt, language) },
                 new BaseLLMConfig.Message { role = "user", content = $"🔤 {text} 🔤" }
             };
-            
             if (Translator.Setting.ContextAware)
             {
-                foreach (var entry in Translator.Caption.AwareContexts)
+                foreach (var entry in Translator.Caption.DisplayLogCards)
                 {
                     string translatedText = entry.TranslatedText;
                     if (translatedText.Contains("[ERROR]") || translatedText.Contains("[WARNING]"))

--- a/src/controls/SnackbarHost.cs
+++ b/src/controls/SnackbarHost.cs
@@ -7,8 +7,8 @@ namespace LiveCaptionsTranslator
         public static Snackbar? mainSnackbar;
         public static MainWindow? mainWindow = (MainWindow)App.Current.MainWindow;
 
-        public static void Show(string title = "", string message = "", SnackbarType type = SnackbarType.Info, 
-                                int width = 500, int timeout = 1,  bool closeButton = false)
+        public static void Show(string title = "", string message = "", string type = "info", 
+                                int timeout = 5, int width = 500, bool closeButton = true)
         {
             ControlAppearance appearance;
             SymbolIcon icon;
@@ -16,17 +16,17 @@ namespace LiveCaptionsTranslator
 
             switch (type)
             {
-                case SnackbarType.Warning:
+                case "warning":
                     appearance = ControlAppearance.Caution;
                     icon = new SymbolIcon(SymbolRegular.Alert24);
                     break;
-                case SnackbarType.Error:
-                    appearance = ControlAppearance.Danger;
-                    icon = new SymbolIcon(SymbolRegular.DismissCircle24);
-                    break;
-                case SnackbarType.Success:
+                case "success":
                     appearance = ControlAppearance.Success;
                     icon = new SymbolIcon(SymbolRegular.CheckmarkCircle24);
+                    break;
+                case "error":
+                    appearance = ControlAppearance.Danger;
+                    icon = new SymbolIcon(SymbolRegular.DismissCircle24);
                     break;
                 default:
                     appearance = ControlAppearance.Secondary;
@@ -48,13 +48,5 @@ namespace LiveCaptionsTranslator
 
             snackbar.Show(true);
         }
-    }
-    
-    public enum SnackbarType
-    {
-        Warning,
-        Error,
-        Success,
-        Info
     }
 }

--- a/src/controls/SnackbarHost.cs
+++ b/src/controls/SnackbarHost.cs
@@ -1,4 +1,5 @@
 ﻿using Wpf.Ui.Controls;
+using System;
 
 namespace LiveCaptionsTranslator
 {
@@ -7,26 +8,30 @@ namespace LiveCaptionsTranslator
         public static Snackbar? mainSnackbar;
         public static MainWindow? mainWindow = (MainWindow)App.Current.MainWindow;
 
-        public static void Show(string title = "", string message = "", string type = "info", 
-                                int timeout = 5, int width = 500, bool closeButton = true)
+        public static void Show(
+            string title = "",
+            string message = "",
+            SnackbarType type = SnackbarType.Info,
+            int width = 500,
+            int timeout = 1,
+            bool closeButton = false)
         {
             ControlAppearance appearance;
             SymbolIcon icon;
-            Snackbar? snackbar;
 
             switch (type)
             {
-                case "warning":
+                case SnackbarType.Warning:
                     appearance = ControlAppearance.Caution;
                     icon = new SymbolIcon(SymbolRegular.Alert24);
                     break;
-                case "success":
-                    appearance = ControlAppearance.Success;
-                    icon = new SymbolIcon(SymbolRegular.CheckmarkCircle24);
-                    break;
-                case "error":
+                case SnackbarType.Error:
                     appearance = ControlAppearance.Danger;
                     icon = new SymbolIcon(SymbolRegular.DismissCircle24);
+                    break;
+                case SnackbarType.Success:
+                    appearance = ControlAppearance.Success;
+                    icon = new SymbolIcon(SymbolRegular.CheckmarkCircle24);
                     break;
                 default:
                     appearance = ControlAppearance.Secondary;
@@ -35,7 +40,7 @@ namespace LiveCaptionsTranslator
             }
 
             mainSnackbar ??= new Snackbar(mainWindow?.snackbarHost);
-            snackbar = mainSnackbar;
+            var snackbar = mainSnackbar;
 
             snackbar.SetCurrentValue(Snackbar.TitleProperty, title);
             snackbar.SetCurrentValue(System.Windows.Controls.ContentControl.ContentProperty, message);
@@ -48,5 +53,37 @@ namespace LiveCaptionsTranslator
 
             snackbar.Show(true);
         }
+
+        public static void Show(
+            string title,
+            string message,
+            string type,
+            int timeout = 1,
+            int width = 500,
+            bool closeButton = false)
+        {
+            Show(title, message, ParseType(type), width, timeout, closeButton);
+        }
+
+        private static SnackbarType ParseType(string? type)
+        {
+            return type?.Trim().ToLowerInvariant() switch
+            {
+                "warning" => SnackbarType.Warning,
+                "error" => SnackbarType.Error,
+                "danger" => SnackbarType.Error,
+                "success" => SnackbarType.Success,
+                "info" => SnackbarType.Info,
+                _ => SnackbarType.Info
+            };
+        }
+    }
+
+    public enum SnackbarType
+    {
+        Warning,
+        Error,
+        Success,
+        Info
     }
 }

--- a/src/localization/ar.xaml
+++ b/src/localization/ar.xaml
@@ -4,183 +4,178 @@
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <!-- SettingPage strings -->
-    <sys:String x:Key="S0">الترجمة المباشرة للتسميات التوضيحية</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsName">الترجمة المباشرة للتسميات التوضيحية</sys:String>
     <sys:String x:Key="S1">بعد Windows 11 الإصدار 24H2، يمكنك فقط تغيير</sys:String>
-    <sys:String x:Key="S2">لغة المصدر</sys:String>
-    <sys:String x:Key="S3">في Live Captions.</sys:String>
-    <sys:String x:Key="S4">ملاحظة:</sys:String>
-    <sys:String x:Key="S5">يرجى الضغط على</sys:String>
-    <sys:String x:Key="S6">"إخفاء"</sys:String>
-    <sys:String x:Key="S7">لإخفاء Live Captions بدلاً من إغلاقه مباشرة.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">لغة المصدر</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">في Live Captions.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">ملاحظة:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">يرجى الضغط على</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"إخفاء"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">لإخفاء Live Captions بدلاً من إغلاقه مباشرة.</sys:String>
 
-    <sys:String x:Key="S8">إظهار</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">إظهار</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">إخفاء</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">إخفاء</sys:String>
-    <sys:String x:Key="S46">إظهار</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">فاصل API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">يحدد تكرار استدعاءات واجهة API للترجمة. كلما كان أصغر كانت الاستدعاءات أكثر.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">يتم استدعاء واجهة الترجمة مرة واحدة بعد تغيّر التسميات التوضيحية</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[فاصل API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">مرات.</sys:String>
 
-    <sys:String x:Key="S9">فاصل API</sys:String>
-    <sys:String x:Key="S10">يحدد تكرار استدعاءات واجهة API للترجمة. كلما كان أصغر كانت الاستدعاءات أكثر.</sys:String>
-    <sys:String x:Key="S11">يتم استدعاء واجهة الترجمة مرة واحدة بعد تغيّر التسميات التوضيحية</sys:String>
-    <sys:String x:Key="S12">[فاصل API]</sys:String>
-    <sys:String x:Key="S13">مرات.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">واجهة ترجمة API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">باستثناء Google و Google2، تتطلب جميع واجهات API الأخرى إعدادات قبل الاستخدام.</sys:String>
 
-    <sys:String x:Key="S14">واجهة ترجمة API</sys:String>
-    <sys:String x:Key="S15">باستثناء Google و Google2، تتطلب جميع واجهات API الأخرى إعدادات قبل الاستخدام.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">لغة الهدف</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">لا توجد لغة الهدف التي أتوقعها!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">يمكنك تعديل محتوى مربع الاختيار هذا مباشرة لتخصيص اللغة، ويُنصح باتباع</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">وسم اللغة BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">تتطلب بعض واجهات API (مثل DeepL) طريقة مختلفة لتحديد لغة الهدف، راجع وثائقهم الرسمية.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">للغات المضمنة لا حاجة للقلق (هناك تعيينات جاهزة). لكن إذا لم تكن لغتك في القائمة فضع ذلك في الحسبان.</sys:String>
 
-    <sys:String x:Key="S16">لغة الهدف</sys:String>
-    <sys:String x:Key="S17">لا توجد لغة الهدف التي أتوقعها!</sys:String>
-    <sys:String x:Key="S18">يمكنك تعديل محتوى مربع الاختيار هذا مباشرة لتخصيص اللغة، ويُنصح باتباع</sys:String>
-    <sys:String x:Key="S19">وسم اللغة BCP 47.</sys:String>
-    <sys:String x:Key="S20">تتطلب بعض واجهات API (مثل DeepL) طريقة مختلفة لتحديد لغة الهدف، راجع وثائقهم الرسمية.</sys:String>
-    <sys:String x:Key="S21">للغات المضمنة لا حاجة للقلق (هناك تعيينات جاهزة). لكن إذا لم تكن لغتك في القائمة فضع ذلك في الحسبان.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">إعدادات API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">فتح</sys:String>
 
-    <sys:String x:Key="S22">إعدادات API</sys:String>
-    <sys:String x:Key="S23">فتح</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">إظهار زمن التأخير</sys:String>
+    <sys:String x:Key="Common_Off">إيقاف</sys:String>
+    <sys:String x:Key="Common_On">تشغيل</sys:String>
 
-    <sys:String x:Key="S24">إظهار زمن التأخير</sys:String>
-    <sys:String x:Key="S25">إيقاف</sys:String>
-    <sys:String x:Key="S26">تشغيل</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">السياق</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">السياق:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">يحدد عدد جمل السياق عند تفعيل</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">الترجمة بحسب السياق</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">الجمل المعروضة:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">يحدد عدد البطاقات المعروضة عند تفعيل</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">بطاقات السجل</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">، وكذلك الحد الأقصى لعدد الجمل في نافذة التراكب.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">يجب أن تكون جمل السياق</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">أكبر من أو تساوي</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">الجمل المعروضة</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. وإلا سيقوم البرنامج بالتعديل تلقائياً.</sys:String>
 
-    <sys:String x:Key="S27">السياق</sys:String>
-    <sys:String x:Key="S28">السياق:</sys:String>
-    <sys:String x:Key="S29">يحدد عدد جمل السياق عند تفعيل</sys:String>
-    <sys:String x:Key="S30">الترجمة بحسب السياق</sys:String>
-    <sys:String x:Key="S31">.</sys:String>
-    <sys:String x:Key="S32">الجمل المعروضة:</sys:String>
-    <sys:String x:Key="S33">يحدد عدد البطاقات المعروضة عند تفعيل</sys:String>
-    <sys:String x:Key="S34">بطاقات السجل</sys:String>
-    <sys:String x:Key="S35">، وكذلك الحد الأقصى لعدد الجمل في نافذة التراكب.</sys:String>
-    <sys:String x:Key="S36">يجب أن تكون جمل السياق</sys:String>
-    <sys:String x:Key="S37">أكبر من أو تساوي</sys:String>
-    <sys:String x:Key="S38">الجمل المعروضة</sys:String>
-    <sys:String x:Key="S39">. وإلا سيقوم البرنامج بالتعديل تلقائياً.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">الجمل المعروضة</sys:String>
 
-    <sys:String x:Key="S40">الجمل المعروضة</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">الترجمة ضمن السياق.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">قد يحسن الدقة لكنه يستهلك رموزاً (tokens) أكثر.</sys:String>
 
-    <sys:String x:Key="S41">الترجمة ضمن السياق.</sys:String>
-    <sys:String x:Key="S42">قد يحسن الدقة لكنه يستهلك رموزاً (tokens) أكثر.</sys:String>
-
-    <sys:String x:Key="S43">لغة الواجهة</sys:String>
-    <sys:String x:Key="S44">اختر اللغة المستخدمة في واجهة التطبيق.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">لغة الواجهة</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">اختر اللغة المستخدمة في واجهة التطبيق.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">تسري التغييرات فورًا ويتم حفظها تلقائيًا.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">السابق</sys:String>
-    <sys:String x:Key="H1">الصفحة التالية</sys:String>
-    <sys:String x:Key="H2">بحث</sys:String>
-    <sys:String x:Key="H3">تصدير</sys:String>
-    <sys:String x:Key="H4">حذف الكل</sys:String>
-    <sys:String x:Key="H5">تحديث</sys:String>
-    <sys:String x:Key="H6">الوقت</sys:String>
-    <sys:String x:Key="H7">النص</sys:String>
-    <sys:String x:Key="H8">المترجم</sys:String>
-    <sys:String x:Key="H9">واجهة API</sys:String>
-    <sys:String x:Key="H10">20/صفحة</sys:String>
-    <sys:String x:Key="H11">30/صفحة</sys:String>
-    <sys:String x:Key="H12">50/صفحة</sys:String>
-    <sys:String x:Key="H13">100/صفحة</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">السابق</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">الصفحة التالية</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">بحث</sys:String>
+
+    <sys:String x:Key="HistoryPage_Action_Export">تصدير</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">حذف الكل</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">تحديث</sys:String>
+
+    <sys:String x:Key="HistoryPage_Column_Time">الوقت</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">النص</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">المترجم</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">واجهة API</sys:String>
+
+    <sys:String x:Key="HistoryPage_PageSize_20">20/صفحة</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/صفحة</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/صفحة</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/صفحة</sys:String>
 
     <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">هل تريد حذف كل السجل؟</sys:String>
-    <sys:String x:Key="H21">لا يمكن التراجع عن هذه العملية!</sys:String>
-    <sys:String x:Key="H22">نعم</sys:String>
-    <sys:String x:Key="H23">لا</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">تم الحفظ</sys:String>
-    <sys:String x:Key="H26">تم حفظ الملف إلى: {0}</sys:String>
-    <sys:String x:Key="H27">فشل الحفظ</sys:String>
-    <sys:String x:Key="H28">فشل حفظ الملف: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">هل تريد حذف كل السجل؟</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">لا يمكن التراجع عن هذه العملية!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">نعم</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">لا</sys:String>
+
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
+
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">تم الحفظ</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">تم حفظ الملف إلى: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">فشل الحفظ</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">فشل حفظ الملف: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">نافذة التراكب</sys:String>
-    <sys:String x:Key="O1">زيادة حجم الخط</sys:String>
-    <sys:String x:Key="O2">تقليل حجم الخط</sys:String>
-    <sys:String x:Key="O3">زيادة سماكة الحد</sys:String>
-    <sys:String x:Key="O4">تقليل سماكة الحد</sys:String>
-    <sys:String x:Key="O5">تغليظ الخط</sys:String>
-    <sys:String x:Key="O6">لون الخط</sys:String>
-    <sys:String x:Key="O7">زيادة شفافية الخلفية</sys:String>
-    <sys:String x:Key="O8">تقليل شفافية الخلفية</sys:String>
-    <sys:String x:Key="O9">لون الخلفية</sys:String>
-    <sys:String x:Key="O10">عرض النص الأصلي فقط أو الترجمة فقط</sys:String>
-    <sys:String x:Key="O11">تبديل موضع النص الأصلي/الترجمة</sys:String>
-    <sys:String x:Key="O12">نقر عبر النافذة</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">نافذة التراكب</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">زيادة حجم الخط</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">تقليل حجم الخط</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">زيادة سماكة الحد</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">تقليل سماكة الحد</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">تغليظ الخط</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">لون الخط</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">زيادة شفافية الخلفية</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">تقليل شفافية الخلفية</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">لون الخلفية</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">عرض النص الأصلي فقط أو الترجمة فقط</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">تبديل موضع النص الأصلي/الترجمة</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">نقر عبر النافذة</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">نرحب بأي شكل من أشكال المساهمة! يمكنك تقديم اقتراحات أو الإبلاغ عن أخطاء عبر GitHub issues، أو المساهمة بالكود مباشرة عبر Pull Requests.</sys:String>
-    <sys:String x:Key="I1">إذا كان هذا البرنامج مفيداً لك، فالرجاء التفكير في منحنا نجمة!</sys:String>
-    <sys:String x:Key="I2">المستودع:</sys:String>
-    <sys:String x:Key="I3">الويكي:</sys:String>
-    <sys:String x:Key="I4">المشرف:</sys:String>
-    <sys:String x:Key="I5">(المؤلف) و</sys:String>
-    <sys:String x:Key="I6">الإصدار:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">نرحب بأي شكل من أشكال المساهمة! يمكنك تقديم اقتراحات أو الإبلاغ عن أخطاء عبر GitHub issues، أو المساهمة بالكود مباشرة عبر Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">إذا كان هذا البرنامج مفيداً لك، فالرجاء التفكير في منحنا نجمة!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">المستودع:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">الويكي:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">المشرف:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(المؤلف) و</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">الإصدار:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">البدء</sys:String>
-    <sys:String x:Key="W1">مرحباً بك في LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">ابدأ</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">مرحباً بك في LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">يعتمد LiveCaptions Translator على Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">قبل التشغيل لأول مرة، عليك إعداده وفق الخطوات التالية:&#x0A;</sys:String>
 
-    <sys:String x:Key="W2">يعتمد LiveCaptions Translator على Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">قبل التشغيل لأول مرة، عليك إعداده وفق الخطوات التالية:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. افتح Windows LiveCaptions واتبع الإرشادات لتنزيل الملفات اللازمة للتعرّف على الكلام دون اتصال وحزم اللغات.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. انقر على</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ ترس الإعدادات</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">لفتح الإعدادات واختر</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Position &gt; Overlaid on screen"</sys:String>
 
-    <sys:String x:Key="W4">&#x0A;1. افتح Windows LiveCaptions واتبع الإرشادات لتنزيل الملفات اللازمة للتعرّف على الكلام دون اتصال وحزم اللغات.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. انقر على</sys:String>
-    <sys:String x:Key="W6"> ترس الإعدادات </sys:String>
-    <sys:String x:Key="W7">في Windows LiveCaptions لفتح قائمة الإعدادات، واختر</sys:String>
-    <sys:String x:Key="W8"> "Position &gt; Overlaid on screen" </sys:String>
-    <sys:String x:Key="W9">.&#x0A;3. انقر على</sys:String>
-    <sys:String x:Key="W10"> "إخفاء" </sys:String>
-    <sys:String x:Key="W11">الموجود في صفحة الإعدادات داخل LiveCaptions Translator لإخفاء Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. انقر على</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"إخفاء"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">في صفحة الإعدادات داخل LiveCaptions Translator لإخفاء Windows LiveCaptions.&#x0A;</sys:String>
 
-    <sys:String x:Key="W12">&#x0A;لقد انتقل البرنامج تلقائياً إلى صفحة الإعدادات وفتح Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">بعد إكمال الإعداد، يمكنك الرجوع إلى الصفحة الرئيسية والاستمتاع بالترجمة الصوتية الفورية.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;لقد انتقل البرنامج تلقائياً إلى صفحة الإعدادات وفتح Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">بعد إكمال الإعداد، يمكنك الرجوع إلى الصفحة الرئيسية والاستمتاع بالترجمة الصوتية الفورية.&#x0A;</sys:String>
 
-    <sys:String x:Key="W14">&#x0A;لمزيد من التفاصيل، تفضل بزيارة الويكي: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;لمزيد من التفاصيل، تفضل بزيارة الويكي: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
 
-    <sys:String x:Key="W16">&#x0A;&#x0A;نصيحة:&#x0A;</sys:String>
-    <sys:String x:Key="W17">لتغيير </sys:String>
-    <sys:String x:Key="W18">لغة المصدر</sys:String>
-    <sys:String x:Key="W19">، يرجى [إظهار] LiveCaptions في صفحة الإعدادات ثم القيام بذلك داخل Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;نصيحة:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">لتغيير</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">لغة المصدر</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">، يرجى [إظهار] LiveCaptions في صفحة الإعدادات ثم القيام بذلك داخل Windows LiveCaptions.</sys:String>
 
-    <sys:String x:Key="W20">لقد فهمت بالكامل وقمت بإعدادها.</sys:String>
-
-    <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">لقد فهمت بالكامل وقمت بإعدادها.</sys:String>
 
     <!-- Navigation menu -->
-    <sys:String x:Key="M10">التسميات</sys:String>
-    <sys:String x:Key="M11">الإعدادات</sys:String>
-    <sys:String x:Key="M12">السجل</sys:String>
-    <sys:String x:Key="M13">معلومات</sys:String>
+    <sys:String x:Key="Navigation_Captions">التسميات</sys:String>
+    <sys:String x:Key="Navigation_Settings">الإعدادات</sys:String>
+    <sys:String x:Key="Navigation_History">السجل</sys:String>
+    <sys:String x:Key="Navigation_Info">معلومات</sys:String>
 
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">بطاقات سجل التسميات</sys:String>
-    <sys:String x:Key="M21">إيقاف الترجمة مؤقتاً (تسجيل فقط)</sys:String>
-    <sys:String x:Key="M22">نافذة التراكب</sys:String>
-    <sys:String x:Key="M23">دائماً في المقدمة</sys:String>
+    <!-- MainWindow strings -->
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">بطاقات سجل التسميات</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">إيقاف الترجمة مؤقتاً (تسجيل فقط)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">نافذة التراكب</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">دائماً في المقدمة</sys:String>
 
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[ERROR] Update Check Failed.</sys:String>
-    <sys:String x:Key="MC1">error</sys:String>
-
-    <sys:String x:Key="MC2">يتوفر إصدار جديد</sys:String>
-    <sys:String x:Key="MC3">تم اكتشاف إصدار جديد: {0}
+    <sys:String x:Key="MainWindow_Update_Error">[ERROR] Update Check Failed.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">error</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">يتوفر إصدار جديد</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">تم اكتشاف إصدار جديد: {0}
 الإصدار الحالي: {1}
 يرجى زيارة GitHub لتنزيل أحدث إصدار.</sys:String>
-    <sys:String x:Key="MC4">تحديث</sys:String>
-    <sys:String x:Key="MC5">تجاهل هذا الإصدار</sys:String>
 
-    <sys:String x:Key="MC6">[ERROR] Open Browser Failed.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[WARNING] تم إغلاق LiveCaptions بشكل غير متوقع، جارٍ إعادة التشغيل...</sys:String>
-    <sys:String x:Key="T1">[متوقف مؤقتاً]</sys:String>
-    <sys:String x:Key="T2">خطأ!</sys:String>
-    <sys:String x:Key="T3">فشل حفظ السجل: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[WARNING] تم إغلاق LiveCaptions بشكل غير متوقع، جارٍ إعادة التشغيل...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[متوقف مؤقتاً]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">خطأ!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">فشل حفظ السجل: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">انقر للنسخ</sys:String>
-    <sys:String x:Key="C1">تم النسخ</sys:String>
-    <sys:String x:Key="C2">فشل النسخ</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">انقر للنسخ</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">تم النسخ</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">فشل النسخ</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/ar.xaml
+++ b/src/localization/ar.xaml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings -->
+    <sys:String x:Key="S0">الترجمة المباشرة للتسميات التوضيحية</sys:String>
+    <sys:String x:Key="S1">بعد Windows 11 الإصدار 24H2، يمكنك فقط تغيير</sys:String>
+    <sys:String x:Key="S2">لغة المصدر</sys:String>
+    <sys:String x:Key="S3">في Live Captions.</sys:String>
+    <sys:String x:Key="S4">ملاحظة:</sys:String>
+    <sys:String x:Key="S5">يرجى الضغط على</sys:String>
+    <sys:String x:Key="S6">"إخفاء"</sys:String>
+    <sys:String x:Key="S7">لإخفاء Live Captions بدلاً من إغلاقه مباشرة.</sys:String>
+
+    <sys:String x:Key="S8">إظهار</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">إخفاء</sys:String>
+    <sys:String x:Key="S46">إظهار</sys:String>
+
+    <sys:String x:Key="S9">فاصل API</sys:String>
+    <sys:String x:Key="S10">يحدد تكرار استدعاءات واجهة API للترجمة. كلما كان أصغر كانت الاستدعاءات أكثر.</sys:String>
+    <sys:String x:Key="S11">يتم استدعاء واجهة الترجمة مرة واحدة بعد تغيّر التسميات التوضيحية</sys:String>
+    <sys:String x:Key="S12">[فاصل API]</sys:String>
+    <sys:String x:Key="S13">مرات.</sys:String>
+
+    <sys:String x:Key="S14">واجهة ترجمة API</sys:String>
+    <sys:String x:Key="S15">باستثناء Google و Google2، تتطلب جميع واجهات API الأخرى إعدادات قبل الاستخدام.</sys:String>
+
+    <sys:String x:Key="S16">لغة الهدف</sys:String>
+    <sys:String x:Key="S17">لا توجد لغة الهدف التي أتوقعها!</sys:String>
+    <sys:String x:Key="S18">يمكنك تعديل محتوى مربع الاختيار هذا مباشرة لتخصيص اللغة، ويُنصح باتباع</sys:String>
+    <sys:String x:Key="S19">وسم اللغة BCP 47.</sys:String>
+    <sys:String x:Key="S20">تتطلب بعض واجهات API (مثل DeepL) طريقة مختلفة لتحديد لغة الهدف، راجع وثائقهم الرسمية.</sys:String>
+    <sys:String x:Key="S21">للغات المضمنة لا حاجة للقلق (هناك تعيينات جاهزة). لكن إذا لم تكن لغتك في القائمة فضع ذلك في الحسبان.</sys:String>
+
+    <sys:String x:Key="S22">إعدادات API</sys:String>
+    <sys:String x:Key="S23">فتح</sys:String>
+
+    <sys:String x:Key="S24">إظهار زمن التأخير</sys:String>
+    <sys:String x:Key="S25">إيقاف</sys:String>
+    <sys:String x:Key="S26">تشغيل</sys:String>
+
+    <sys:String x:Key="S27">السياق</sys:String>
+    <sys:String x:Key="S28">السياق:</sys:String>
+    <sys:String x:Key="S29">يحدد عدد جمل السياق عند تفعيل</sys:String>
+    <sys:String x:Key="S30">الترجمة بحسب السياق</sys:String>
+    <sys:String x:Key="S31">.</sys:String>
+    <sys:String x:Key="S32">الجمل المعروضة:</sys:String>
+    <sys:String x:Key="S33">يحدد عدد البطاقات المعروضة عند تفعيل</sys:String>
+    <sys:String x:Key="S34">بطاقات السجل</sys:String>
+    <sys:String x:Key="S35">، وكذلك الحد الأقصى لعدد الجمل في نافذة التراكب.</sys:String>
+    <sys:String x:Key="S36">يجب أن تكون جمل السياق</sys:String>
+    <sys:String x:Key="S37">أكبر من أو تساوي</sys:String>
+    <sys:String x:Key="S38">الجمل المعروضة</sys:String>
+    <sys:String x:Key="S39">. وإلا سيقوم البرنامج بالتعديل تلقائياً.</sys:String>
+
+    <sys:String x:Key="S40">الجمل المعروضة</sys:String>
+
+    <sys:String x:Key="S41">الترجمة ضمن السياق.</sys:String>
+    <sys:String x:Key="S42">قد يحسن الدقة لكنه يستهلك رموزاً (tokens) أكثر.</sys:String>
+
+    <sys:String x:Key="S43">لغة الواجهة</sys:String>
+    <sys:String x:Key="S44">اختر اللغة المستخدمة في واجهة التطبيق.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">السابق</sys:String>
+    <sys:String x:Key="H1">الصفحة التالية</sys:String>
+    <sys:String x:Key="H2">بحث</sys:String>
+    <sys:String x:Key="H3">تصدير</sys:String>
+    <sys:String x:Key="H4">حذف الكل</sys:String>
+    <sys:String x:Key="H5">تحديث</sys:String>
+    <sys:String x:Key="H6">الوقت</sys:String>
+    <sys:String x:Key="H7">النص</sys:String>
+    <sys:String x:Key="H8">المترجم</sys:String>
+    <sys:String x:Key="H9">واجهة API</sys:String>
+    <sys:String x:Key="H10">20/صفحة</sys:String>
+    <sys:String x:Key="H11">30/صفحة</sys:String>
+    <sys:String x:Key="H12">50/صفحة</sys:String>
+    <sys:String x:Key="H13">100/صفحة</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">هل تريد حذف كل السجل؟</sys:String>
+    <sys:String x:Key="H21">لا يمكن التراجع عن هذه العملية!</sys:String>
+    <sys:String x:Key="H22">نعم</sys:String>
+    <sys:String x:Key="H23">لا</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">تم الحفظ</sys:String>
+    <sys:String x:Key="H26">تم حفظ الملف إلى: {0}</sys:String>
+    <sys:String x:Key="H27">فشل الحفظ</sys:String>
+    <sys:String x:Key="H28">فشل حفظ الملف: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">نافذة التراكب</sys:String>
+    <sys:String x:Key="O1">زيادة حجم الخط</sys:String>
+    <sys:String x:Key="O2">تقليل حجم الخط</sys:String>
+    <sys:String x:Key="O3">زيادة سماكة الحد</sys:String>
+    <sys:String x:Key="O4">تقليل سماكة الحد</sys:String>
+    <sys:String x:Key="O5">تغليظ الخط</sys:String>
+    <sys:String x:Key="O6">لون الخط</sys:String>
+    <sys:String x:Key="O7">زيادة شفافية الخلفية</sys:String>
+    <sys:String x:Key="O8">تقليل شفافية الخلفية</sys:String>
+    <sys:String x:Key="O9">لون الخلفية</sys:String>
+    <sys:String x:Key="O10">عرض النص الأصلي فقط أو الترجمة فقط</sys:String>
+    <sys:String x:Key="O11">تبديل موضع النص الأصلي/الترجمة</sys:String>
+    <sys:String x:Key="O12">نقر عبر النافذة</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">نرحب بأي شكل من أشكال المساهمة! يمكنك تقديم اقتراحات أو الإبلاغ عن أخطاء عبر GitHub issues، أو المساهمة بالكود مباشرة عبر Pull Requests.</sys:String>
+    <sys:String x:Key="I1">إذا كان هذا البرنامج مفيداً لك، فالرجاء التفكير في منحنا نجمة!</sys:String>
+    <sys:String x:Key="I2">المستودع:</sys:String>
+    <sys:String x:Key="I3">الويكي:</sys:String>
+    <sys:String x:Key="I4">المشرف:</sys:String>
+    <sys:String x:Key="I5">(المؤلف) و</sys:String>
+    <sys:String x:Key="I6">الإصدار:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">البدء</sys:String>
+    <sys:String x:Key="W1">مرحباً بك في LiveCaptions Translator!</sys:String>
+
+    <sys:String x:Key="W2">يعتمد LiveCaptions Translator على Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">قبل التشغيل لأول مرة، عليك إعداده وفق الخطوات التالية:&#x0A;</sys:String>
+
+    <sys:String x:Key="W4">&#x0A;1. افتح Windows LiveCaptions واتبع الإرشادات لتنزيل الملفات اللازمة للتعرّف على الكلام دون اتصال وحزم اللغات.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. انقر على</sys:String>
+    <sys:String x:Key="W6"> ترس الإعدادات </sys:String>
+    <sys:String x:Key="W7">في Windows LiveCaptions لفتح قائمة الإعدادات، واختر</sys:String>
+    <sys:String x:Key="W8"> "Position &gt; Overlaid on screen" </sys:String>
+    <sys:String x:Key="W9">.&#x0A;3. انقر على</sys:String>
+    <sys:String x:Key="W10"> "إخفاء" </sys:String>
+    <sys:String x:Key="W11">الموجود في صفحة الإعدادات داخل LiveCaptions Translator لإخفاء Windows LiveCaptions.&#x0A;</sys:String>
+
+    <sys:String x:Key="W12">&#x0A;لقد انتقل البرنامج تلقائياً إلى صفحة الإعدادات وفتح Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">بعد إكمال الإعداد، يمكنك الرجوع إلى الصفحة الرئيسية والاستمتاع بالترجمة الصوتية الفورية.&#x0A;</sys:String>
+
+    <sys:String x:Key="W14">&#x0A;لمزيد من التفاصيل، تفضل بزيارة الويكي: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+
+    <sys:String x:Key="W16">&#x0A;&#x0A;نصيحة:&#x0A;</sys:String>
+    <sys:String x:Key="W17">لتغيير </sys:String>
+    <sys:String x:Key="W18">لغة المصدر</sys:String>
+    <sys:String x:Key="W19">، يرجى [إظهار] LiveCaptions في صفحة الإعدادات ثم القيام بذلك داخل Windows LiveCaptions.</sys:String>
+
+    <sys:String x:Key="W20">لقد فهمت بالكامل وقمت بإعدادها.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">التسميات</sys:String>
+    <sys:String x:Key="M11">الإعدادات</sys:String>
+    <sys:String x:Key="M12">السجل</sys:String>
+    <sys:String x:Key="M13">معلومات</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">بطاقات سجل التسميات</sys:String>
+    <sys:String x:Key="M21">إيقاف الترجمة مؤقتاً (تسجيل فقط)</sys:String>
+    <sys:String x:Key="M22">نافذة التراكب</sys:String>
+    <sys:String x:Key="M23">دائماً في المقدمة</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[ERROR] Update Check Failed.</sys:String>
+    <sys:String x:Key="MC1">error</sys:String>
+
+    <sys:String x:Key="MC2">يتوفر إصدار جديد</sys:String>
+    <sys:String x:Key="MC3">تم اكتشاف إصدار جديد: {0}
+الإصدار الحالي: {1}
+يرجى زيارة GitHub لتنزيل أحدث إصدار.</sys:String>
+    <sys:String x:Key="MC4">تحديث</sys:String>
+    <sys:String x:Key="MC5">تجاهل هذا الإصدار</sys:String>
+
+    <sys:String x:Key="MC6">[ERROR] Open Browser Failed.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[WARNING] تم إغلاق LiveCaptions بشكل غير متوقع، جارٍ إعادة التشغيل...</sys:String>
+    <sys:String x:Key="T1">[متوقف مؤقتاً]</sys:String>
+    <sys:String x:Key="T2">خطأ!</sys:String>
+    <sys:String x:Key="T3">فشل حفظ السجل: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">انقر للنسخ</sys:String>
+    <sys:String x:Key="C1">تم النسخ</sys:String>
+    <sys:String x:Key="C2">فشل النسخ</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/bn.xaml
+++ b/src/localization/bn.xaml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- Bengali (bn) localization (improved) -->
+
+    <!-- SettingPage strings -->
+    <sys:String x:Key="S0">লাইভ ক্যাপশন</sys:String>
+    <sys:String x:Key="S1">Windows 11 সংস্করণ 24H2 এর পরে, আপনি কেবল</sys:String>
+    <sys:String x:Key="S2">উৎস ভাষা</sys:String>
+    <sys:String x:Key="S3">লাইভ ক্যাপশন-এ পরিবর্তন করতে পারবেন।</sys:String>
+    <sys:String x:Key="S4">নোট:</sys:String>
+    <sys:String x:Key="S5">অনুগ্রহ করে ক্লিক করুন</sys:String>
+    <sys:String x:Key="S6">"লুকান"</sys:String>
+    <sys:String x:Key="S7">লাইভ ক্যাপশন সরাসরি বন্ধ করার পরিবর্তে লুকাতে।</sys:String>
+
+    <sys:String x:Key="S8">দেখান</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">লুকান</sys:String>
+    <sys:String x:Key="S46">দেখান</sys:String>
+
+    <sys:String x:Key="S9">API অন্তরাল</sys:String>
+    <sys:String x:Key="S10">অনুবাদ API কলের ফ্রিকোয়েন্সি নির্ধারণ করে। যত ছোট, কল তত ঘন ঘন।</sys:String>
+    <sys:String x:Key="S11">ক্যাপশন পরিবর্তনের পরে API একবার কল হয়</sys:String>
+    <sys:String x:Key="S12">[API অন্তরাল]</sys:String>
+    <sys:String x:Key="S13">বার</sys:String>
+
+    <sys:String x:Key="S14">অনুবাদ API</sys:String>
+    <sys:String x:Key="S15">Google এবং Google2 ব্যতীত, অন্য API গুলো ব্যবহারের আগে কনফিগার করা প্রয়োজন।</sys:String>
+
+    <sys:String x:Key="S16">লক্ষ্য ভাষা</sys:String>
+    <sys:String x:Key="S17">প্রত্যাশিত লক্ষ্য ভাষা নেই!</sys:String>
+    <sys:String x:Key="S18">আপনি সরাসরি এই কম্বোবক্সে ভাষা সম্পাদনা করতে পারেন, এবং এটি সুপারিশ করা হয়</sys:String>
+    <sys:String x:Key="S19">BCP 47 ভাষা ট্যাগ অনুযায়ী।</sys:String>
+    <sys:String x:Key="S20">কিছু API (যেমন DeepL) অন্যভাবে লক্ষ্য ভাষা নির্ধারণ করে; তাদের ডকুমেন্টেশন দেখুন।</sys:String>
+    <sys:String x:Key="S21">যদি তালিকায় আপনার প্রত্যাশিত ভাষা না থাকে, এই বিষয়টি মনে রাখুন।</sys:String>
+
+    <sys:String x:Key="S22">এপিআই সেটিংস</sys:String>
+    <sys:String x:Key="S23">খোলা</sys:String>
+
+    <sys:String x:Key="S24">প্রদর্শনের বিলম্ব দেখান</sys:String>
+    <sys:String x:Key="S25">বন্ধ</sys:String>
+    <sys:String x:Key="S26">চালু</sys:String>
+
+    <sys:String x:Key="S27">প্রসঙ্গ</sys:String>
+    <sys:String x:Key="S28">প্রসঙ্গ:</sys:String>
+    <sys:String x:Key="S29">ক্যাপশন অনুবাদের সময় প্রসঙ্গ বাক্যের সংখ্যা নির্ধারণ করে</sys:String>
+    <sys:String x:Key="S30">প্রসঙ্গ সচেতন</sys:String>
+    <sys:String x:Key="S31">চালু থাকলে।</sys:String>
+    <sys:String x:Key="S32">ওভারলে বাক্য:</sys:String>
+    <sys:String x:Key="S33">লগ কার্ড সক্রিয় থাকলে প্রদর্শিত কার্ডের সংখ্যা এবং ওভারলে উইন্ডোতে সর্বোচ্চ বাক্যের সংখ্যা নির্ধারণ করে।</sys:String>
+    <sys:String x:Key="S34">লগ কার্ড</sys:String>
+    <sys:String x:Key="S35">।</sys:String>
+    <sys:String x:Key="S36">প্রসঙ্গ অবশ্যই</sys:String>
+    <sys:String x:Key="S37">সামান্য বা সমান হতে হবে</sys:String>
+    <sys:String x:Key="S38">প্রদর্শনের বাক্য</sys:String>
+    <sys:String x:Key="S39">। না হলে প্রোগ্রাম স্বয়ংক্রিয়ভাবে তাদের সমন্বয় করবে।</sys:String>
+
+    <sys:String x:Key="S40">প্রদর্শনের বাক্য</sys:String>
+
+    <sys:String x:Key="S41">প্রসঙ্গ অনুযায়ী অনুবাদ।</sys:String>
+    <sys:String x:Key="S42">অনুবাদের সঠিকতা বাড়ায়, তবে বেশি টোকেন খরচ হয়।</sys:String>
+
+    <sys:String x:Key="S43">UI ভাষা</sys:String>
+    <sys:String x:Key="S44">অ্যাপের UI এর জন্য ভাষা নির্বাচন করুন।</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">পূর্ববর্তী</sys:String>
+    <sys:String x:Key="H1">পরবর্তী পাতা</sys:String>
+    <sys:String x:Key="H2">অনুসন্ধান</sys:String>
+    <sys:String x:Key="H3">নির্মাণ করুন</sys:String>
+    <sys:String x:Key="H4">সব মুছে ফেলে দিন</sys:String>
+    <sys:String x:Key="H5">রিফ্রেশ</sys:String>
+    <sys:String x:Key="H6">সময়</sys:String>
+    <sys:String x:Key="H7">ক্যাপশন</sys:String>
+    <sys:String x:Key="H8">অনুবাদ</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/পৃষ্ঠা</sys:String>
+    <sys:String x:Key="H11">30/পাতা</sys:String>
+    <sys:String x:Key="H12">50/পৃষ্ঠা</sys:String>
+    <sys:String x:Key="H13">100/পৃষ্ঠা</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">আপনি কি সব ইতিহাস মুছে দিতে চান?</sys:String>
+    <sys:String x:Key="H21">এই কাজ পূর্বাবস্থায় ফেরানো যাবে না!</sys:String>
+    <sys:String x:Key="H22">হ্যাঁ</sys:String>
+    <sys:String x:Key="H23">না</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">সংরক্ষণ সফল</sys:String>
+    <sys:String x:Key="H26">ফাইল সংরক্ষিত হয়েছে: {0}</sys:String>
+    <sys:String x:Key="H27">সংরক্ষণ ব্যর্থ</sys:String>
+    <sys:String x:Key="H28">ফাইল সংরক্ষণ ব্যর্থ: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">ওভারলে উইন্ডো</sys:String>
+    <sys:String x:Key="O1">ফন্ট সাইজ বাড়ান</sys:String>
+    <sys:String x:Key="O2">ফন্ট সাইজ কমান</sys:String>
+    <sys:String x:Key="O3">ফন্ট স্ট্রোক বাড়ান</sys:String>
+    <sys:String x:Key="O4">ফন্ট স্ট্রোক কমান</sys:String>
+    <sys:String x:Key="O5">ফন্ট বোল্ড</sys:String>
+    <sys:String x:Key="O6">ফন্ট রঙ</sys:String>
+    <sys:String x:Key="O7">পটভূমির অস্পষ্টতা বাড়ান</sys:String>
+    <sys:String x:Key="O8">পট্ভূমির অস্পষ্টতা কমান</sys:String>
+    <sys:String x:Key="O9">পটভূমির রঙ</sys:String>
+    <sys:String x:Key="O10">শুধু সাবটাইটেল বা অনুবাদ দেখান</sys:String>
+    <sys:String x:Key="O11">সাবটাইটেল/অনুবাদের অবস্থান পরিবর্তন করুন</sys:String>
+    <sys:String x:Key="O12">ক্লিক থ্রু</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">আমরা যে কোনো রকম অবদানকে স্বাগত জানাই! আপনি GitHub ইস্যুর মাধ্যমে পরামর্শ দিতে পারেন বা কোড সরাসরি Pull Request করে অবদান রাখতে পারেন।</sys:String>
+    <sys:String x:Key="I1">এই প্রোগ্রামটি আপনার কাজে লাগলে, আমাদের একটি স্টার দেওয়ার কথা ভাবুন!</sys:String>
+    <sys:String x:Key="I2">রেপোজিটরি:</sys:String>
+    <sys:String x:Key="I3">উইকি:</sys:String>
+    <sys:String x:Key="I4">রক্ষণকারী:</sys:String>
+    <sys:String x:Key="I5">(লেখক) এবং</sys:String>
+    <sys:String x:Key="I6">সংস্করণ:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">শুরু করুন</sys:String>
+    <sys:String x:Key="W1">LiveCaptions Translator-এ স্বাগতম!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator Windows LiveCaptions-এর উপর ভিত্তি করে তৈরি।</sys:String>
+    <sys:String x:Key="W3">প্রথমবার চালানোর আগে, নিচের ধাপগুলো অনুসরণ করে সেটআপ করুন:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Windows LiveCaptions খুলুন এবং নির্দেশনা অনুসরণ করে অন-ডিভাইস স্পিচ রিকগনিশন ও ভাষা প্যাকের প্রয়োজনীয় ফাইল ডাউনলোড করুন।</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Windows LiveCaptions-এ</sys:String>
+    <sys:String x:Key="W6"> গিয়ার </sys:String>
+    <sys:String x:Key="W7">আইকনে ক্লিক করে সেটিংস মেনু খুলুন এবং</sys:String>
+    <sys:String x:Key="W8"> "Position &gt; Overlaid on screen" </sys:String>
+    <sys:String x:Key="W9"> নির্বাচন করুন।&#x0A;3. LiveCaptions Translator-এর সেটিংস পেজে থাকা</sys:String>
+    <sys:String x:Key="W10"> "লুকান" </sys:String>
+    <sys:String x:Key="W11">বোতামে ক্লিক করে Windows LiveCaptions লুকান।&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;প্রোগ্রামটি স্বয়ংক্রিয়ভাবে সেটিংস পেজে নিয়ে গেছে এবং Windows LiveCaptions খুলেছে।</sys:String>
+    <sys:String x:Key="W13">সেটআপ শেষ হলে, আপনি মূল পেজে ফিরে গিয়ে রিয়েল-টাইম অডিও অনুবাদ উপভোগ করতে পারবেন।&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;আরও বিস্তারিত জানতে আমাদের উইকি দেখুন: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;টিপ:&#x0A;</sys:String>
+    <sys:String x:Key="W17">পরিবর্তন করতে </sys:String>
+    <sys:String x:Key="W18">উৎস ভাষা</sys:String>
+    <sys:String x:Key="W19">, সেটিংস পেজে [দেখান] দিয়ে LiveCaptions দেখান এবং এটি Windows LiveCaptions-এ গিয়ে পরিবর্তন করুন।</sys:String>
+    <sys:String x:Key="W20">আমি সম্পূর্ণভাবে বুঝেছি এবং কনফিগার করেছি।</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">ক্যাপশন</sys:String>
+    <sys:String x:Key="M11">সেটিং</sys:String>
+    <sys:String x:Key="M12">ইতিহাস</sys:String>
+    <sys:String x:Key="M13">তথ্য</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">ক্যাপশনের লগ কার্ড</sys:String>
+    <sys:String x:Key="M21">অনুবাদ বিরতি (শুধু লগ)</sys:String>
+    <sys:String x:Key="M22">ওভারলে উইন্ডো</sys:String>
+    <sys:String x:Key="M23">সবসময় উপরে</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[ERROR] আপডেট পরীক্ষা ব্যর্থ।</sys:String>
+    <sys:String x:Key="MC1">ভুলি</sys:String>
+
+    <sys:String x:Key="MC2">নতুন সংস্করণ উপলব্ধ</sys:String>
+    <sys:String x:Key="MC3">একটি নতুন সংস্করণ সনাক্ত হয়েছে: {0}
+বর্তমান সংস্করণ: {1}
+সর্বশেষ রিলিজ ডাউনলোড করতে অনুগ্রহ করে GitHub ভিজিট করুন।</sys:String>
+    <sys:String x:Key="MC4">আপডেট</sys:String>
+    <sys:String x:Key="MC5">এই সংস্করণ উপেক্ষা করুন</sys:String>
+
+    <sys:String x:Key="MC6">[ERROR] ব্রাউজার খুলতে ব্যর্থ।</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[WARNING] LiveCaptions অপ্রত্যাশিতভাবে বন্ধ হয়েছিল, পুনরায় চালু করা হচ্ছে...</sys:String>
+    <sys:String x:Key="T1">[Paused]</sys:String>
+    <sys:String x:Key="T2">Error!</sys:String>
+    <sys:String x:Key="T3">ইতিহাস সংরক্ষণ ব্যর্থ: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">ক্লিক করে কপি করুন</sys:String>
+    <sys:String x:Key="C1">কপি হয়েছে</sys:String>
+    <sys:String x:Key="C2">কপি ব্যর্থ</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/bn.xaml
+++ b/src/localization/bn.xaml
@@ -1,182 +1,174 @@
-<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- Bengali (bn) localization (improved) -->
-
     <!-- SettingPage strings -->
-    <sys:String x:Key="S0">লাইভ ক্যাপশন</sys:String>
-    <sys:String x:Key="S1">Windows 11 সংস্করণ 24H2 এর পরে, আপনি কেবল</sys:String>
-    <sys:String x:Key="S2">উৎস ভাষা</sys:String>
-    <sys:String x:Key="S3">লাইভ ক্যাপশন-এ পরিবর্তন করতে পারবেন।</sys:String>
-    <sys:String x:Key="S4">নোট:</sys:String>
-    <sys:String x:Key="S5">অনুগ্রহ করে ক্লিক করুন</sys:String>
-    <sys:String x:Key="S6">"লুকান"</sys:String>
-    <sys:String x:Key="S7">লাইভ ক্যাপশন সরাসরি বন্ধ করার পরিবর্তে লুকাতে।</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsName">লাইভ ক্যাপশন</sys:String>
+    <sys:String x:Key="S1">Windows 11 24H2 এর পরে, আপনি কেবল পরিবর্তন করতে পারবেন</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">উৎস ভাষা</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">লাইভ ক্যাপশন-এ।</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">নোট:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">অনুগ্রহ করে ক্লিক করুন</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"লুকান"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">লাইভ ক্যাপশন সরাসরি বন্ধ করার পরিবর্তে লুকান।</sys:String>
 
-    <sys:String x:Key="S8">দেখান</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">দেখান</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">লুকান</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">লুকান</sys:String>
-    <sys:String x:Key="S46">দেখান</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API অন্তরাল</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">অনুবাদ API কত ঘন ঘন কল হবে তা নির্ধারণ করে। ছোট মান হলে আরও ঘন ঘন কল হয়।</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">ক্যাপশন পরিবর্তনের পরে একবার API কল হবে</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API অন্তরাল]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">বার।</sys:String>
 
-    <sys:String x:Key="S9">API অন্তরাল</sys:String>
-    <sys:String x:Key="S10">অনুবাদ API কলের ফ্রিকোয়েন্সি নির্ধারণ করে। যত ছোট, কল তত ঘন ঘন।</sys:String>
-    <sys:String x:Key="S11">ক্যাপশন পরিবর্তনের পরে API একবার কল হয়</sys:String>
-    <sys:String x:Key="S12">[API অন্তরাল]</sys:String>
-    <sys:String x:Key="S13">বার</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">অনুবাদ API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Google এবং Google2 ব্যতীত, অন্য API ব্যবহারের আগে কনফিগার করা প্রয়োজন।</sys:String>
 
-    <sys:String x:Key="S14">অনুবাদ API</sys:String>
-    <sys:String x:Key="S15">Google এবং Google2 ব্যতীত, অন্য API গুলো ব্যবহারের আগে কনফিগার করা প্রয়োজন।</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">লক্ষ্য ভাষা</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">আপনার কাঙ্ক্ষিত লক্ষ্য ভাষা নেই?</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">আপনি সরাসরি এই ComboBox-এর লেখা সম্পাদনা করে ভাষা কাস্টমাইজ করতে পারেন। সুপারিশ করা হয়</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47 ভাষা ট্যাগ অনুসরণ করতে।</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">কিছু API (যেমন DeepL) লক্ষ্য ভাষা নির্ধারণের জন্য ভিন্ন পদ্ধতি ব্যবহার করে। অনুগ্রহ করে তাদের ডকুমেন্টেশন দেখুন।</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">অন্তর্নির্মিত লক্ষ্য ভাষা ইতিমধ্যেই ম্যাপ করা হয়েছে। আপনার ভাষা তালিকায় না থাকলে এটি মনে রাখুন।</sys:String>
 
-    <sys:String x:Key="S16">লক্ষ্য ভাষা</sys:String>
-    <sys:String x:Key="S17">প্রত্যাশিত লক্ষ্য ভাষা নেই!</sys:String>
-    <sys:String x:Key="S18">আপনি সরাসরি এই কম্বোবক্সে ভাষা সম্পাদনা করতে পারেন, এবং এটি সুপারিশ করা হয়</sys:String>
-    <sys:String x:Key="S19">BCP 47 ভাষা ট্যাগ অনুযায়ী।</sys:String>
-    <sys:String x:Key="S20">কিছু API (যেমন DeepL) অন্যভাবে লক্ষ্য ভাষা নির্ধারণ করে; তাদের ডকুমেন্টেশন দেখুন।</sys:String>
-    <sys:String x:Key="S21">যদি তালিকায় আপনার প্রত্যাশিত ভাষা না থাকে, এই বিষয়টি মনে রাখুন।</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API সেটিংস</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">খুলুন</sys:String>
 
-    <sys:String x:Key="S22">এপিআই সেটিংস</sys:String>
-    <sys:String x:Key="S23">খোলা</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">ল্যাটেন্সি দেখান</sys:String>
+    <sys:String x:Key="Common_Off">বন্ধ</sys:String>
+    <sys:String x:Key="Common_On">চালু</sys:String>
 
-    <sys:String x:Key="S24">প্রদর্শনের বিলম্ব দেখান</sys:String>
-    <sys:String x:Key="S25">বন্ধ</sys:String>
-    <sys:String x:Key="S26">চালু</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">প্রসঙ্গ</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">প্রসঙ্গ:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">যখন</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">প্রসঙ্গ সচেতন</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">চালু থাকে, তখন প্রসঙ্গ বাক্যের সংখ্যা নির্ধারণ করে।</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">ওভারলে বাক্য:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">যখন</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">লগ কার্ড</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">চালু থাকে, তখন প্রদর্শিত কার্ডের সংখ্যা এবং ওভারলে উইন্ডোতে সর্বাধিক বাক্যের সংখ্যা নির্ধারণ করে।</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">প্রসঙ্গ অবশ্যই</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">বড় বা সমান হতে হবে</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">প্রদর্শিত বাক্য</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">। না হলে অ্যাপ স্বয়ংক্রিয়ভাবে সামঞ্জস্য করবে।</sys:String>
 
-    <sys:String x:Key="S27">প্রসঙ্গ</sys:String>
-    <sys:String x:Key="S28">প্রসঙ্গ:</sys:String>
-    <sys:String x:Key="S29">ক্যাপশন অনুবাদের সময় প্রসঙ্গ বাক্যের সংখ্যা নির্ধারণ করে</sys:String>
-    <sys:String x:Key="S30">প্রসঙ্গ সচেতন</sys:String>
-    <sys:String x:Key="S31">চালু থাকলে।</sys:String>
-    <sys:String x:Key="S32">ওভারলে বাক্য:</sys:String>
-    <sys:String x:Key="S33">লগ কার্ড সক্রিয় থাকলে প্রদর্শিত কার্ডের সংখ্যা এবং ওভারলে উইন্ডোতে সর্বোচ্চ বাক্যের সংখ্যা নির্ধারণ করে।</sys:String>
-    <sys:String x:Key="S34">লগ কার্ড</sys:String>
-    <sys:String x:Key="S35">।</sys:String>
-    <sys:String x:Key="S36">প্রসঙ্গ অবশ্যই</sys:String>
-    <sys:String x:Key="S37">সামান্য বা সমান হতে হবে</sys:String>
-    <sys:String x:Key="S38">প্রদর্শনের বাক্য</sys:String>
-    <sys:String x:Key="S39">। না হলে প্রোগ্রাম স্বয়ংক্রিয়ভাবে তাদের সমন্বয় করবে।</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">প্রদর্শিত বাক্য</sys:String>
 
-    <sys:String x:Key="S40">প্রদর্শনের বাক্য</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">প্রসঙ্গসহ অনুবাদ।</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">নির্ভুলতা বাড়াতে পারে, তবে বেশি টোকেন ব্যবহার করে।</sys:String>
 
-    <sys:String x:Key="S41">প্রসঙ্গ অনুযায়ী অনুবাদ।</sys:String>
-    <sys:String x:Key="S42">অনুবাদের সঠিকতা বাড়ায়, তবে বেশি টোকেন খরচ হয়।</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI ভাষা</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">অ্যাপ UI-এ ব্যবহৃত ভাষা নির্বাচন করুন।</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">পরিবর্তন সঙ্গে সঙ্গে কার্যকর হয় এবং স্বয়ংক্রিয়ভাবে সংরক্ষিত হয়।</sys:String>
 
-    <sys:String x:Key="S43">UI ভাষা</sys:String>
-    <sys:String x:Key="S44">অ্যাপের UI এর জন্য ভাষা নির্বাচন করুন।</sys:String>
+    <!-- HistoryPage strings (semantic keys) -->
+    <sys:String x:Key="HistoryPage_Pagination_Previous">পূর্ববর্তী পৃষ্ঠা</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">পরবর্তী পৃষ্ঠা</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">অনুসন্ধান</sys:String>
 
-    <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">পূর্ববর্তী</sys:String>
-    <sys:String x:Key="H1">পরবর্তী পাতা</sys:String>
-    <sys:String x:Key="H2">অনুসন্ধান</sys:String>
-    <sys:String x:Key="H3">নির্মাণ করুন</sys:String>
-    <sys:String x:Key="H4">সব মুছে ফেলে দিন</sys:String>
-    <sys:String x:Key="H5">রিফ্রেশ</sys:String>
-    <sys:String x:Key="H6">সময়</sys:String>
-    <sys:String x:Key="H7">ক্যাপশন</sys:String>
-    <sys:String x:Key="H8">অনুবাদ</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/পৃষ্ঠা</sys:String>
-    <sys:String x:Key="H11">30/পাতা</sys:String>
-    <sys:String x:Key="H12">50/পৃষ্ঠা</sys:String>
-    <sys:String x:Key="H13">100/পৃষ্ঠা</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">রপ্তানি</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">সব মুছে ফেলুন</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">রিফ্রেশ</sys:String>
+
+    <sys:String x:Key="HistoryPage_Column_Time">সময়</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">ক্যাপশন</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">অনুবাদ</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+
+    <sys:String x:Key="HistoryPage_PageSize_20">20/পৃষ্ঠা</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/পৃষ্ঠা</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/পৃষ্ঠা</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/পৃষ্ঠা</sys:String>
 
     <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">আপনি কি সব ইতিহাস মুছে দিতে চান?</sys:String>
-    <sys:String x:Key="H21">এই কাজ পূর্বাবস্থায় ফেরানো যাবে না!</sys:String>
-    <sys:String x:Key="H22">হ্যাঁ</sys:String>
-    <sys:String x:Key="H23">না</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">সংরক্ষণ সফল</sys:String>
-    <sys:String x:Key="H26">ফাইল সংরক্ষিত হয়েছে: {0}</sys:String>
-    <sys:String x:Key="H27">সংরক্ষণ ব্যর্থ</sys:String>
-    <sys:String x:Key="H28">ফাইল সংরক্ষণ ব্যর্থ: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">আপনি কি সব ইতিহাস মুছে ফেলতে চান?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">এই কাজটি পূর্বাবস্থায় ফেরানো যাবে না!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">হ্যাঁ</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">না</sys:String>
 
-    <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">ওভারলে উইন্ডো</sys:String>
-    <sys:String x:Key="O1">ফন্ট সাইজ বাড়ান</sys:String>
-    <sys:String x:Key="O2">ফন্ট সাইজ কমান</sys:String>
-    <sys:String x:Key="O3">ফন্ট স্ট্রোক বাড়ান</sys:String>
-    <sys:String x:Key="O4">ফন্ট স্ট্রোক কমান</sys:String>
-    <sys:String x:Key="O5">ফন্ট বোল্ড</sys:String>
-    <sys:String x:Key="O6">ফন্ট রঙ</sys:String>
-    <sys:String x:Key="O7">পটভূমির অস্পষ্টতা বাড়ান</sys:String>
-    <sys:String x:Key="O8">পট্ভূমির অস্পষ্টতা কমান</sys:String>
-    <sys:String x:Key="O9">পটভূমির রঙ</sys:String>
-    <sys:String x:Key="O10">শুধু সাবটাইটেল বা অনুবাদ দেখান</sys:String>
-    <sys:String x:Key="O11">সাবটাইটেল/অনুবাদের অবস্থান পরিবর্তন করুন</sys:String>
-    <sys:String x:Key="O12">ক্লিক থ্রু</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
+
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">সংরক্ষণ সফল</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">ফাইল সংরক্ষিত হয়েছে: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">সংরক্ষণ ব্যর্থ</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">ফাইল সংরক্ষণ ব্যর্থ: {0}</sys:String>
+
+    <!-- OverlayWindow strings (semantic tooltips) -->
+    <sys:String x:Key="OverlayWindow_Title">ওভারলে উইন্ডো</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">ফন্ট সাইজ বাড়ান</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">ফন্ট সাইজ কমান</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">ফন্ট স্ট্রোক বাড়ান</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">ফন্ট স্ট্রোক কমান</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">বোল্ড</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">ফন্ট রঙ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">পটভূমির অস্বচ্ছতা বাড়ান</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">পটভূমির অস্বচ্ছতা কমান</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">পটভূমির রঙ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">শুধু সাবটাইটেল বা অনুবাদ দেখান</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">সাবটাইটেল/অনুবাদের অবস্থান পরিবর্তন</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">ক্লিক-থ্রু</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">আমরা যে কোনো রকম অবদানকে স্বাগত জানাই! আপনি GitHub ইস্যুর মাধ্যমে পরামর্শ দিতে পারেন বা কোড সরাসরি Pull Request করে অবদান রাখতে পারেন।</sys:String>
-    <sys:String x:Key="I1">এই প্রোগ্রামটি আপনার কাজে লাগলে, আমাদের একটি স্টার দেওয়ার কথা ভাবুন!</sys:String>
-    <sys:String x:Key="I2">রেপোজিটরি:</sys:String>
-    <sys:String x:Key="I3">উইকি:</sys:String>
-    <sys:String x:Key="I4">রক্ষণকারী:</sys:String>
-    <sys:String x:Key="I5">(লেখক) এবং</sys:String>
-    <sys:String x:Key="I6">সংস্করণ:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">সব ধরনের অবদান স্বাগত! আপনি GitHub ইস্যুর মাধ্যমে ফিচার প্রস্তাব বা বাগ রিপোর্ট করতে পারেন, অথবা সরাসরি Pull Request জমা দিয়ে কোডে অবদান রাখতে পারেন।</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">যদি এই প্রোগ্রামটি আপনার কাজে আসে, অনুগ্রহ করে প্রকল্পটিকে একটি স্টার দিন!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">রেপো:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">উইকি:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">রক্ষণাবেক্ষক:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(লেখক) এবং</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">সংস্করণ:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">শুরু করুন</sys:String>
-    <sys:String x:Key="W1">LiveCaptions Translator-এ স্বাগতম!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator Windows LiveCaptions-এর উপর ভিত্তি করে তৈরি।</sys:String>
-    <sys:String x:Key="W3">প্রথমবার চালানোর আগে, নিচের ধাপগুলো অনুসরণ করে সেটআপ করুন:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Windows LiveCaptions খুলুন এবং নির্দেশনা অনুসরণ করে অন-ডিভাইস স্পিচ রিকগনিশন ও ভাষা প্যাকের প্রয়োজনীয় ফাইল ডাউনলোড করুন।</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Windows LiveCaptions-এ</sys:String>
-    <sys:String x:Key="W6"> গিয়ার </sys:String>
-    <sys:String x:Key="W7">আইকনে ক্লিক করে সেটিংস মেনু খুলুন এবং</sys:String>
-    <sys:String x:Key="W8"> "Position &gt; Overlaid on screen" </sys:String>
-    <sys:String x:Key="W9"> নির্বাচন করুন।&#x0A;3. LiveCaptions Translator-এর সেটিংস পেজে থাকা</sys:String>
-    <sys:String x:Key="W10"> "লুকান" </sys:String>
-    <sys:String x:Key="W11">বোতামে ক্লিক করে Windows LiveCaptions লুকান।&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;প্রোগ্রামটি স্বয়ংক্রিয়ভাবে সেটিংস পেজে নিয়ে গেছে এবং Windows LiveCaptions খুলেছে।</sys:String>
-    <sys:String x:Key="W13">সেটআপ শেষ হলে, আপনি মূল পেজে ফিরে গিয়ে রিয়েল-টাইম অডিও অনুবাদ উপভোগ করতে পারবেন।&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;আরও বিস্তারিত জানতে আমাদের উইকি দেখুন: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;টিপ:&#x0A;</sys:String>
-    <sys:String x:Key="W17">পরিবর্তন করতে </sys:String>
-    <sys:String x:Key="W18">উৎস ভাষা</sys:String>
-    <sys:String x:Key="W19">, সেটিংস পেজে [দেখান] দিয়ে LiveCaptions দেখান এবং এটি Windows LiveCaptions-এ গিয়ে পরিবর্তন করুন।</sys:String>
-    <sys:String x:Key="W20">আমি সম্পূর্ণভাবে বুঝেছি এবং কনফিগার করেছি।</sys:String>
-
-    <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">শুরু করুন</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">LiveCaptions Translator-এ স্বাগতম!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator Windows Live Captions-এর উপর ভিত্তি করে তৈরি।</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;প্রথমবার চালানোর আগে, নিম্নলিখিত সেটআপ ধাপগুলো সম্পন্ন করুন:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Windows Live Captions খুলুন এবং নির্দেশিকা অনুযায়ী অফলাইন স্পিচ রিকগনিশন ফাইল এবং ভাষা প্যাক ডাউনলোড করুন।</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. ক্লিক করুন</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ গিয়ার</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">আইকন খুলতে সেটিংসে এবং নির্বাচন করতে</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"অবস্থান > স্ক্রিনে ওভারলে"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. ক্লিক করুন</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"লুকান"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">LiveCaptions Translator সেটিংস পৃষ্ঠায় বোতামটি লাইভ ক্যাপশন লুকাতে।&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;অ্যাপ স্বয়ংক্রিয়ভাবে সেটিংস পৃষ্ঠায় গেছে এবং Windows Live Captions খুলেছে।</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">সেটআপ সম্পন্ন হলে, আপনি প্রধান পৃষ্ঠায় ফিরে গিয়ে রিয়েল-টাইম অডিও অনুবাদ উপভোগ করতে পারেন।&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;বিস্তারিত তথ্যের জন্য উইকি দেখুন: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;টিপ:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">আপনি যদি পরিবর্তন করতে চান</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">উৎস ভাষা</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, অনুগ্রহ করে প্রথমে [Show] লাইভ ক্যাপশন ক্লিক করুন এবং তারপর Windows Live Captions-এ এটি পরিবর্তন করুন।</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">আমি সম্পূর্ণরূপে বুঝেছি এবং সেটআপ সম্পন্ন করেছি।</sys:String>
 
     <!-- Navigation menu -->
-    <sys:String x:Key="M10">ক্যাপশন</sys:String>
-    <sys:String x:Key="M11">সেটিং</sys:String>
-    <sys:String x:Key="M12">ইতিহাস</sys:String>
-    <sys:String x:Key="M13">তথ্য</sys:String>
+    <sys:String x:Key="Navigation_Captions">ক্যাপশন</sys:String>
+    <sys:String x:Key="Navigation_Settings">সেটিংস</sys:String>
+    <sys:String x:Key="Navigation_History">ইতিহাস</sys:String>
+    <sys:String x:Key="Navigation_Info">তথ্য</sys:String>
 
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">ক্যাপশনের লগ কার্ড</sys:String>
-    <sys:String x:Key="M21">অনুবাদ বিরতি (শুধু লগ)</sys:String>
-    <sys:String x:Key="M22">ওভারলে উইন্ডো</sys:String>
-    <sys:String x:Key="M23">সবসময় উপরে</sys:String>
+    <!-- MainWindow strings -->
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">ক্যাপশন লগ কার্ড</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">অনুবাদ বিরতি (শুধু লগ)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">ওভারলে উইন্ডো</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">সর্বদা উপরে</sys:String>
 
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[ERROR] আপডেট পরীক্ষা ব্যর্থ।</sys:String>
-    <sys:String x:Key="MC1">ভুলি</sys:String>
-
-    <sys:String x:Key="MC2">নতুন সংস্করণ উপলব্ধ</sys:String>
-    <sys:String x:Key="MC3">একটি নতুন সংস্করণ সনাক্ত হয়েছে: {0}
+    <sys:String x:Key="MainWindow_Update_Error">[ত্রুটি] আপডেট চেক ব্যর্থ হয়েছে।</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">ত্রুটি</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">নতুন সংস্করণ পাওয়া গেছে</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">নতুন সংস্করণ পাওয়া গেছে: {0}
 বর্তমান সংস্করণ: {1}
-সর্বশেষ রিলিজ ডাউনলোড করতে অনুগ্রহ করে GitHub ভিজিট করুন।</sys:String>
-    <sys:String x:Key="MC4">আপডেট</sys:String>
-    <sys:String x:Key="MC5">এই সংস্করণ উপেক্ষা করুন</sys:String>
+অনুগ্রহ করে GitHub-এ গিয়ে সর্বশেষ রিলিজ ডাউনলোড করুন।</sys:String>
 
-    <sys:String x:Key="MC6">[ERROR] ব্রাউজার খুলতে ব্যর্থ।</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[WARNING] LiveCaptions অপ্রত্যাশিতভাবে বন্ধ হয়েছিল, পুনরায় চালু করা হচ্ছে...</sys:String>
-    <sys:String x:Key="T1">[Paused]</sys:String>
-    <sys:String x:Key="T2">Error!</sys:String>
-    <sys:String x:Key="T3">ইতিহাস সংরক্ষণ ব্যর্থ: {0}</sys:String>
+    <!-- Translator  -->
+    <sys:String x:Key="Translator_Status_Restarting">[WARNING] লাইভ ক্যাপশন অপ্রত্যাশিতভাবে বন্ধ হয়েছে, পুনরায় চালু করা হচ্ছে…</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[বিরতি]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">ত্রুটি!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">ইতিহাস সংরক্ষণ ব্যর্থ: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">ক্লিক করে কপি করুন</sys:String>
-    <sys:String x:Key="C1">কপি হয়েছে</sys:String>
-    <sys:String x:Key="C2">কপি ব্যর্থ</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">কপি করতে ক্লিক করুন</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">কপি হয়েছে</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">কপি ব্যর্থ</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/cs-cz.xaml
+++ b/src/localization/cs-cz.xaml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Živé titulky</sys:String>
+    <sys:String x:Key="S1">Po verzi 24H2 Windows 11 můžete změnit pouze</sys:String>
+    <sys:String x:Key="S2">Zdrojový jazyk</sys:String>
+    <sys:String x:Key="S3">v Živých titulcích.</sys:String>
+    <sys:String x:Key="S4">Poznámka:</sys:String>
+    <sys:String x:Key="S5">Klikněte prosím</sys:String>
+    <sys:String x:Key="S6">"Skrýt"</sys:String>
+    <sys:String x:Key="S7">pro skrytí Živých titulků místo jejich přímého zavření.</sys:String>
+    <sys:String x:Key="S8">Zobrazit</sys:String>
+    <sys:String x:Key="S45">Skrýt</sys:String>
+    <sys:String x:Key="S46">Zobrazit</sys:String>
+
+    <sys:String x:Key="S9">Interval API</sys:String>
+    <sys:String x:Key="S10">Určuje frekvenci volání překladatelského API. Čím menší, tím častější volání.</sys:String>
+    <sys:String x:Key="S11">Překladatelské API se volá jednou po změně titulku</sys:String>
+    <sys:String x:Key="S12">[Interval API]</sys:String>
+    <sys:String x:Key="S13">krát.</sys:String>
+
+    <sys:String x:Key="S14">Překladatelské API</sys:String>
+    <sys:String x:Key="S15">S výjimkou Google a Google2 je nutné ostatní API nakonfigurovat před použitím.</sys:String>
+
+    <sys:String x:Key="S16">Cílový jazyk</sys:String>
+    <sys:String x:Key="S17">Požadovaný cílový jazyk není dostupný!</sys:String>
+    <sys:String x:Key="S18">Můžete přímo upravit obsah tohoto rozbalovacího seznamu pro přizpůsobení jazyka; doporučuje se dodržovat</sys:String>
+    <sys:String x:Key="S19">značku jazyka BCP 47.</sys:String>
+    <sys:String x:Key="S20">Některá API (např. DeepL) vyžadují jiný způsob definice cílového jazyka, viz jejich oficiální dokumentace.</sys:String>
+    <sys:String x:Key="S21">Pro zahrnuté cílové jazyky není třeba to řešit, protože jsme vytvořili mapování značek. Pokud však váš očekávaný jazyk není v seznamu, mějte toto na paměti.</sys:String>
+
+    <sys:String x:Key="S22">Nastavení API</sys:String>
+    <sys:String x:Key="S23">Otevřít</sys:String>
+    <sys:String x:Key="S24">Zobrazit zpoždění</sys:String>
+    <sys:String x:Key="S25">Vypnuto</sys:String>
+    <sys:String x:Key="S26">Zapnuto</sys:String>
+
+    <sys:String x:Key="S27">Kontexty</sys:String>
+    <sys:String x:Key="S28">Kontexty:</sys:String>
+    <sys:String x:Key="S29">Určuje počet kontextových vět, když je</sys:String>
+    <sys:String x:Key="S30">Chytrý kontext</sys:String>
+    <sys:String x:Key="S31">zapnutý.</sys:String>
+    <sys:String x:Key="S32">Zobrazené věty:</sys:String>
+    <sys:String x:Key="S33">Určuje počet zobrazených karet, když je</sys:String>
+    <sys:String x:Key="S34">Záznam karet</sys:String>
+    <sys:String x:Key="S35">zapnutý, stejně jako maximální počet vět zobrazených v překryvné vrstvě.</sys:String>
+    <sys:String x:Key="S36">Kontexty musí být</sys:String>
+    <sys:String x:Key="S37">větší nebo rovno</sys:String>
+    <sys:String x:Key="S38">Zobrazené věty</sys:String>
+    <sys:String x:Key="S39">. Pokud není splněno, program je automaticky upraví.</sys:String>
+    <sys:String x:Key="S40">Zobrazené věty</sys:String>
+
+    <sys:String x:Key="S41">Překládat v kontextu.</sys:String>
+    <sys:String x:Key="S42">Může zlepšit přesnost překladu, ale spotřebuje více tokenů.</sys:String>
+
+    <sys:String x:Key="S43">Jazyk UI</sys:String>
+    <sys:String x:Key="S44">Vyberte jazyk používaný uživatelským rozhraním aplikace.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Předchozí</sys:String>
+    <sys:String x:Key="H1">Další stránka</sys:String>
+    <sys:String x:Key="H2">Hledat</sys:String>
+    <sys:String x:Key="H3">Exportovat</sys:String>
+    <sys:String x:Key="H4">Smazat vše</sys:String>
+    <sys:String x:Key="H5">Obnovit</sys:String>
+    <sys:String x:Key="H6">Čas</sys:String>
+    <sys:String x:Key="H7">Titulek</sys:String>
+    <sys:String x:Key="H8">Přeloženo</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/stránka</sys:String>
+    <sys:String x:Key="H11">30/stránka</sys:String>
+    <sys:String x:Key="H12">50/stránka</sys:String>
+    <sys:String x:Key="H13">100/stránka</sys:String>
+
+    <sys:String x:Key="H20">Opravdu chcete smazat celou historii?</sys:String>
+    <sys:String x:Key="H21">Tuto akci nelze vrátit!</sys:String>
+    <sys:String x:Key="H22">Ano</sys:String>
+    <sys:String x:Key="H23">Ne</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Všechny soubory (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Uloženo úspěšně</sys:String>
+    <sys:String x:Key="H26">Soubor uložen do: {0}</sys:String>
+    <sys:String x:Key="H27">Uložení selhalo</sys:String>
+    <sys:String x:Key="H28">Uložení souboru selhalo: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Překryvná okna</sys:String>
+    <sys:String x:Key="O1">Zvětšit velikost písma</sys:String>
+    <sys:String x:Key="O2">Zmenšit velikost písma</sys:String>
+    <sys:String x:Key="O3">Zvětšit obrys písma</sys:String>
+    <sys:String x:Key="O4">Zmenšit obrys písma</sys:String>
+    <sys:String x:Key="O5">Tučné</sys:String>
+    <sys:String x:Key="O6">Barva písma</sys:String>
+    <sys:String x:Key="O7">Zvýšit průhlednost pozadí</sys:String>
+    <sys:String x:Key="O8">Snížit průhlednost pozadí</sys:String>
+    <sys:String x:Key="O9">Barva pozadí</sys:String>
+    <sys:String x:Key="O10">Zobrazit pouze titulky nebo překlady</sys:String>
+    <sys:String x:Key="O11">Přepnout pozici titulku/překladu</sys:String>
+    <sys:String x:Key="O12">Ignorovat kliknutí</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Vítáme jakoukoli formu příspěvků! Můžete poskytnout návrhy nebo nahlásit chyby prostřednictvím GitHub Issues, nebo přímo přispět kódem pomocí Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Pokud je vám tento program užitečný, prosím zvažte hvězdičku na GitHubu!</sys:String>
+    <sys:String x:Key="I2">Repozitář:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Správce:</sys:String>
+    <sys:String x:Key="I5">(Autor) a</sys:String>
+    <sys:String x:Key="I6">Verze:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Začínáme</sys:String>
+    <sys:String x:Key="W1">Vítejte v LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator je založen na Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Před prvním spuštěním je nutné jej nakonfigurovat podle následujících kroků:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Otevřete Windows LiveCaptions a podle průvodce stáhněte potřebné soubory pro místní rozpoznávání řeči a jazykové balíčky.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Klikněte na</sys:String>
+    <sys:String x:Key="W6">⚙️ ikonu ozubeného kola</sys:String>
+    <sys:String x:Key="W7">v Windows LiveCaptions pro otevření nabídky nastavení a vyberte</sys:String>
+    <sys:String x:Key="W8">"Pozice &gt; Překryté na obrazovce"</sys:String>
+    <sys:String x:Key="W9">3. Klikněte na tlačítko</sys:String>
+    <sys:String x:Key="W10">"Skrýt"</sys:String>
+    <sys:String x:Key="W11">v nastavení LiveCaptions Translator pro skrytí Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Program automaticky otevřel stránku nastavení a Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Po dokončení konfigurace se můžete vrátit na hlavní stránku a užívat si překlad zvuku v reálném čase.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;Pro více informací navštivte naši wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Pro změnu </sys:String>
+    <sys:String x:Key="W18">Zdrojového jazyka</sys:String>
+    <sys:String x:Key="W19">, prosím [Zobrazit] LiveCaptions na stránce nastavení a proveďte změnu ve Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">Plně jsem porozuměl a nakonfiguroval.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Titulky</sys:String>
+    <sys:String x:Key="M11">Nastavení</sys:String>
+    <sys:String x:Key="M12">Historie</sys:String>
+    <sys:String x:Key="M13">Info</sys:String>
+    <sys:String x:Key="M20">Záznam karet titulků</sys:String>
+    <sys:String x:Key="M21">Pozastavit překlad (jen záznam)</sys:String>
+    <sys:String x:Key="M22">Překryvná okna</sys:String>
+    <sys:String x:Key="M23">Vždy navrchu</sys:String>
+
+    <sys:String x:Key="MC0">[CHYBA] Kontrola aktualizace selhala.</sys:String>
+    <sys:String x:Key="MC1">chyba</sys:String>
+    <sys:String x:Key="MC2">Nová verze dostupná</sys:String>
+    <sys:String x:Key="MC3">Byla nalezena nová verze: {0}
+Aktuální verze: {1}
+Navštivte prosím GitHub pro stažení nejnovější verze.</sys:String>
+    <sys:String x:Key="MC4">Aktualizovat</sys:String>
+    <sys:String x:Key="MC5">Ignorovat tuto verzi</sys:String>
+    <sys:String x:Key="MC6">[CHYBA] Otevření prohlížeče selhalo.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[UPOZORNĚNÍ] Živé titulky byly neočekávaně uzavřeny, restartuji...</sys:String>
+    <sys:String x:Key="T1">[Pozastaveno]</sys:String>
+    <sys:String x:Key="T2">Chyba!</sys:String>
+    <sys:String x:Key="T3">Záznam historie selhal: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Klikněte pro kopírování</sys:String>
+    <sys:String x:Key="C1">Zkopírováno</sys:String>
+    <sys:String x:Key="C2">Kopírování selhalo</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/cs-cz.xaml
+++ b/src/localization/cs-cz.xaml
@@ -3,165 +3,172 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Živé titulky</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Živé titulky</sys:String>
     <sys:String x:Key="S1">Po verzi 24H2 Windows 11 můžete změnit pouze</sys:String>
-    <sys:String x:Key="S2">Zdrojový jazyk</sys:String>
-    <sys:String x:Key="S3">v Živých titulcích.</sys:String>
-    <sys:String x:Key="S4">Poznámka:</sys:String>
-    <sys:String x:Key="S5">Klikněte prosím</sys:String>
-    <sys:String x:Key="S6">"Skrýt"</sys:String>
-    <sys:String x:Key="S7">pro skrytí Živých titulků místo jejich přímého zavření.</sys:String>
-    <sys:String x:Key="S8">Zobrazit</sys:String>
-    <sys:String x:Key="S45">Skrýt</sys:String>
-    <sys:String x:Key="S46">Zobrazit</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Zdrojový jazyk</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">v Živých titulcích.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Poznámka:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Klikněte prosím</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Skrýt"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">pro skrytí Živých titulků místo jejich přímého zavření.</sys:String>
 
-    <sys:String x:Key="S9">Interval API</sys:String>
-    <sys:String x:Key="S10">Určuje frekvenci volání překladatelského API. Čím menší, tím častější volání.</sys:String>
-    <sys:String x:Key="S11">Překladatelské API se volá jednou po změně titulku</sys:String>
-    <sys:String x:Key="S12">[Interval API]</sys:String>
-    <sys:String x:Key="S13">krát.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Zobrazit</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Skrýt</sys:String>
 
-    <sys:String x:Key="S14">Překladatelské API</sys:String>
-    <sys:String x:Key="S15">S výjimkou Google a Google2 je nutné ostatní API nakonfigurovat před použitím.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Interval API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Určuje frekvenci volání překladatelského API. Čím menší, tím častější volání.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">Překladatelské API se volá jednou po změně titulku</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Interval API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">krát.</sys:String>
 
-    <sys:String x:Key="S16">Cílový jazyk</sys:String>
-    <sys:String x:Key="S17">Požadovaný cílový jazyk není dostupný!</sys:String>
-    <sys:String x:Key="S18">Můžete přímo upravit obsah tohoto rozbalovacího seznamu pro přizpůsobení jazyka; doporučuje se dodržovat</sys:String>
-    <sys:String x:Key="S19">značku jazyka BCP 47.</sys:String>
-    <sys:String x:Key="S20">Některá API (např. DeepL) vyžadují jiný způsob definice cílového jazyka, viz jejich oficiální dokumentace.</sys:String>
-    <sys:String x:Key="S21">Pro zahrnuté cílové jazyky není třeba to řešit, protože jsme vytvořili mapování značek. Pokud však váš očekávaný jazyk není v seznamu, mějte toto na paměti.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">Překladatelské API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">S výjimkou Google a Google2 je nutné ostatní API nakonfigurovat před použitím.</sys:String>
 
-    <sys:String x:Key="S22">Nastavení API</sys:String>
-    <sys:String x:Key="S23">Otevřít</sys:String>
-    <sys:String x:Key="S24">Zobrazit zpoždění</sys:String>
-    <sys:String x:Key="S25">Vypnuto</sys:String>
-    <sys:String x:Key="S26">Zapnuto</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Cílový jazyk</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Požadovaný cílový jazyk není dostupný!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Můžete přímo upravit obsah tohoto rozbalovacího seznamu pro přizpůsobení jazyka; doporučuje se dodržovat</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">značku jazyka BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Některá API (např. DeepL) vyžadují jiný způsob definice cílového jazyka, viz jejich oficiální dokumentace.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Pro zahrnuté cílové jazyky není třeba to řešit, protože jsme vytvořili mapování značek. Pokud však váš očekávaný jazyk není v seznamu, mějte toto na paměti.</sys:String>
 
-    <sys:String x:Key="S27">Kontexty</sys:String>
-    <sys:String x:Key="S28">Kontexty:</sys:String>
-    <sys:String x:Key="S29">Určuje počet kontextových vět, když je</sys:String>
-    <sys:String x:Key="S30">Chytrý kontext</sys:String>
-    <sys:String x:Key="S31">zapnutý.</sys:String>
-    <sys:String x:Key="S32">Zobrazené věty:</sys:String>
-    <sys:String x:Key="S33">Určuje počet zobrazených karet, když je</sys:String>
-    <sys:String x:Key="S34">Záznam karet</sys:String>
-    <sys:String x:Key="S35">zapnutý, stejně jako maximální počet vět zobrazených v překryvné vrstvě.</sys:String>
-    <sys:String x:Key="S36">Kontexty musí být</sys:String>
-    <sys:String x:Key="S37">větší nebo rovno</sys:String>
-    <sys:String x:Key="S38">Zobrazené věty</sys:String>
-    <sys:String x:Key="S39">. Pokud není splněno, program je automaticky upraví.</sys:String>
-    <sys:String x:Key="S40">Zobrazené věty</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Nastavení API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Otevřít</sys:String>
 
-    <sys:String x:Key="S41">Překládat v kontextu.</sys:String>
-    <sys:String x:Key="S42">Může zlepšit přesnost překladu, ale spotřebuje více tokenů.</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Zobrazit zpoždění</sys:String>
+    <sys:String x:Key="Common_Off">Vypnuto</sys:String>
+    <sys:String x:Key="Common_On">Zapnuto</sys:String>
 
-    <sys:String x:Key="S43">Jazyk UI</sys:String>
-    <sys:String x:Key="S44">Vyberte jazyk používaný uživatelským rozhraním aplikace.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Kontexty</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Kontexty:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Určuje počet kontextových vět, když je</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Chytrý kontext</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">zapnutý.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Zobrazené věty:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Určuje počet zobrazených karet, když je</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Záznam karet</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">zapnutý, stejně jako maximální počet vět zobrazených v překryvné vrstvě.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Kontexty musí být</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">větší nebo rovno</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Zobrazené věty</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Pokud není splněno, program je automaticky upraví.</sys:String>
+
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Zobrazené věty</sys:String>
+
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Překládat v kontextu.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Může zlepšit přesnost překladu, ale spotřebuje více tokenů.</sys:String>
+
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Jazyk UI</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Vyberte jazyk používaný uživatelským rozhraním aplikace.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Změny se projeví okamžitě a automaticky se uloží.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Předchozí</sys:String>
-    <sys:String x:Key="H1">Další stránka</sys:String>
-    <sys:String x:Key="H2">Hledat</sys:String>
-    <sys:String x:Key="H3">Exportovat</sys:String>
-    <sys:String x:Key="H4">Smazat vše</sys:String>
-    <sys:String x:Key="H5">Obnovit</sys:String>
-    <sys:String x:Key="H6">Čas</sys:String>
-    <sys:String x:Key="H7">Titulek</sys:String>
-    <sys:String x:Key="H8">Přeloženo</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/stránka</sys:String>
-    <sys:String x:Key="H11">30/stránka</sys:String>
-    <sys:String x:Key="H12">50/stránka</sys:String>
-    <sys:String x:Key="H13">100/stránka</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Předchozí stránka</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Další stránka</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Hledat</sys:String>
 
-    <sys:String x:Key="H20">Opravdu chcete smazat celou historii?</sys:String>
-    <sys:String x:Key="H21">Tuto akci nelze vrátit!</sys:String>
-    <sys:String x:Key="H22">Ano</sys:String>
-    <sys:String x:Key="H23">Ne</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Všechny soubory (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Uloženo úspěšně</sys:String>
-    <sys:String x:Key="H26">Soubor uložen do: {0}</sys:String>
-    <sys:String x:Key="H27">Uložení selhalo</sys:String>
-    <sys:String x:Key="H28">Uložení souboru selhalo: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Exportovat</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Smazat vše</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Obnovit</sys:String>
+
+    <sys:String x:Key="HistoryPage_Column_Time">Čas</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Titulek</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Přeloženo</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+
+    <sys:String x:Key="HistoryPage_PageSize_20">20/stránka</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/stránka</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/stránka</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/stránka</sys:String>
+
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Opravdu chcete smazat celou historii?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Tuto akci nelze vrátit!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Ano</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Ne</sys:String>
+
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Všechny soubory (*.*)|*.*</sys:String>
+
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Uloženo úspěšně</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Soubor uložen do: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Uložení selhalo</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Uložení souboru selhalo: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Překryvná okna</sys:String>
-    <sys:String x:Key="O1">Zvětšit velikost písma</sys:String>
-    <sys:String x:Key="O2">Zmenšit velikost písma</sys:String>
-    <sys:String x:Key="O3">Zvětšit obrys písma</sys:String>
-    <sys:String x:Key="O4">Zmenšit obrys písma</sys:String>
-    <sys:String x:Key="O5">Tučné</sys:String>
-    <sys:String x:Key="O6">Barva písma</sys:String>
-    <sys:String x:Key="O7">Zvýšit průhlednost pozadí</sys:String>
-    <sys:String x:Key="O8">Snížit průhlednost pozadí</sys:String>
-    <sys:String x:Key="O9">Barva pozadí</sys:String>
-    <sys:String x:Key="O10">Zobrazit pouze titulky nebo překlady</sys:String>
-    <sys:String x:Key="O11">Přepnout pozici titulku/překladu</sys:String>
-    <sys:String x:Key="O12">Ignorovat kliknutí</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Překryvná okna</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Zvětšit velikost písma</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Zmenšit velikost písma</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Zvětšit obrys písma</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Zmenšit obrys písma</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Tučné</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Barva písma</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Zvýšit průhlednost pozadí</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Snížit průhlednost pozadí</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Barva pozadí</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Zobrazit pouze titulky nebo překlady</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Přepnout pozici titulku/překladu</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Ignorovat kliknutí</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Vítáme jakoukoli formu příspěvků! Můžete poskytnout návrhy nebo nahlásit chyby prostřednictvím GitHub Issues, nebo přímo přispět kódem pomocí Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Pokud je vám tento program užitečný, prosím zvažte hvězdičku na GitHubu!</sys:String>
-    <sys:String x:Key="I2">Repozitář:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Správce:</sys:String>
-    <sys:String x:Key="I5">(Autor) a</sys:String>
-    <sys:String x:Key="I6">Verze:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Vítáme jakoukoli formu příspěvků! Můžete poskytnout návrhy nebo nahlásit chyby prostřednictvím GitHub Issues, nebo přímo přispět kódem pomocí Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Pokud je vám tento program užitečný, prosím zvažte hvězdičku na GitHubu!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repozitář:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Správce:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Autor) a</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Verze:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Začínáme</sys:String>
-    <sys:String x:Key="W1">Vítejte v LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator je založen na Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Před prvním spuštěním je nutné jej nakonfigurovat podle následujících kroků:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Otevřete Windows LiveCaptions a podle průvodce stáhněte potřebné soubory pro místní rozpoznávání řeči a jazykové balíčky.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Klikněte na</sys:String>
-    <sys:String x:Key="W6">⚙️ ikonu ozubeného kola</sys:String>
-    <sys:String x:Key="W7">v Windows LiveCaptions pro otevření nabídky nastavení a vyberte</sys:String>
-    <sys:String x:Key="W8">"Pozice &gt; Překryté na obrazovce"</sys:String>
-    <sys:String x:Key="W9">3. Klikněte na tlačítko</sys:String>
-    <sys:String x:Key="W10">"Skrýt"</sys:String>
-    <sys:String x:Key="W11">v nastavení LiveCaptions Translator pro skrytí Windows LiveCaptions.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Program automaticky otevřel stránku nastavení a Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Po dokončení konfigurace se můžete vrátit na hlavní stránku a užívat si překlad zvuku v reálném čase.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;Pro více informací navštivte naši wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Pro změnu </sys:String>
-    <sys:String x:Key="W18">Zdrojového jazyka</sys:String>
-    <sys:String x:Key="W19">, prosím [Zobrazit] LiveCaptions na stránce nastavení a proveďte změnu ve Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">Plně jsem porozuměl a nakonfiguroval.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Začínáme</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Vítejte v LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator je založen na Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Před prvním spuštěním je nutné jej nakonfigurovat podle následujících kroků:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Otevřete Windows Live Captions a podle průvodce stáhněte potřebné soubory pro místní rozpoznávání řeči a jazykové balíčky.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Klikněte</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ ikonu</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">pro otevření nabídky nastavení a vyberte</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Pozice &gt; Překryté na obrazovce"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Klikněte na</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Skrýt"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">tlačítko v nastavení LiveCaptions Translator pro skrytí Windows Live Captions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Program automaticky otevřel stránku nastavení a Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Po dokončení konfigurace se můžete vrátit na hlavní stránku a užívat si překlad zvuku v reálném čase.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Pro více informací navštivte naši wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Pro změnu</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">zdrojového jazyka</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, prosím klikněte [Zobrazit] Live Captions a změňte jazyk ve Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Plně jsem porozuměl a nakonfiguroval.</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="Navigation_Captions">Titulky</sys:String>
+    <sys:String x:Key="Navigation_Settings">Nastavení</sys:String>
+    <sys:String x:Key="Navigation_History">Historie</sys:String>
+    <sys:String x:Key="Navigation_Info">Info</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Titulky</sys:String>
-    <sys:String x:Key="M11">Nastavení</sys:String>
-    <sys:String x:Key="M12">Historie</sys:String>
-    <sys:String x:Key="M13">Info</sys:String>
-    <sys:String x:Key="M20">Záznam karet titulků</sys:String>
-    <sys:String x:Key="M21">Pozastavit překlad (jen záznam)</sys:String>
-    <sys:String x:Key="M22">Překryvná okna</sys:String>
-    <sys:String x:Key="M23">Vždy navrchu</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Záznam karet titulků</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pozastavit překlad (jen záznam)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Překryvná okna</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Vždy navrchu</sys:String>
 
-    <sys:String x:Key="MC0">[CHYBA] Kontrola aktualizace selhala.</sys:String>
-    <sys:String x:Key="MC1">chyba</sys:String>
-    <sys:String x:Key="MC2">Nová verze dostupná</sys:String>
-    <sys:String x:Key="MC3">Byla nalezena nová verze: {0}
+    <sys:String x:Key="MainWindow_Update_Error">[CHYBA] Kontrola aktualizace selhala.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">Chyba</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Nová verze dostupná</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Byla nalezena nová verze: {0}
 Aktuální verze: {1}
 Navštivte prosím GitHub pro stažení nejnovější verze.</sys:String>
-    <sys:String x:Key="MC4">Aktualizovat</sys:String>
-    <sys:String x:Key="MC5">Ignorovat tuto verzi</sys:String>
-    <sys:String x:Key="MC6">[CHYBA] Otevření prohlížeče selhalo.</sys:String>
 
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[UPOZORNĚNÍ] Živé titulky byly neočekávaně uzavřeny, restartuji...</sys:String>
-    <sys:String x:Key="T1">[Pozastaveno]</sys:String>
-    <sys:String x:Key="T2">Chyba!</sys:String>
-    <sys:String x:Key="T3">Záznam historie selhal: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[UPOZORNĚNÍ] Živé titulky byly neočekávaně uzavřeny, restartuji...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Pozastaveno]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Chyba!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Záznam historie selhal: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Klikněte pro kopírování</sys:String>
-    <sys:String x:Key="C1">Zkopírováno</sys:String>
-    <sys:String x:Key="C2">Kopírování selhalo</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Klikněte pro kopírování</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Zkopírováno</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Kopírování selhalo</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/de-de.xaml
+++ b/src/localization/de-de.xaml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Live-Untertitel</sys:String>
+    <sys:String x:Key="S1">Nach Windows 11 Version 24H2 können Sie nur die</sys:String>
+    <sys:String x:Key="S2">Quellsprache</sys:String>
+    <sys:String x:Key="S3">in Live-Untertiteln ändern.</sys:String>
+    <sys:String x:Key="S4">Hinweis:</sys:String>
+    <sys:String x:Key="S5">Bitte klicken Sie</sys:String>
+    <sys:String x:Key="S6">"Ausblenden"</sys:String>
+    <sys:String x:Key="S7">um Live-Untertitel zu verbergen, anstatt sie direkt zu schließen.</sys:String>
+
+    <sys:String x:Key="S8">Anzeigen</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Ausblenden</sys:String>
+    <sys:String x:Key="S46">Anzeigen</sys:String>
+
+    <sys:String x:Key="S9">API-Intervall</sys:String>
+    <sys:String x:Key="S10">Bestimmt die Häufigkeit der Übersetzungs-API-Aufrufe. Je kleiner, desto häufiger die Aufrufe.</sys:String>
+    <sys:String x:Key="S11">Die Übersetzungs-API wird einmal nach einer Untertiteländerung aufgerufen</sys:String>
+    <sys:String x:Key="S12">[API-Intervall]</sys:String>
+    <sys:String x:Key="S13">Mal.</sys:String>
+
+    <sys:String x:Key="S14">Übersetzungs-API</sys:String>
+    <sys:String x:Key="S15">Mit Ausnahme von Google und Google2 müssen alle anderen APIs vor der Verwendung konfiguriert werden.</sys:String>
+
+    <sys:String x:Key="S16">Zielsprache</sys:String>
+    <sys:String x:Key="S17">Die gewünschte Zielsprache ist nicht verfügbar!</sys:String>
+    <sys:String x:Key="S18">Sie können den Inhalt dieses Kombinationsfelds direkt bearbeiten, um die Sprache anzupassen, empfohlen wird die Verwendung des</sys:String>
+    <sys:String x:Key="S19">BCP 47-Sprachcodes.</sys:String>
+    <sys:String x:Key="S20">Einige APIs (wie DeepL) erfordern eine andere Methode zur Definition der Zielsprache, siehe deren offizielle Dokumentation.</sys:String>
+    <sys:String x:Key="S21">Für die enthaltenen Zielsprachen ist dies nicht nötig, da wir Tag-Mappings eingebaut haben. Wenn Ihre gewünschte Sprache nicht in der Liste ist, beachten Sie dies bitte.</sys:String>
+
+    <sys:String x:Key="S22">API-Einstellungen</sys:String>
+    <sys:String x:Key="S23">Öffnen</sys:String>
+    <sys:String x:Key="S24">Latenz anzeigen</sys:String>
+    <sys:String x:Key="S25">Aus</sys:String>
+    <sys:String x:Key="S26">Ein</sys:String>
+
+    <sys:String x:Key="S27">Kontexte</sys:String>
+    <sys:String x:Key="S28">Kontexte:</sys:String>
+    <sys:String x:Key="S29">Bestimmt die Anzahl der Kontextsätze, wenn</sys:String>
+    <sys:String x:Key="S30">Kontextbewusstsein</sys:String>
+    <sys:String x:Key="S31">aktiviert ist.</sys:String>
+    <sys:String x:Key="S32">Überlagerte Sätze:</sys:String>
+    <sys:String x:Key="S33">Bestimmt die Anzahl der angezeigten Karten, wenn</sys:String>
+    <sys:String x:Key="S34">Protokollkarten</sys:String>
+    <sys:String x:Key="S35">aktiviert sind, sowie die maximale Anzahl der Sätze, die im Overlay-Fenster angezeigt werden.</sys:String>
+    <sys:String x:Key="S36">Kontexte müssen</sys:String>
+    <sys:String x:Key="S37">größer oder gleich</sys:String>
+    <sys:String x:Key="S38">Angezeigte Sätze</sys:String>
+    <sys:String x:Key="S39">sein. Falls nicht, passt das Programm sie automatisch an.</sys:String>
+    <sys:String x:Key="S40">Angezeigte Sätze</sys:String>
+
+    <sys:String x:Key="S41">Im Kontext übersetzen.</sys:String>
+    <sys:String x:Key="S42">Dies kann die Übersetzungsgenauigkeit verbessern, verbraucht jedoch mehr Tokens.</sys:String>
+
+    <sys:String x:Key="S43">UI-Sprache</sys:String>
+    <sys:String x:Key="S44">Wählen Sie die Sprache, die von der Benutzeroberfläche der Anwendung verwendet wird.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Vorherige</sys:String>
+    <sys:String x:Key="H1">Nächste Seite</sys:String>
+    <sys:String x:Key="H2">Suchen</sys:String>
+    <sys:String x:Key="H3">Exportieren</sys:String>
+    <sys:String x:Key="H4">Alles löschen</sys:String>
+    <sys:String x:Key="H5">Aktualisieren</sys:String>
+    <sys:String x:Key="H6">Zeit</sys:String>
+    <sys:String x:Key="H7">Untertitel</sys:String>
+    <sys:String x:Key="H8">Übersetzt</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/Seite</sys:String>
+    <sys:String x:Key="H11">30/Seite</sys:String>
+    <sys:String x:Key="H12">50/Seite</sys:String>
+    <sys:String x:Key="H13">100/Seite</sys:String>
+
+    <sys:String x:Key="H20">Möchten Sie wirklich den gesamten Verlauf löschen?</sys:String>
+    <sys:String x:Key="H21">Dieser Vorgang kann nicht rückgängig gemacht werden!</sys:String>
+    <sys:String x:Key="H22">Ja</sys:String>
+    <sys:String x:Key="H23">Nein</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Alle Dateien (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Erfolgreich gespeichert</sys:String>
+    <sys:String x:Key="H26">Datei gespeichert unter: {0}</sys:String>
+    <sys:String x:Key="H27">Speichern fehlgeschlagen</sys:String>
+    <sys:String x:Key="H28">Datei konnte nicht gespeichert werden: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Overlay-Fenster</sys:String>
+    <sys:String x:Key="O1">Schriftgröße vergrößern</sys:String>
+    <sys:String x:Key="O2">Schriftgröße verkleinern</sys:String>
+    <sys:String x:Key="O3">Schriftkontur vergrößern</sys:String>
+    <sys:String x:Key="O4">Schriftkontur verkleinern</sys:String>
+    <sys:String x:Key="O5">Fett</sys:String>
+    <sys:String x:Key="O6">Schriftfarbe</sys:String>
+    <sys:String x:Key="O7">Hintergrundtransparenz erhöhen</sys:String>
+    <sys:String x:Key="O8">Hintergrundtransparenz verringern</sys:String>
+    <sys:String x:Key="O9">Hintergrundfarbe</sys:String>
+    <sys:String x:Key="O10">Nur Untertitel oder Übersetzungen anzeigen</sys:String>
+    <sys:String x:Key="O11">Position von Untertitel/Übersetzung wechseln</sys:String>
+    <sys:String x:Key="O12">Durchklicken erlauben</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Wir begrüßen jegliche Form von Beiträgen! Sie können Vorschläge machen oder Bugs über GitHub Issues melden oder direkt Code über Pull Requests beitragen.</sys:String>
+    <sys:String x:Key="I1">Wenn dieses Programm Ihnen hilft, geben Sie uns bitte einen Stern auf GitHub!</sys:String>
+    <sys:String x:Key="I2">Repository:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Betreuer:</sys:String>
+    <sys:String x:Key="I5">(Autor) und</sys:String>
+    <sys:String x:Key="I6">Version:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Erste Schritte</sys:String>
+    <sys:String x:Key="W1">Willkommen beim LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator basiert auf Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Vor dem ersten Start müssen Sie es gemäß den folgenden Schritten konfigurieren:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Öffnen Sie Windows LiveCaptions und laden Sie gemäß der Anleitung die erforderlichen Dateien für die lokale Spracherkennung und Sprachpakete herunter.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Klicken Sie auf</sys:String>
+    <sys:String x:Key="W6">⚙️ Symbol</sys:String>
+    <sys:String x:Key="W7">in Windows LiveCaptions, um das Einstellungsmenü zu öffnen, und wählen Sie</sys:String>
+    <sys:String x:Key="W8">"Position &gt; Überlagert auf dem Bildschirm"</sys:String>
+    <sys:String x:Key="W9">3. Klicken Sie auf die</sys:String>
+    <sys:String x:Key="W10">"Ausblenden"</sys:String>
+    <sys:String x:Key="W11">Schaltfläche in den Einstellungen von LiveCaptions Translator, um Windows LiveCaptions zu verbergen.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Das Programm hat automatisch die Einstellungsseite geöffnet und Windows LiveCaptions gestartet.</sys:String>
+    <sys:String x:Key="W13">Nach Abschluss der Konfiguration können Sie zur Hauptseite zurückkehren und Echtzeit-Audioübersetzungen genießen.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;Für weitere Details besuchen Sie unser Wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Tipp:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Um die </sys:String>
+    <sys:String x:Key="W18">Quellsprache</sys:String>
+    <sys:String x:Key="W19">zu ändern, bitte [Anzeigen] Sie LiveCaptions auf der Einstellungsseite und ändern Sie es in Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">Ich habe alles verstanden und konfiguriert.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Untertitel</sys:String>
+    <sys:String x:Key="M11">Einstellungen</sys:String>
+    <sys:String x:Key="M12">Verlauf</sys:String>
+    <sys:String x:Key="M13">Info</sys:String>
+    <sys:String x:Key="M20">Protokollkarten der Untertitel</sys:String>
+    <sys:String x:Key="M21">Übersetzung pausieren (nur Protokoll)</sys:String>
+    <sys:String x:Key="M22">Overlay-Fenster</sys:String>
+    <sys:String x:Key="M23">Immer im Vordergrund</sys:String>
+
+    <sys:String x:Key="MC0">[FEHLER] Update-Prüfung fehlgeschlagen.</sys:String>
+    <sys:String x:Key="MC1">Fehler</sys:String>
+    <sys:String x:Key="MC2">Neue Version verfügbar</sys:String>
+    <sys:String x:Key="MC3">Eine neue Version wurde erkannt: {0}
+Aktuelle Version: {1}
+Bitte besuchen Sie GitHub, um die neueste Version herunterzuladen.</sys:String>
+    <sys:String x:Key="MC4">Aktualisieren</sys:String>
+    <sys:String x:Key="MC5">Diese Version ignorieren</sys:String>
+    <sys:String x:Key="MC6">[FEHLER] Browser konnte nicht geöffnet werden.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[WARNUNG] Live-Untertitel wurden unerwartet geschlossen, starte neu...</sys:String>
+    <sys:String x:Key="T1">[Pausiert]</sys:String>
+    <sys:String x:Key="T2">Fehler!</sys:String>
+    <sys:String x:Key="T3">Protokollierung des Verlaufs fehlgeschlagen: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Zum Kopieren klicken</sys:String>
+    <sys:String x:Key="C1">Kopiert</sys:String>
+    <sys:String x:Key="C2">Kopieren fehlgeschlagen</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/de-de.xaml
+++ b/src/localization/de-de.xaml
@@ -3,168 +3,165 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Live-Untertitel</sys:String>
-    <sys:String x:Key="S1">Nach Windows 11 Version 24H2 können Sie nur die</sys:String>
-    <sys:String x:Key="S2">Quellsprache</sys:String>
-    <sys:String x:Key="S3">in Live-Untertiteln ändern.</sys:String>
-    <sys:String x:Key="S4">Hinweis:</sys:String>
-    <sys:String x:Key="S5">Bitte klicken Sie</sys:String>
-    <sys:String x:Key="S6">"Ausblenden"</sys:String>
-    <sys:String x:Key="S7">um Live-Untertitel zu verbergen, anstatt sie direkt zu schließen.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Live-Untertitel</sys:String>
+    <sys:String x:Key="S1">Ab Windows 11 24H2 kannst du nur noch</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Quellsprache</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">in Live-Untertiteln ändern.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Hinweis:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Bitte klicke</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Ausblenden"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">um Live-Untertitel auszublenden, statt sie direkt zu schließen.</sys:String>
 
-    <sys:String x:Key="S8">Anzeigen</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Anzeigen</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Ausblenden</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Ausblenden</sys:String>
-    <sys:String x:Key="S46">Anzeigen</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API-Intervall</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Legt die Häufigkeit der Übersetzungs-API-Aufrufe fest. Je kleiner der Wert, desto häufiger wird aufgerufen.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">Die Übersetzungs-API wird einmal aufgerufen, nachdem sich Untertitel</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API-Intervall]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">mal geändert haben.</sys:String>
 
-    <sys:String x:Key="S9">API-Intervall</sys:String>
-    <sys:String x:Key="S10">Bestimmt die Häufigkeit der Übersetzungs-API-Aufrufe. Je kleiner, desto häufiger die Aufrufe.</sys:String>
-    <sys:String x:Key="S11">Die Übersetzungs-API wird einmal nach einer Untertiteländerung aufgerufen</sys:String>
-    <sys:String x:Key="S12">[API-Intervall]</sys:String>
-    <sys:String x:Key="S13">Mal.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">Übersetzungs-API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Außer Google und Google2 müssen alle anderen APIs vor der Nutzung konfiguriert werden.</sys:String>
 
-    <sys:String x:Key="S14">Übersetzungs-API</sys:String>
-    <sys:String x:Key="S15">Mit Ausnahme von Google und Google2 müssen alle anderen APIs vor der Verwendung konfiguriert werden.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Zielsprache</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Meine gewünschte Zielsprache ist nicht dabei!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Du kannst den Inhalt dieser ComboBox direkt bearbeiten, um eine Sprache zu definieren. Empfohlen wird die Verwendung von</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP-47-Sprachkennungen.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Einige APIs (z. B. DeepL) verwenden eine andere Definition für die Zielsprache. Weitere Informationen findest du in deren Dokumentation.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Für integrierte Zielsprachen ist das unkritisch (Tag-Mapping ist vorhanden); wenn deine Sprache nicht in der Liste ist, beachte das.</sys:String>
 
-    <sys:String x:Key="S16">Zielsprache</sys:String>
-    <sys:String x:Key="S17">Die gewünschte Zielsprache ist nicht verfügbar!</sys:String>
-    <sys:String x:Key="S18">Sie können den Inhalt dieses Kombinationsfelds direkt bearbeiten, um die Sprache anzupassen, empfohlen wird die Verwendung des</sys:String>
-    <sys:String x:Key="S19">BCP 47-Sprachcodes.</sys:String>
-    <sys:String x:Key="S20">Einige APIs (wie DeepL) erfordern eine andere Methode zur Definition der Zielsprache, siehe deren offizielle Dokumentation.</sys:String>
-    <sys:String x:Key="S21">Für die enthaltenen Zielsprachen ist dies nicht nötig, da wir Tag-Mappings eingebaut haben. Wenn Ihre gewünschte Sprache nicht in der Liste ist, beachten Sie dies bitte.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API-Einstellungen</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Öffnen</sys:String>
 
-    <sys:String x:Key="S22">API-Einstellungen</sys:String>
-    <sys:String x:Key="S23">Öffnen</sys:String>
-    <sys:String x:Key="S24">Latenz anzeigen</sys:String>
-    <sys:String x:Key="S25">Aus</sys:String>
-    <sys:String x:Key="S26">Ein</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Latenz anzeigen</sys:String>
+    <sys:String x:Key="Common_Off">Aus</sys:String>
+    <sys:String x:Key="Common_On">An</sys:String>
 
-    <sys:String x:Key="S27">Kontexte</sys:String>
-    <sys:String x:Key="S28">Kontexte:</sys:String>
-    <sys:String x:Key="S29">Bestimmt die Anzahl der Kontextsätze, wenn</sys:String>
-    <sys:String x:Key="S30">Kontextbewusstsein</sys:String>
-    <sys:String x:Key="S31">aktiviert ist.</sys:String>
-    <sys:String x:Key="S32">Überlagerte Sätze:</sys:String>
-    <sys:String x:Key="S33">Bestimmt die Anzahl der angezeigten Karten, wenn</sys:String>
-    <sys:String x:Key="S34">Protokollkarten</sys:String>
-    <sys:String x:Key="S35">aktiviert sind, sowie die maximale Anzahl der Sätze, die im Overlay-Fenster angezeigt werden.</sys:String>
-    <sys:String x:Key="S36">Kontexte müssen</sys:String>
-    <sys:String x:Key="S37">größer oder gleich</sys:String>
-    <sys:String x:Key="S38">Angezeigte Sätze</sys:String>
-    <sys:String x:Key="S39">sein. Falls nicht, passt das Programm sie automatisch an.</sys:String>
-    <sys:String x:Key="S40">Angezeigte Sätze</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Kontext</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Kontext:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Legt die Anzahl der Kontext-Sätze fest, wenn</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Kontextsensitiv</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">aktiviert ist.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Overlay-Sätze:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Legt die Anzahl der angezeigten Karten fest, wenn</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Log-Karten</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">aktiviert ist, sowie die maximale Satzanzahl im Overlay-Fenster.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Kontext muss</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">größer oder gleich</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Angezeigte Sätze</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">sein, sonst wird automatisch angepasst.</sys:String>
 
-    <sys:String x:Key="S41">Im Kontext übersetzen.</sys:String>
-    <sys:String x:Key="S42">Dies kann die Übersetzungsgenauigkeit verbessern, verbraucht jedoch mehr Tokens.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Angezeigte Sätze</sys:String>
 
-    <sys:String x:Key="S43">UI-Sprache</sys:String>
-    <sys:String x:Key="S44">Wählen Sie die Sprache, die von der Benutzeroberfläche der Anwendung verwendet wird.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Im Kontext übersetzen.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Kann die Übersetzungsgenauigkeit verbessern, verbraucht aber mehr Tokens.</sys:String>
+
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI-Sprache</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Wähle die Sprache der Benutzeroberfläche der App.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Änderungen werden sofort übernommen und automatisch gespeichert.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Vorherige</sys:String>
-    <sys:String x:Key="H1">Nächste Seite</sys:String>
-    <sys:String x:Key="H2">Suchen</sys:String>
-    <sys:String x:Key="H3">Exportieren</sys:String>
-    <sys:String x:Key="H4">Alles löschen</sys:String>
-    <sys:String x:Key="H5">Aktualisieren</sys:String>
-    <sys:String x:Key="H6">Zeit</sys:String>
-    <sys:String x:Key="H7">Untertitel</sys:String>
-    <sys:String x:Key="H8">Übersetzt</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/Seite</sys:String>
-    <sys:String x:Key="H11">30/Seite</sys:String>
-    <sys:String x:Key="H12">50/Seite</sys:String>
-    <sys:String x:Key="H13">100/Seite</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Vorherige Seite</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Nächste Seite</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Suchen</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Exportieren</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Alles löschen</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Aktualisieren</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Zeit</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Untertitel</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Übersetzung</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/Seite</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/Seite</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/Seite</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/Seite</sys:String>
 
-    <sys:String x:Key="H20">Möchten Sie wirklich den gesamten Verlauf löschen?</sys:String>
-    <sys:String x:Key="H21">Dieser Vorgang kann nicht rückgängig gemacht werden!</sys:String>
-    <sys:String x:Key="H22">Ja</sys:String>
-    <sys:String x:Key="H23">Nein</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Alle Dateien (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Erfolgreich gespeichert</sys:String>
-    <sys:String x:Key="H26">Datei gespeichert unter: {0}</sys:String>
-    <sys:String x:Key="H27">Speichern fehlgeschlagen</sys:String>
-    <sys:String x:Key="H28">Datei konnte nicht gespeichert werden: {0}</sys:String>
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Möchtest du wirklich den gesamten Verlauf löschen?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Diese Aktion kann nicht rückgängig gemacht werden!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Ja</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Nein</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Alle Dateien (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Speichern erfolgreich</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Datei gespeichert unter: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Speichern fehlgeschlagen</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Dateispeicherung fehlgeschlagen: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Overlay-Fenster</sys:String>
-    <sys:String x:Key="O1">Schriftgröße vergrößern</sys:String>
-    <sys:String x:Key="O2">Schriftgröße verkleinern</sys:String>
-    <sys:String x:Key="O3">Schriftkontur vergrößern</sys:String>
-    <sys:String x:Key="O4">Schriftkontur verkleinern</sys:String>
-    <sys:String x:Key="O5">Fett</sys:String>
-    <sys:String x:Key="O6">Schriftfarbe</sys:String>
-    <sys:String x:Key="O7">Hintergrundtransparenz erhöhen</sys:String>
-    <sys:String x:Key="O8">Hintergrundtransparenz verringern</sys:String>
-    <sys:String x:Key="O9">Hintergrundfarbe</sys:String>
-    <sys:String x:Key="O10">Nur Untertitel oder Übersetzungen anzeigen</sys:String>
-    <sys:String x:Key="O11">Position von Untertitel/Übersetzung wechseln</sys:String>
-    <sys:String x:Key="O12">Durchklicken erlauben</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Overlay-Fenster</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Schrift vergrößern</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Schrift verkleinern</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Kontur vergrößern</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Kontur verkleinern</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Fett</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Schriftfarbe</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Hintergrundtransparenz erhöhen</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Hintergrundtransparenz verringern</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Hintergrundfarbe</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Nur Original oder Übersetzung anzeigen</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Original/Übersetzung Position wechseln</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Klickdurchlässig</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Wir begrüßen jegliche Form von Beiträgen! Sie können Vorschläge machen oder Bugs über GitHub Issues melden oder direkt Code über Pull Requests beitragen.</sys:String>
-    <sys:String x:Key="I1">Wenn dieses Programm Ihnen hilft, geben Sie uns bitte einen Stern auf GitHub!</sys:String>
-    <sys:String x:Key="I2">Repository:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Betreuer:</sys:String>
-    <sys:String x:Key="I5">(Autor) und</sys:String>
-    <sys:String x:Key="I6">Version:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Beiträge jeder Art sind willkommen! Du kannst Vorschläge machen oder Bugs über GitHub Issues melden oder Code über Pull Requests beisteuern.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Wenn dir dieses Programm hilft, freue ich mich über einen Star auf GitHub!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repository:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Maintainer:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Autor) und</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Version:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Erste Schritte</sys:String>
-    <sys:String x:Key="W1">Willkommen beim LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator basiert auf Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Vor dem ersten Start müssen Sie es gemäß den folgenden Schritten konfigurieren:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Öffnen Sie Windows LiveCaptions und laden Sie gemäß der Anleitung die erforderlichen Dateien für die lokale Spracherkennung und Sprachpakete herunter.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Klicken Sie auf</sys:String>
-    <sys:String x:Key="W6">⚙️ Symbol</sys:String>
-    <sys:String x:Key="W7">in Windows LiveCaptions, um das Einstellungsmenü zu öffnen, und wählen Sie</sys:String>
-    <sys:String x:Key="W8">"Position &gt; Überlagert auf dem Bildschirm"</sys:String>
-    <sys:String x:Key="W9">3. Klicken Sie auf die</sys:String>
-    <sys:String x:Key="W10">"Ausblenden"</sys:String>
-    <sys:String x:Key="W11">Schaltfläche in den Einstellungen von LiveCaptions Translator, um Windows LiveCaptions zu verbergen.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Das Programm hat automatisch die Einstellungsseite geöffnet und Windows LiveCaptions gestartet.</sys:String>
-    <sys:String x:Key="W13">Nach Abschluss der Konfiguration können Sie zur Hauptseite zurückkehren und Echtzeit-Audioübersetzungen genießen.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;Für weitere Details besuchen Sie unser Wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Tipp:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Um die </sys:String>
-    <sys:String x:Key="W18">Quellsprache</sys:String>
-    <sys:String x:Key="W19">zu ändern, bitte [Anzeigen] Sie LiveCaptions auf der Einstellungsseite und ändern Sie es in Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">Ich habe alles verstanden und konfiguriert.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Erste Schritte</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Willkommen bei LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator basiert auf den Windows Live-Untertiteln (Live Captions).</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Vor dem ersten Start musst du die folgenden Schritte durchführen:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Öffne die Windows Live-Untertitel und folge dem Assistenten, um die erforderlichen Dateien und Sprachpakete für die Offline-Spracherkennung herunterzuladen.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Klicke in den Windows Live-Untertiteln auf</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ Zahnrad</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">, um die Einstellungen zu öffnen, und wähle</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">„Position &gt; Auf dem Bildschirm überlagern“</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Klicke auf der Einstellungsseite von LiveCaptions Translator auf</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">„Ausblenden“</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">, um Windows Live-Untertitel auszublenden.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Die App ist automatisch zur Einstellungsseite gesprungen und hat Windows Live-Untertitel geöffnet.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Nach der Einrichtung kannst du zurück zur Startseite wechseln und Echtzeit-Audioübersetzung nutzen.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Weitere Details im Wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Tipp:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Um die </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Quellsprache</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">zu ändern, klicke zuerst in den Einstellungen auf [Anzeigen] und ändere sie anschließend in Windows Live-Untertiteln.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Ich habe alles verstanden und eingerichtet.</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="Navigation_Captions">Untertitel</sys:String>
+    <sys:String x:Key="Navigation_Settings">Einstellungen</sys:String>
+    <sys:String x:Key="Navigation_History">Verlauf</sys:String>
+    <sys:String x:Key="Navigation_Info">Info</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Untertitel</sys:String>
-    <sys:String x:Key="M11">Einstellungen</sys:String>
-    <sys:String x:Key="M12">Verlauf</sys:String>
-    <sys:String x:Key="M13">Info</sys:String>
-    <sys:String x:Key="M20">Protokollkarten der Untertitel</sys:String>
-    <sys:String x:Key="M21">Übersetzung pausieren (nur Protokoll)</sys:String>
-    <sys:String x:Key="M22">Overlay-Fenster</sys:String>
-    <sys:String x:Key="M23">Immer im Vordergrund</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Untertitel-Log-Karten</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Übersetzung pausieren (nur protokollieren)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Overlay-Fenster</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Immer im Vordergrund</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[FEHLER] Updateprüfung fehlgeschlagen.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">error</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Neue Version gefunden</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Neue Version erkannt: {0} Aktuelle Version: {1} Bitte lade die neueste Release-Version von GitHub herunter.</sys:String>
 
-    <sys:String x:Key="MC0">[FEHLER] Update-Prüfung fehlgeschlagen.</sys:String>
-    <sys:String x:Key="MC1">Fehler</sys:String>
-    <sys:String x:Key="MC2">Neue Version verfügbar</sys:String>
-    <sys:String x:Key="MC3">Eine neue Version wurde erkannt: {0}
-Aktuelle Version: {1}
-Bitte besuchen Sie GitHub, um die neueste Version herunterzuladen.</sys:String>
-    <sys:String x:Key="MC4">Aktualisieren</sys:String>
-    <sys:String x:Key="MC5">Diese Version ignorieren</sys:String>
-    <sys:String x:Key="MC6">[FEHLER] Browser konnte nicht geöffnet werden.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[WARNUNG] Live-Untertitel wurden unerwartet geschlossen, starte neu...</sys:String>
-    <sys:String x:Key="T1">[Pausiert]</sys:String>
-    <sys:String x:Key="T2">Fehler!</sys:String>
-    <sys:String x:Key="T3">Protokollierung des Verlaufs fehlgeschlagen: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[WARNUNG] Live-Untertitel wurden unerwartet geschlossen, starte neu…</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Pausiert]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Fehler!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Speichern des Verlaufs fehlgeschlagen: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Zum Kopieren klicken</sys:String>
-    <sys:String x:Key="C1">Kopiert</sys:String>
-    <sys:String x:Key="C2">Kopieren fehlgeschlagen</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Klicken zum Kopieren</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Kopiert</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Kopieren fehlgeschlagen</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/en-us.xaml
+++ b/src/localization/en-us.xaml
@@ -1,186 +1,174 @@
-<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">LiveCaptions</sys:String>
-    <sys:String x:Key="S1">After Windows 11 version 24H2, you can only change the</sys:String>
-    <sys:String x:Key="S2">Source Language</sys:String>
-    <sys:String x:Key="S3">in LiveCaptions.</sys:String>
-    <sys:String x:Key="S4">Note:</sys:String>
-    <sys:String x:Key="S5">Please click</sys:String>
-    <sys:String x:Key="S6">"Hide"</sys:String>
-    <sys:String x:Key="S7">to hide LiveCaptions instead of closing it directly.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Live Captions</sys:String>
+    <sys:String x:Key="S1">After Windows 11 24H2, you can only change</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">source language</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">in Live Captions.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Note:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Please click</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Hide"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">to hide Live Captions instead of closing it.</sys:String>
 
-    <sys:String x:Key="S8">Show</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Show</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Hide</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Hide</sys:String>
-    <sys:String x:Key="S46">Show</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API Interval</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Determines how often the translation API is called. Smaller values call more frequently.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">Call the translation API once after captions change</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API Interval]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">times.</sys:String>
 
-    <sys:String x:Key="S9">API Interval</sys:String>
-    <sys:String x:Key="S10">Determines the frequency of translate API calls. The smaller it is, the more frequent API calls.</sys:String>
-    <sys:String x:Key="S11">The translate API is called once after the caption changes</sys:String>
-    <sys:String x:Key="S12">[API Interval]</sys:String>
-    <sys:String x:Key="S13">times.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">Translate API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Except Google and Google2, other APIs require configuration before use.</sys:String>
 
-    <sys:String x:Key="S14">Translate API</sys:String>
-    <sys:String x:Key="S15">Except for Google and Google2, all other APIs require configuring before they can be used.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Target language</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">No target language I want?</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">You can edit this ComboBox text to customize the language. It is recommended to follow</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47 language tags.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Some APIs (e.g. DeepL) require a different way to specify target language. Please check their documentation.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Built-in target languages are mapped already. If your language isn't in the list, keep this in mind.</sys:String>
 
-    <sys:String x:Key="S16">Target Language</sys:String>
-    <sys:String x:Key="S17">There isn't the target language I expect!</sys:String>
-    <sys:String x:Key="S18">You can directly edit the content of this combobox to customize the language, and it is recommended to follow the</sys:String>
-    <sys:String x:Key="S19">BCP 47 language tag.</sys:String>
-    <sys:String x:Key="S20">Some of APIs (such as DeepL) needs another way to define target language, see their official docs for more details.</sys:String>
-    <sys:String x:Key="S21">No need to consider this for included target languages, since we've built in tag mappings. But if your expected language isn't in the list, keep this in mind.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API Settings</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Open</sys:String>
 
-    <sys:String x:Key="S22">API Setting</sys:String>
-    <sys:String x:Key="S23">Open</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Show latency</sys:String>
+    <sys:String x:Key="Common_Off">Off</sys:String>
+    <sys:String x:Key="Common_On">On</sys:String>
 
-    <sys:String x:Key="S24">Show Latency</sys:String>
-    <sys:String x:Key="S25">Off</sys:String>
-    <sys:String x:Key="S26">On</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Contexts</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Contexts:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Determines the number of context sentences when</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Context-aware</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">is enabled.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Overlay sentences:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Determines the number of cards shown when</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Log cards</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">is enabled, and the maximum sentences shown in the overlay window.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Contexts must be</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">greater than or equal to</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Display sentences</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Otherwise the app will adjust automatically.</sys:String>
 
-    <sys:String x:Key="S27">Contexts</sys:String>
-    <sys:String x:Key="S28">Contexts:</sys:String>
-    <sys:String x:Key="S29">Determines the number of context sentences when</sys:String>
-    <sys:String x:Key="S30">Context Aware</sys:String>
-    <sys:String x:Key="S31">is enabled.</sys:String>
-    <sys:String x:Key="S32">Overlay Sentences:</sys:String>
-    <sys:String x:Key="S33">Determines the number of displayed cards when</sys:String>
-    <sys:String x:Key="S34">Log Cards</sys:String>
-    <sys:String x:Key="S35">is enabled, as well as the max number of sentences displayed in the Overlay Window.</sys:String>
-    <sys:String x:Key="S36">Contexts must be</sys:String>
-    <sys:String x:Key="S37">greater than or equal</sys:String>
-    <sys:String x:Key="S38">Display Sentences</sys:String>
-    <sys:String x:Key="S39">. If not met, the program will automatically adjust them.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Display sentences</sys:String>
 
-    <sys:String x:Key="S40">Display Sentences</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Translate with context.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">May improve accuracy but consumes more tokens.</sys:String>
 
-    <sys:String x:Key="S41">Translate in context.</sys:String>
-    <sys:String x:Key="S42">It can improve translation accuracy, but will consume more tokens.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI language</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Select the language used by the app UI.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Changes take effect immediately and are saved automatically.</sys:String>
 
-    <sys:String x:Key="S43">UI Language</sys:String>
-    <sys:String x:Key="S44">Select the language used by the application's UI.</sys:String>
+    <!-- HistoryPage strings (semantic keys) -->
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Previous page</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Next page</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Search</sys:String>
 
-    <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Previous</sys:String>
-    <sys:String x:Key="H1">Next Page</sys:String>
-    <sys:String x:Key="H2">Search</sys:String>
-    <sys:String x:Key="H3">Export</sys:String>
-    <sys:String x:Key="H4">Delete All</sys:String>
-    <sys:String x:Key="H5">Refresh</sys:String>
-    <sys:String x:Key="H6">Time</sys:String>
-    <sys:String x:Key="H7">Caption</sys:String>
-    <sys:String x:Key="H8">Translated</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/page</sys:String>
-    <sys:String x:Key="H11">30/page</sys:String>
-    <sys:String x:Key="H12">50/page</sys:String>
-    <sys:String x:Key="H13">100/page</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Export</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Delete all</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Refresh</sys:String>
+
+    <sys:String x:Key="HistoryPage_Column_Time">Time</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Caption</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Translate</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+
+    <sys:String x:Key="HistoryPage_PageSize_20">20/page</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/page</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/page</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/page</sys:String>
 
     <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">Do you want to delete all history?</sys:String>
-    <sys:String x:Key="H21">This operation cannot be undone!</sys:String>
-    <sys:String x:Key="H22">Yes</sys:String>
-    <sys:String x:Key="H23">No</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Saved Success</sys:String>
-    <sys:String x:Key="H26">File saved to: {0}</sys:String>
-    <sys:String x:Key="H27">Save Failed</sys:String>
-    <sys:String x:Key="H28">File saved failed: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Are you sure to delete all history?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">This action cannot be undone!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Yes</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">No</sys:String>
 
-    <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Overlay Window</sys:String>
-    <sys:String x:Key="O1">Font Size Increase</sys:String>
-    <sys:String x:Key="O2">Font Size Decrease</sys:String>
-    <sys:String x:Key="O3">Font Stroke Increase</sys:String>
-    <sys:String x:Key="O4">Font Stroke Decrease</sys:String>
-    <sys:String x:Key="O5">Font Bold</sys:String>
-    <sys:String x:Key="O6">Font Color</sys:String>
-    <sys:String x:Key="O7">Background Opacity Increase</sys:String>
-    <sys:String x:Key="O8">Background Opacity Decrease</sys:String>
-    <sys:String x:Key="O9">Background Color</sys:String>
-    <sys:String x:Key="O10">Show only subtitles or translations</sys:String>
-    <sys:String x:Key="O11">Switch subtitle/translation position</sys:String>
-    <sys:String x:Key="O12">Click Through</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
+
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Saved successfully</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">File saved to: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Save failed</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Save file failed: {0}</sys:String>
+
+    <!-- OverlayWindow strings (semantic tooltips) -->
+    <sys:String x:Key="OverlayWindow_Title">Overlay window</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Increase font size</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Decrease font size</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Increase stroke</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Decrease stroke</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Bold</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Font color</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Increase background opacity</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Decrease background opacity</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Background color</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Show subtitle only or translation only</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Switch subtitle/translation position</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Click-through</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">We welcome any form of contribution! You can provide suggestions or report bugs via GitHub issues, or contribute code directly by submitting Pull Requests.</sys:String>
-    <sys:String x:Key="I1">If this program is helpful to you, please consider giving us a star!</sys:String>
-    <sys:String x:Key="I2">Repository:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Maintainer:</sys:String>
-    <sys:String x:Key="I5">(Author) and</sys:String>
-    <sys:String x:Key="I6">Version:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Contributions of all kinds are welcome! You can suggest features or report bugs through GitHub issues, or contribute code directly by submitting Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">If this program helps you, please consider giving the project a Star!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repo:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Maintainer:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Author) and</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Version:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Getting Started</sys:String>
-    <sys:String x:Key="W1">Welcome to LiveCaptions Translator!</sys:String>
-
-    <sys:String x:Key="W2">LiveCaptions Translator is based on Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Before your first running, you need to configure it according to the following steps:&#x0A;</sys:String>
-
-    <sys:String x:Key="W4">&#x0A;1. Open Windows LiveCaptions and follow the guide to download the necessary files for on-device speech recognition and language packs.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Click the</sys:String>
-    <sys:String x:Key="W6">⚙️ gear</sys:String>
-    <sys:String x:Key="W7">icon in Windows LiveCaptions to open the settings menu, and select</sys:String>
-    <sys:String x:Key="W8">"Position &gt; Overlaid on screen"</sys:String>
-    <sys:String x:Key="W9">3. Click the</sys:String>
-    <sys:String x:Key="W10">"Hide"</sys:String>
-    <sys:String x:Key="W11">button located in the setting page of LiveCaptions Translator to hide Windows LiveCaptions.&#x0A;</sys:String>
-
-    <sys:String x:Key="W12">&#x0A;The program has automatically navigated to the setting page and opened Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">After completing the configuration, you can switch back to the main page and enjoy real-time audio translation.&#x0A;</sys:String>
-
-    <sys:String x:Key="W14">&#x0A;For more details, visit our wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-
-    <sys:String x:Key="W16">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
-    <sys:String x:Key="W17">To change the </sys:String>
-    <sys:String x:Key="W18">Source Language</sys:String>
-    <sys:String x:Key="W19">, please [Show] LiveCaptions on the setting page and do it in Windows LiveCaptions.</sys:String>
-
-    <sys:String x:Key="W20">I have fully understood and configured.</sys:String>
-
-    <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Get Started</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Welcome to LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator is based on Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Before the first run, please complete the following setup steps:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Open Windows Live Captions and follow the guide to download offline speech recognition files and language packs.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Click</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ gear</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">icon to open Settings and select</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Position &gt; Overlaid on screen"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Click</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Hide"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">button in LiveCaptions Translator settings page to hide Windows Live Captions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;The app has automatically jumped to the settings page and opened Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">After the setup is complete, you can go back to the main page and enjoy real-time audio translation.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;For more details, please check the Wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">If you want to change</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">source language</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, please click [Show] Live Captions first and then change it in Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">I have fully understood and completed the setup.</sys:String>
 
     <!-- Navigation menu -->
-    <sys:String x:Key="M10">Caption</sys:String>
-    <sys:String x:Key="M11">Setting</sys:String>
-    <sys:String x:Key="M12">History</sys:String>
-    <sys:String x:Key="M13">Info</sys:String>
+    <sys:String x:Key="Navigation_Captions">Captions</sys:String>
+    <sys:String x:Key="Navigation_Settings">Settings</sys:String>
+    <sys:String x:Key="Navigation_History">History</sys:String>
+    <sys:String x:Key="Navigation_Info">Info</sys:String>
 
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">Log Cards of Captions</sys:String>
-    <sys:String x:Key="M21">Pause Translation (Log Only)</sys:String>
-    <sys:String x:Key="M22">Overlay Window</sys:String>
-    <sys:String x:Key="M23">Always on Top</sys:String>
+    <!-- MainWindow strings -->
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Caption log cards</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pause translation (log only)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Overlay window</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Always on top</sys:String>
 
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[ERROR] Update Check Failed.</sys:String>
-    <sys:String x:Key="MC1">error</sys:String>
-
-    <sys:String x:Key="MC2">New Version Available</sys:String>
-    <sys:String x:Key="MC3">A new version has been detected: {0}
+    <sys:String x:Key="MainWindow_Update_Error">[ERROR] Update check failed.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">error</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">New version found</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">New version detected: {0}
 Current version: {1}
-Please visit GitHub to download the latest release.</sys:String>
-    <sys:String x:Key="MC4">Update</sys:String>
-    <sys:String x:Key="MC5">Ignore this version</sys:String>
+Please go to GitHub to download the latest release.</sys:String>
 
-    <sys:String x:Key="MC6">[ERROR] Open Browser Failed.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[WARNING] LiveCaptions was unexpectedly closed, restarting...</sys:String>
-    <sys:String x:Key="T1">[Paused]</sys:String>
-    <sys:String x:Key="T2">Error!</sys:String>
-    <sys:String x:Key="T3">Logging history failed: {0}</sys:String>
+    <!-- Translator  -->
+    <sys:String x:Key="Translator_Status_Restarting">[WARNING] Live Captions closed unexpectedly, restarting…</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Paused]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Error!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Write history failed: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Click To Copy</sys:String>
-    <sys:String x:Key="C1">Copied</sys:String>
-    <sys:String x:Key="C2">Copy Failed</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Click to copy</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Copied</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Copy failed</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/en-us.xaml
+++ b/src/localization/en-us.xaml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">LiveCaptions</sys:String>
+    <sys:String x:Key="S1">After Windows 11 version 24H2, you can only change the</sys:String>
+    <sys:String x:Key="S2">Source Language</sys:String>
+    <sys:String x:Key="S3">in LiveCaptions.</sys:String>
+    <sys:String x:Key="S4">Note:</sys:String>
+    <sys:String x:Key="S5">Please click</sys:String>
+    <sys:String x:Key="S6">"Hide"</sys:String>
+    <sys:String x:Key="S7">to hide LiveCaptions instead of closing it directly.</sys:String>
+
+    <sys:String x:Key="S8">Show</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Hide</sys:String>
+    <sys:String x:Key="S46">Show</sys:String>
+
+    <sys:String x:Key="S9">API Interval</sys:String>
+    <sys:String x:Key="S10">Determines the frequency of translate API calls. The smaller it is, the more frequent API calls.</sys:String>
+    <sys:String x:Key="S11">The translate API is called once after the caption changes</sys:String>
+    <sys:String x:Key="S12">[API Interval]</sys:String>
+    <sys:String x:Key="S13">times.</sys:String>
+
+    <sys:String x:Key="S14">Translate API</sys:String>
+    <sys:String x:Key="S15">Except for Google and Google2, all other APIs require configuring before they can be used.</sys:String>
+
+    <sys:String x:Key="S16">Target Language</sys:String>
+    <sys:String x:Key="S17">There isn't the target language I expect!</sys:String>
+    <sys:String x:Key="S18">You can directly edit the content of this combobox to customize the language, and it is recommended to follow the</sys:String>
+    <sys:String x:Key="S19">BCP 47 language tag.</sys:String>
+    <sys:String x:Key="S20">Some of APIs (such as DeepL) needs another way to define target language, see their official docs for more details.</sys:String>
+    <sys:String x:Key="S21">No need to consider this for included target languages, since we've built in tag mappings. But if your expected language isn't in the list, keep this in mind.</sys:String>
+
+    <sys:String x:Key="S22">API Setting</sys:String>
+    <sys:String x:Key="S23">Open</sys:String>
+
+    <sys:String x:Key="S24">Show Latency</sys:String>
+    <sys:String x:Key="S25">Off</sys:String>
+    <sys:String x:Key="S26">On</sys:String>
+
+    <sys:String x:Key="S27">Contexts</sys:String>
+    <sys:String x:Key="S28">Contexts:</sys:String>
+    <sys:String x:Key="S29">Determines the number of context sentences when</sys:String>
+    <sys:String x:Key="S30">Context Aware</sys:String>
+    <sys:String x:Key="S31">is enabled.</sys:String>
+    <sys:String x:Key="S32">Overlay Sentences:</sys:String>
+    <sys:String x:Key="S33">Determines the number of displayed cards when</sys:String>
+    <sys:String x:Key="S34">Log Cards</sys:String>
+    <sys:String x:Key="S35">is enabled, as well as the max number of sentences displayed in the Overlay Window.</sys:String>
+    <sys:String x:Key="S36">Contexts must be</sys:String>
+    <sys:String x:Key="S37">greater than or equal</sys:String>
+    <sys:String x:Key="S38">Display Sentences</sys:String>
+    <sys:String x:Key="S39">. If not met, the program will automatically adjust them.</sys:String>
+
+    <sys:String x:Key="S40">Display Sentences</sys:String>
+
+    <sys:String x:Key="S41">Translate in context.</sys:String>
+    <sys:String x:Key="S42">It can improve translation accuracy, but will consume more tokens.</sys:String>
+
+    <sys:String x:Key="S43">UI Language</sys:String>
+    <sys:String x:Key="S44">Select the language used by the application's UI.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Previous</sys:String>
+    <sys:String x:Key="H1">Next Page</sys:String>
+    <sys:String x:Key="H2">Search</sys:String>
+    <sys:String x:Key="H3">Export</sys:String>
+    <sys:String x:Key="H4">Delete All</sys:String>
+    <sys:String x:Key="H5">Refresh</sys:String>
+    <sys:String x:Key="H6">Time</sys:String>
+    <sys:String x:Key="H7">Caption</sys:String>
+    <sys:String x:Key="H8">Translated</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/page</sys:String>
+    <sys:String x:Key="H11">30/page</sys:String>
+    <sys:String x:Key="H12">50/page</sys:String>
+    <sys:String x:Key="H13">100/page</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">Do you want to delete all history?</sys:String>
+    <sys:String x:Key="H21">This operation cannot be undone!</sys:String>
+    <sys:String x:Key="H22">Yes</sys:String>
+    <sys:String x:Key="H23">No</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|All file (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Saved Success</sys:String>
+    <sys:String x:Key="H26">File saved to: {0}</sys:String>
+    <sys:String x:Key="H27">Save Failed</sys:String>
+    <sys:String x:Key="H28">File saved failed: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Overlay Window</sys:String>
+    <sys:String x:Key="O1">Font Size Increase</sys:String>
+    <sys:String x:Key="O2">Font Size Decrease</sys:String>
+    <sys:String x:Key="O3">Font Stroke Increase</sys:String>
+    <sys:String x:Key="O4">Font Stroke Decrease</sys:String>
+    <sys:String x:Key="O5">Font Bold</sys:String>
+    <sys:String x:Key="O6">Font Color</sys:String>
+    <sys:String x:Key="O7">Background Opacity Increase</sys:String>
+    <sys:String x:Key="O8">Background Opacity Decrease</sys:String>
+    <sys:String x:Key="O9">Background Color</sys:String>
+    <sys:String x:Key="O10">Show only subtitles or translations</sys:String>
+    <sys:String x:Key="O11">Switch subtitle/translation position</sys:String>
+    <sys:String x:Key="O12">Click Through</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">We welcome any form of contribution! You can provide suggestions or report bugs via GitHub issues, or contribute code directly by submitting Pull Requests.</sys:String>
+    <sys:String x:Key="I1">If this program is helpful to you, please consider giving us a star!</sys:String>
+    <sys:String x:Key="I2">Repository:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Maintainer:</sys:String>
+    <sys:String x:Key="I5">(Author) and</sys:String>
+    <sys:String x:Key="I6">Version:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Getting Started</sys:String>
+    <sys:String x:Key="W1">Welcome to LiveCaptions Translator!</sys:String>
+
+    <sys:String x:Key="W2">LiveCaptions Translator is based on Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Before your first running, you need to configure it according to the following steps:&#x0A;</sys:String>
+
+    <sys:String x:Key="W4">&#x0A;1. Open Windows LiveCaptions and follow the guide to download the necessary files for on-device speech recognition and language packs.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Click the</sys:String>
+    <sys:String x:Key="W6">⚙️ gear</sys:String>
+    <sys:String x:Key="W7">icon in Windows LiveCaptions to open the settings menu, and select</sys:String>
+    <sys:String x:Key="W8">"Position &gt; Overlaid on screen"</sys:String>
+    <sys:String x:Key="W9">3. Click the</sys:String>
+    <sys:String x:Key="W10">"Hide"</sys:String>
+    <sys:String x:Key="W11">button located in the setting page of LiveCaptions Translator to hide Windows LiveCaptions.&#x0A;</sys:String>
+
+    <sys:String x:Key="W12">&#x0A;The program has automatically navigated to the setting page and opened Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">After completing the configuration, you can switch back to the main page and enjoy real-time audio translation.&#x0A;</sys:String>
+
+    <sys:String x:Key="W14">&#x0A;For more details, visit our wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+
+    <sys:String x:Key="W16">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
+    <sys:String x:Key="W17">To change the </sys:String>
+    <sys:String x:Key="W18">Source Language</sys:String>
+    <sys:String x:Key="W19">, please [Show] LiveCaptions on the setting page and do it in Windows LiveCaptions.</sys:String>
+
+    <sys:String x:Key="W20">I have fully understood and configured.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">Caption</sys:String>
+    <sys:String x:Key="M11">Setting</sys:String>
+    <sys:String x:Key="M12">History</sys:String>
+    <sys:String x:Key="M13">Info</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">Log Cards of Captions</sys:String>
+    <sys:String x:Key="M21">Pause Translation (Log Only)</sys:String>
+    <sys:String x:Key="M22">Overlay Window</sys:String>
+    <sys:String x:Key="M23">Always on Top</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[ERROR] Update Check Failed.</sys:String>
+    <sys:String x:Key="MC1">error</sys:String>
+
+    <sys:String x:Key="MC2">New Version Available</sys:String>
+    <sys:String x:Key="MC3">A new version has been detected: {0}
+Current version: {1}
+Please visit GitHub to download the latest release.</sys:String>
+    <sys:String x:Key="MC4">Update</sys:String>
+    <sys:String x:Key="MC5">Ignore this version</sys:String>
+
+    <sys:String x:Key="MC6">[ERROR] Open Browser Failed.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[WARNING] LiveCaptions was unexpectedly closed, restarting...</sys:String>
+    <sys:String x:Key="T1">[Paused]</sys:String>
+    <sys:String x:Key="T2">Error!</sys:String>
+    <sys:String x:Key="T3">Logging history failed: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Click To Copy</sys:String>
+    <sys:String x:Key="C1">Copied</sys:String>
+    <sys:String x:Key="C2">Copy Failed</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/es-mx.xaml
+++ b/src/localization/es-mx.xaml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Subtítulos en Vivo</sys:String>
+    <sys:String x:Key="S1">Después de la versión 24H2 de Windows 11, solo puedes cambiar el</sys:String>
+    <sys:String x:Key="S2">Idioma de Origen</sys:String>
+    <sys:String x:Key="S3">en Subtítulos en Vivo.</sys:String>
+    <sys:String x:Key="S4">Nota:</sys:String>
+    <sys:String x:Key="S5">Por favor haz clic</sys:String>
+    <sys:String x:Key="S6">"Ocultar"</sys:String>
+    <sys:String x:Key="S7">para ocultar Subtítulos en Vivo en lugar de cerrarlo directamente.</sys:String>
+
+    <sys:String x:Key="S8">Mostrar</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Ocultar</sys:String>
+    <sys:String x:Key="S46">Mostrar</sys:String>
+
+    <sys:String x:Key="S9">Intervalo de API</sys:String>
+    <sys:String x:Key="S10">Determina la frecuencia de las llamadas a la API de traducción. Cuanto menor, más frecuentes serán las llamadas.</sys:String>
+    <sys:String x:Key="S11">La API de traducción se llama una vez después de que el subtítulo cambie</sys:String>
+    <sys:String x:Key="S12">[Intervalo de API]</sys:String>
+    <sys:String x:Key="S13">veces.</sys:String>
+
+    <sys:String x:Key="S14">API de Traducción</sys:String>
+    <sys:String x:Key="S15">Excepto Google y Google2, todas las demás APIs requieren configuración antes de poder usarse.</sys:String>
+
+    <sys:String x:Key="S16">Idioma de Destino</sys:String>
+    <sys:String x:Key="S17">¡El idioma de destino que esperabas no está disponible!</sys:String>
+    <sys:String x:Key="S18">Puedes editar directamente el contenido de este combo para personalizar el idioma; se recomienda seguir la</sys:String>
+    <sys:String x:Key="S19">etiqueta de idioma BCP 47.</sys:String>
+    <sys:String x:Key="S20">Algunas APIs (como DeepL) requieren otra forma de definir el idioma de destino; consulta su documentación oficial para más detalles.</sys:String>
+    <sys:String x:Key="S21">No es necesario considerar esto para los idiomas incluidos, ya que hemos incorporado mapeos de etiquetas. Pero si tu idioma esperado no está en la lista, tenlo en cuenta.</sys:String>
+
+    <sys:String x:Key="S22">Configuración de API</sys:String>
+    <sys:String x:Key="S23">Abrir</sys:String>
+
+    <sys:String x:Key="S24">Mostrar Latencia</sys:String>
+    <sys:String x:Key="S25">Desactivado</sys:String>
+    <sys:String x:Key="S26">Activado</sys:String>
+
+    <sys:String x:Key="S27">Contextos</sys:String>
+    <sys:String x:Key="S28">Contextos:</sys:String>
+    <sys:String x:Key="S29">Determina el número de frases de contexto cuando</sys:String>
+    <sys:String x:Key="S30">Contexto Inteligente</sys:String>
+    <sys:String x:Key="S31">está activado.</sys:String>
+    <sys:String x:Key="S32">Frases en Overlay:</sys:String>
+    <sys:String x:Key="S33">Determina el número de tarjetas mostradas cuando</sys:String>
+    <sys:String x:Key="S34">Registro de Tarjetas</sys:String>
+    <sys:String x:Key="S35">está activado, así como el número máximo de frases mostradas en la Ventana Overlay.</sys:String>
+    <sys:String x:Key="S36">Los contextos deben ser</sys:String>
+    <sys:String x:Key="S37">mayores o iguales a</sys:String>
+    <sys:String x:Key="S38">Frases a Mostrar</sys:String>
+    <sys:String x:Key="S39">. Si no se cumple, el programa los ajustará automáticamente.</sys:String>
+
+    <sys:String x:Key="S40">Frases a Mostrar</sys:String>
+
+    <sys:String x:Key="S41">Traducir en contexto.</sys:String>
+    <sys:String x:Key="S42">Puede mejorar la precisión de la traducción, pero consumirá más tokens.</sys:String>
+
+    <sys:String x:Key="S43">Idioma de la Interfaz</sys:String>
+    <sys:String x:Key="S44">Selecciona el idioma usado por la interfaz de la aplicación.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Anterior</sys:String>
+    <sys:String x:Key="H1">Página Siguiente</sys:String>
+    <sys:String x:Key="H2">Buscar</sys:String>
+    <sys:String x:Key="H3">Exportar</sys:String>
+    <sys:String x:Key="H4">Eliminar Todo</sys:String>
+    <sys:String x:Key="H5">Actualizar</sys:String>
+    <sys:String x:Key="H6">Hora</sys:String>
+    <sys:String x:Key="H7">Subtítulo</sys:String>
+    <sys:String x:Key="H8">Traducido</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/página</sys:String>
+    <sys:String x:Key="H11">30/página</sys:String>
+    <sys:String x:Key="H12">50/página</sys:String>
+    <sys:String x:Key="H13">100/página</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">¿Deseas eliminar todo el historial?</sys:String>
+    <sys:String x:Key="H21">¡Esta acción no se puede deshacer!</sys:String>
+    <sys:String x:Key="H22">Sí</sys:String>
+    <sys:String x:Key="H23">No</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Todos los archivos (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Guardado Correctamente</sys:String>
+    <sys:String x:Key="H26">Archivo guardado en: {0}</sys:String>
+    <sys:String x:Key="H27">Error al Guardar</sys:String>
+    <sys:String x:Key="H28">Error al guardar el archivo: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Ventana Overlay</sys:String>
+    <sys:String x:Key="O1">Aumentar Tamaño de Fuente</sys:String>
+    <sys:String x:Key="O2">Disminuir Tamaño de Fuente</sys:String>
+    <sys:String x:Key="O3">Aumentar Contorno de Fuente</sys:String>
+    <sys:String x:Key="O4">Disminuir Contorno de Fuente</sys:String>
+    <sys:String x:Key="O5">Fuente Negrita</sys:String>
+    <sys:String x:Key="O6">Color de Fuente</sys:String>
+    <sys:String x:Key="O7">Aumentar Opacidad de Fondo</sys:String>
+    <sys:String x:Key="O8">Disminuir Opacidad de Fondo</sys:String>
+    <sys:String x:Key="O9">Color de Fondo</sys:String>
+    <sys:String x:Key="O10">Mostrar solo subtítulos o traducciones</sys:String>
+    <sys:String x:Key="O11">Cambiar posición subtítulo/traducción</sys:String>
+    <sys:String x:Key="O12">Ignorar Clic</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">¡Agradecemos cualquier tipo de contribución! Puedes enviar sugerencias o reportar errores vía GitHub, o contribuir con código directamente mediante Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Si este programa te resulta útil, ¡considera darnos una estrella!</sys:String>
+    <sys:String x:Key="I2">Repositorio:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Mantenedor:</sys:String>
+    <sys:String x:Key="I5">(Autor) y</sys:String>
+    <sys:String x:Key="I6">Versión:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Comenzando</sys:String>
+    <sys:String x:Key="W1">¡Bienvenido a LiveCaptions Translator!</sys:String>
+
+    <sys:String x:Key="W2">LiveCaptions Translator se basa en Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Antes de ejecutarlo por primera vez, configúralo según los siguientes pasos:&#x0A;</sys:String>
+
+    <sys:String x:Key="W4">&#x0A;1. Abre Windows LiveCaptions y sigue la guía para descargar los archivos necesarios para el reconocimiento de voz en el dispositivo y los paquetes de idioma.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Haz clic en el</sys:String>
+    <sys:String x:Key="W6">⚙️ ícono de engranaje</sys:String>
+    <sys:String x:Key="W7">en Windows LiveCaptions para abrir el menú de configuración y selecciona</sys:String>
+    <sys:String x:Key="W8">"Posición > Superpuesto en Pantalla"</sys:String>
+    <sys:String x:Key="W9">3. Haz clic en el botón</sys:String>
+    <sys:String x:Key="W10">"Ocultar"</sys:String>
+    <sys:String x:Key="W11">ubicado en la página de configuración de LiveCaptions Translator para ocultar Windows LiveCaptions.&#x0A;</sys:String>
+
+    <sys:String x:Key="W12">&#x0A;El programa ha navegado automáticamente a la página de configuración y abierto Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Después de completar la configuración, puedes volver a la página principal y disfrutar de la traducción de audio en tiempo real.&#x0A;</sys:String>
+
+    <sys:String x:Key="W14">&#x0A;Para más detalles, visita nuestra wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+
+    <sys:String x:Key="W16">&#x0A;&#x0A;Consejo:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Para cambiar el </sys:String>
+    <sys:String x:Key="W18">Idioma de Origen</sys:String>
+    <sys:String x:Key="W19">, por favor [Mostrar] LiveCaptions en la página de configuración y hazlo en Windows LiveCaptions.</sys:String>
+
+    <sys:String x:Key="W20">He entendido y configurado completamente.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">Subtítulos</sys:String>
+    <sys:String x:Key="M11">Configuración</sys:String>
+    <sys:String x:Key="M12">Historial</sys:String>
+    <sys:String x:Key="M13">Información</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">Tarjetas de Log de Subtítulos</sys:String>
+    <sys:String x:Key="M21">Pausar Traducción (Solo Log)</sys:String>
+    <sys:String x:Key="M22">Ventana Overlay</sys:String>
+    <sys:String x:Key="M23">Siempre al Frente</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[ERROR] Falló la Verificación de Actualizaciones.</sys:String>
+    <sys:String x:Key="MC1">error</sys:String>
+
+    <sys:String x:Key="MC2">Nueva Versión Disponible</sys:String>
+    <sys:String x:Key="MC3">Se ha detectado una nueva versión: {0}
+Versión actual: {1}
+Por favor visita GitHub para descargar la última versión.</sys:String>
+    <sys:String x:Key="MC4">Actualizar</sys:String>
+    <sys:String x:Key="MC5">Ignorar esta versión</sys:String>
+
+    <sys:String x:Key="MC6">[ERROR] Falló Abrir el Navegador.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[ADVERTENCIA] LiveCaptions se cerró inesperadamente, reiniciando...</sys:String>
+    <sys:String x:Key="T1">[Pausado]</sys:String>
+    <sys:String x:Key="T2">¡Error!</sys:String>
+    <sys:String x:Key="T3">Error al registrar historial: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Haz clic para Copiar</sys:String>
+    <sys:String x:Key="C1">Copiado</sys:String>
+    <sys:String x:Key="C2">Error al Copiar</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/es-mx.xaml
+++ b/src/localization/es-mx.xaml
@@ -3,184 +3,149 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Subtítulos en Vivo</sys:String>
-    <sys:String x:Key="S1">Después de la versión 24H2 de Windows 11, solo puedes cambiar el</sys:String>
-    <sys:String x:Key="S2">Idioma de Origen</sys:String>
-    <sys:String x:Key="S3">en Subtítulos en Vivo.</sys:String>
-    <sys:String x:Key="S4">Nota:</sys:String>
-    <sys:String x:Key="S5">Por favor haz clic</sys:String>
-    <sys:String x:Key="S6">"Ocultar"</sys:String>
-    <sys:String x:Key="S7">para ocultar Subtítulos en Vivo en lugar de cerrarlo directamente.</sys:String>
-
-    <sys:String x:Key="S8">Mostrar</sys:String>
-
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Ocultar</sys:String>
-    <sys:String x:Key="S46">Mostrar</sys:String>
-
-    <sys:String x:Key="S9">Intervalo de API</sys:String>
-    <sys:String x:Key="S10">Determina la frecuencia de las llamadas a la API de traducción. Cuanto menor, más frecuentes serán las llamadas.</sys:String>
-    <sys:String x:Key="S11">La API de traducción se llama una vez después de que el subtítulo cambie</sys:String>
-    <sys:String x:Key="S12">[Intervalo de API]</sys:String>
-    <sys:String x:Key="S13">veces.</sys:String>
-
-    <sys:String x:Key="S14">API de Traducción</sys:String>
-    <sys:String x:Key="S15">Excepto Google y Google2, todas las demás APIs requieren configuración antes de poder usarse.</sys:String>
-
-    <sys:String x:Key="S16">Idioma de Destino</sys:String>
-    <sys:String x:Key="S17">¡El idioma de destino que esperabas no está disponible!</sys:String>
-    <sys:String x:Key="S18">Puedes editar directamente el contenido de este combo para personalizar el idioma; se recomienda seguir la</sys:String>
-    <sys:String x:Key="S19">etiqueta de idioma BCP 47.</sys:String>
-    <sys:String x:Key="S20">Algunas APIs (como DeepL) requieren otra forma de definir el idioma de destino; consulta su documentación oficial para más detalles.</sys:String>
-    <sys:String x:Key="S21">No es necesario considerar esto para los idiomas incluidos, ya que hemos incorporado mapeos de etiquetas. Pero si tu idioma esperado no está en la lista, tenlo en cuenta.</sys:String>
-
-    <sys:String x:Key="S22">Configuración de API</sys:String>
-    <sys:String x:Key="S23">Abrir</sys:String>
-
-    <sys:String x:Key="S24">Mostrar Latencia</sys:String>
-    <sys:String x:Key="S25">Desactivado</sys:String>
-    <sys:String x:Key="S26">Activado</sys:String>
-
-    <sys:String x:Key="S27">Contextos</sys:String>
-    <sys:String x:Key="S28">Contextos:</sys:String>
-    <sys:String x:Key="S29">Determina el número de frases de contexto cuando</sys:String>
-    <sys:String x:Key="S30">Contexto Inteligente</sys:String>
-    <sys:String x:Key="S31">está activado.</sys:String>
-    <sys:String x:Key="S32">Frases en Overlay:</sys:String>
-    <sys:String x:Key="S33">Determina el número de tarjetas mostradas cuando</sys:String>
-    <sys:String x:Key="S34">Registro de Tarjetas</sys:String>
-    <sys:String x:Key="S35">está activado, así como el número máximo de frases mostradas en la Ventana Overlay.</sys:String>
-    <sys:String x:Key="S36">Los contextos deben ser</sys:String>
-    <sys:String x:Key="S37">mayores o iguales a</sys:String>
-    <sys:String x:Key="S38">Frases a Mostrar</sys:String>
-    <sys:String x:Key="S39">. Si no se cumple, el programa los ajustará automáticamente.</sys:String>
-
-    <sys:String x:Key="S40">Frases a Mostrar</sys:String>
-
-    <sys:String x:Key="S41">Traducir en contexto.</sys:String>
-    <sys:String x:Key="S42">Puede mejorar la precisión de la traducción, pero consumirá más tokens.</sys:String>
-
-    <sys:String x:Key="S43">Idioma de la Interfaz</sys:String>
-    <sys:String x:Key="S44">Selecciona el idioma usado por la interfaz de la aplicación.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Subtítulos en Vivo</sys:String>
+    <sys:String x:Key="S1">Después de la versión 24H2 de Windows 11, solo puedes cambiar</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Idioma de Origen</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">en Subtítulos en Vivo.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Nota:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Por favor haz clic</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Ocultar"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">para ocultar Subtítulos en Vivo en lugar de cerrarlo directamente.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Ocultar</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Intervalo de API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Determina la frecuencia de las llamadas a la API de traducción. Valores más bajos llaman más frecuentemente.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">Llamar a la API de traducción una vez después de que los subtítulos cambien</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Intervalo de API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">veces.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">API de Traducción</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Excepto Google y Google2, otras APIs requieren configuración antes de usarse.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Idioma de Destino</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">¿No encuentras el idioma de destino que deseas?</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Puedes editar este texto en el ComboBox para personalizar el idioma. Se recomienda seguir</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">las etiquetas de idioma BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Algunas APIs (por ejemplo, DeepL) requieren una forma diferente de especificar el idioma de destino. Consulta su documentación.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Los idiomas integrados ya están mapeados. Si tu idioma no está en la lista, tenlo en cuenta.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Configuración de API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Abrir</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Mostrar Latencia</sys:String>
+    <sys:String x:Key="Common_Off">Desactivado</sys:String>
+    <sys:String x:Key="Common_On">Activado</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Contextos</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Contextos:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Determina el número de frases de contexto cuando</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Contexto Inteligente</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">está activado.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Frases en Overlay:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Determina el número de tarjetas mostradas cuando</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Registro de Tarjetas</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">está activado, y el número máximo de frases mostradas en la ventana overlay.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Los contextos deben ser</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">mayores o iguales a</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Frases a Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. De lo contrario, la aplicación los ajustará automáticamente.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Frases a Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Traducir con contexto.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Puede mejorar la precisión pero consume más tokens.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Idioma de la Interfaz</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Selecciona el idioma usado en la interfaz de la aplicación.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Los cambios se aplican inmediatamente y se guardan automáticamente.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Anterior</sys:String>
-    <sys:String x:Key="H1">Página Siguiente</sys:String>
-    <sys:String x:Key="H2">Buscar</sys:String>
-    <sys:String x:Key="H3">Exportar</sys:String>
-    <sys:String x:Key="H4">Eliminar Todo</sys:String>
-    <sys:String x:Key="H5">Actualizar</sys:String>
-    <sys:String x:Key="H6">Hora</sys:String>
-    <sys:String x:Key="H7">Subtítulo</sys:String>
-    <sys:String x:Key="H8">Traducido</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/página</sys:String>
-    <sys:String x:Key="H11">30/página</sys:String>
-    <sys:String x:Key="H12">50/página</sys:String>
-    <sys:String x:Key="H13">100/página</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Anterior</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Página Siguiente</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Buscar</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Exportar</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Eliminar Todo</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Actualizar</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Hora</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Subtítulo</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Traducido</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/página</sys:String>
 
     <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">¿Deseas eliminar todo el historial?</sys:String>
-    <sys:String x:Key="H21">¡Esta acción no se puede deshacer!</sys:String>
-    <sys:String x:Key="H22">Sí</sys:String>
-    <sys:String x:Key="H23">No</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Todos los archivos (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Guardado Correctamente</sys:String>
-    <sys:String x:Key="H26">Archivo guardado en: {0}</sys:String>
-    <sys:String x:Key="H27">Error al Guardar</sys:String>
-    <sys:String x:Key="H28">Error al guardar el archivo: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">¿Deseas eliminar todo el historial?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">¡Esta acción no se puede deshacer!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Sí</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">No</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Todos los archivos (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Guardado Correctamente</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Archivo guardado en: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Error al Guardar</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Error al guardar el archivo: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Ventana Overlay</sys:String>
-    <sys:String x:Key="O1">Aumentar Tamaño de Fuente</sys:String>
-    <sys:String x:Key="O2">Disminuir Tamaño de Fuente</sys:String>
-    <sys:String x:Key="O3">Aumentar Contorno de Fuente</sys:String>
-    <sys:String x:Key="O4">Disminuir Contorno de Fuente</sys:String>
-    <sys:String x:Key="O5">Fuente Negrita</sys:String>
-    <sys:String x:Key="O6">Color de Fuente</sys:String>
-    <sys:String x:Key="O7">Aumentar Opacidad de Fondo</sys:String>
-    <sys:String x:Key="O8">Disminuir Opacidad de Fondo</sys:String>
-    <sys:String x:Key="O9">Color de Fondo</sys:String>
-    <sys:String x:Key="O10">Mostrar solo subtítulos o traducciones</sys:String>
-    <sys:String x:Key="O11">Cambiar posición subtítulo/traducción</sys:String>
-    <sys:String x:Key="O12">Ignorar Clic</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Ventana Overlay</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Aumentar Tamaño de Fuente</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Disminuir Tamaño de Fuente</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Aumentar Contorno de Fuente</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Disminuir Contorno de Fuente</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Fuente Negrita</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Color de Fuente</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Aumentar Opacidad de Fondo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Disminuir Opacidad de Fondo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Color de Fondo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Mostrar solo subtítulos o traducciones</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Cambiar posición subtítulo/traducción</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Ignorar Clic</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">¡Agradecemos cualquier tipo de contribución! Puedes enviar sugerencias o reportar errores vía GitHub, o contribuir con código directamente mediante Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Si este programa te resulta útil, ¡considera darnos una estrella!</sys:String>
-    <sys:String x:Key="I2">Repositorio:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Mantenedor:</sys:String>
-    <sys:String x:Key="I5">(Autor) y</sys:String>
-    <sys:String x:Key="I6">Versión:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">¡Agradecemos cualquier tipo de contribución! Puedes sugerir funciones, reportar errores o contribuir con código mediante Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Si este programa te ayuda, ¡considera darle una estrella al proyecto!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repositorio:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Mantenedor:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Autor) y</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Versión:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Comenzando</sys:String>
-    <sys:String x:Key="W1">¡Bienvenido a LiveCaptions Translator!</sys:String>
-
-    <sys:String x:Key="W2">LiveCaptions Translator se basa en Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Antes de ejecutarlo por primera vez, configúralo según los siguientes pasos:&#x0A;</sys:String>
-
-    <sys:String x:Key="W4">&#x0A;1. Abre Windows LiveCaptions y sigue la guía para descargar los archivos necesarios para el reconocimiento de voz en el dispositivo y los paquetes de idioma.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Haz clic en el</sys:String>
-    <sys:String x:Key="W6">⚙️ ícono de engranaje</sys:String>
-    <sys:String x:Key="W7">en Windows LiveCaptions para abrir el menú de configuración y selecciona</sys:String>
-    <sys:String x:Key="W8">"Posición > Superpuesto en Pantalla"</sys:String>
-    <sys:String x:Key="W9">3. Haz clic en el botón</sys:String>
-    <sys:String x:Key="W10">"Ocultar"</sys:String>
-    <sys:String x:Key="W11">ubicado en la página de configuración de LiveCaptions Translator para ocultar Windows LiveCaptions.&#x0A;</sys:String>
-
-    <sys:String x:Key="W12">&#x0A;El programa ha navegado automáticamente a la página de configuración y abierto Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Después de completar la configuración, puedes volver a la página principal y disfrutar de la traducción de audio en tiempo real.&#x0A;</sys:String>
-
-    <sys:String x:Key="W14">&#x0A;Para más detalles, visita nuestra wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-
-    <sys:String x:Key="W16">&#x0A;&#x0A;Consejo:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Para cambiar el </sys:String>
-    <sys:String x:Key="W18">Idioma de Origen</sys:String>
-    <sys:String x:Key="W19">, por favor [Mostrar] LiveCaptions en la página de configuración y hazlo en Windows LiveCaptions.</sys:String>
-
-    <sys:String x:Key="W20">He entendido y configurado completamente.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Comenzar</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">¡Bienvenido a LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator se basa en Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Antes de ejecutarlo por primera vez, completa los siguientes pasos:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Abre Windows Live Captions y sigue la guía para descargar los archivos de reconocimiento de voz y paquetes de idioma.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Haz clic</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ engranaje</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">para abrir Configuración y selecciona</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Posición > Superpuesto en Pantalla"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Haz clic</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Ocultar"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">en la página de configuración de LiveCaptions Translator para ocultar Windows Live Captions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;La aplicación ha navegado automáticamente a la página de configuración y abierto Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Después de la configuración, vuelve a la página principal y disfruta de la traducción de audio en tiempo real.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Para más detalles, consulta la Wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Consejo:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Si deseas cambiar</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">el idioma de origen</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, primero haz clic en [Mostrar] Live Captions y luego cámbialo en Windows Live Captions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">He entendido y completado la configuración.</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Tarjetas de log de subtítulos</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pausar traducción (solo log)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Ventana Overlay</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Siempre al frente</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[ERROR] Falló la verificación de actualizaciones.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">error</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Nueva versión encontrada</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Nueva versión detectada: {0} Versión actual: {1} Por favor ve a GitHub para descargar la última versión.</sys:String>
 
-    <!-- Navigation menu -->
-    <sys:String x:Key="M10">Subtítulos</sys:String>
-    <sys:String x:Key="M11">Configuración</sys:String>
-    <sys:String x:Key="M12">Historial</sys:String>
-    <sys:String x:Key="M13">Información</sys:String>
-
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">Tarjetas de Log de Subtítulos</sys:String>
-    <sys:String x:Key="M21">Pausar Traducción (Solo Log)</sys:String>
-    <sys:String x:Key="M22">Ventana Overlay</sys:String>
-    <sys:String x:Key="M23">Siempre al Frente</sys:String>
-
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[ERROR] Falló la Verificación de Actualizaciones.</sys:String>
-    <sys:String x:Key="MC1">error</sys:String>
-
-    <sys:String x:Key="MC2">Nueva Versión Disponible</sys:String>
-    <sys:String x:Key="MC3">Se ha detectado una nueva versión: {0}
-Versión actual: {1}
-Por favor visita GitHub para descargar la última versión.</sys:String>
-    <sys:String x:Key="MC4">Actualizar</sys:String>
-    <sys:String x:Key="MC5">Ignorar esta versión</sys:String>
-
-    <sys:String x:Key="MC6">[ERROR] Falló Abrir el Navegador.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[ADVERTENCIA] LiveCaptions se cerró inesperadamente, reiniciando...</sys:String>
-    <sys:String x:Key="T1">[Pausado]</sys:String>
-    <sys:String x:Key="T2">¡Error!</sys:String>
-    <sys:String x:Key="T3">Error al registrar historial: {0}</sys:String>
+    <!-- Translator strings -->
+    <sys:String x:Key="Translator_Status_Restarting">[ADVERTENCIA] Live Captions se cerró inesperadamente, reiniciando…</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Pausado]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">¡Error!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Error al registrar historial: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Haz clic para Copiar</sys:String>
-    <sys:String x:Key="C1">Copiado</sys:String>
-    <sys:String x:Key="C2">Error al Copiar</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Haz clic para copiar</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Copiado</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Error al copiar</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/fr-fr.xaml
+++ b/src/localization/fr-fr.xaml
@@ -3,184 +3,165 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Sous-titres en Direct</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Sous-titres en Direct</sys:String>
     <sys:String x:Key="S1">Après la version 24H2 de Windows 11, vous pouvez uniquement modifier la</sys:String>
-    <sys:String x:Key="S2">Langue Source</sys:String>
-    <sys:String x:Key="S3">dans les Sous-titres en Direct.</sys:String>
-    <sys:String x:Key="S4">Remarque :</sys:String>
-    <sys:String x:Key="S5">Veuillez cliquer</sys:String>
-    <sys:String x:Key="S6">"Masquer"</sys:String>
-    <sys:String x:Key="S7">pour masquer les Sous-titres en Direct au lieu de les fermer directement.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Langue Source</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">dans les Sous-titres en Direct.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Remarque :</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Veuillez cliquer</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Masquer"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">pour masquer les Sous-titres en Direct au lieu de les fermer directement.</sys:String>
 
-    <sys:String x:Key="S8">Afficher</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Afficher</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Masquer</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Masquer</sys:String>
-    <sys:String x:Key="S46">Afficher</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Intervalle API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Détermine la fréquence des appels à l'API de traduction. Plus la valeur est petite, plus les appels sont fréquents.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">L'API de traduction est appelée une fois après chaque changement de sous-titre</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Intervalle API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">fois.</sys:String>
 
-    <sys:String x:Key="S9">Intervalle API</sys:String>
-    <sys:String x:Key="S10">Détermine la fréquence des appels à l'API de traduction. Plus la valeur est petite, plus les appels sont fréquents.</sys:String>
-    <sys:String x:Key="S11">L'API de traduction est appelée une fois après chaque changement de sous-titre</sys:String>
-    <sys:String x:Key="S12">[Intervalle API]</sys:String>
-    <sys:String x:Key="S13">fois.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">API de Traduction</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Sauf pour Google et Google2, toutes les autres APIs nécessitent une configuration avant utilisation.</sys:String>
 
-    <sys:String x:Key="S14">API de Traduction</sys:String>
-    <sys:String x:Key="S15">Sauf pour Google et Google2, toutes les autres APIs nécessitent une configuration avant utilisation.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Langue Cible</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">La langue cible souhaitée n'est pas disponible !</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Vous pouvez modifier directement le contenu de cette liste déroulante pour personnaliser la langue, il est recommandé de suivre la</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">balise de langue BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Certaines APIs (comme DeepL) nécessitent une autre méthode pour définir la langue cible, consultez leur documentation officielle pour plus de détails.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Pas besoin de se préoccuper de cela pour les langues incluses, car nous avons intégré les correspondances de balises. Mais si votre langue attendue n'est pas dans la liste, gardez cela à l'esprit.</sys:String>
 
-    <sys:String x:Key="S16">Langue Cible</sys:String>
-    <sys:String x:Key="S17">La langue cible souhaitée n'est pas disponible !</sys:String>
-    <sys:String x:Key="S18">Vous pouvez modifier directement le contenu de cette liste déroulante pour personnaliser la langue, il est recommandé de suivre la</sys:String>
-    <sys:String x:Key="S19">balise de langue BCP 47.</sys:String>
-    <sys:String x:Key="S20">Certaines APIs (comme DeepL) nécessitent une autre méthode pour définir la langue cible, consultez leur documentation officielle pour plus de détails.</sys:String>
-    <sys:String x:Key="S21">Pas besoin de se préoccuper de cela pour les langues incluses, car nous avons intégré les correspondances de balises. Mais si votre langue attendue n'est pas dans la liste, gardez cela à l'esprit.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Paramètres API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Ouvrir</sys:String>
 
-    <sys:String x:Key="S22">Paramètres API</sys:String>
-    <sys:String x:Key="S23">Ouvrir</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Afficher la Latence</sys:String>
+    <sys:String x:Key="Common_Off">Désactivé</sys:String>
+    <sys:String x:Key="Common_On">Activé</sys:String>
 
-    <sys:String x:Key="S24">Afficher la Latence</sys:String>
-    <sys:String x:Key="S25">Désactivé</sys:String>
-    <sys:String x:Key="S26">Activé</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Contextes</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Contextes :</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Détermine le nombre de phrases contextuelles lorsque</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Contexte Intelligent</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">est activé.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Phrases en Overlay :</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Détermine le nombre de cartes affichées lorsque</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Cartes de Journal</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">est activé, ainsi que le nombre maximum de phrases affichées dans la fenêtre Overlay.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Les contextes doivent être</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">supérieurs ou égaux à</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Phrases à Afficher</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Sinon, le programme les ajustera automatiquement.</sys:String>
 
-    <sys:String x:Key="S27">Contextes</sys:String>
-    <sys:String x:Key="S28">Contextes :</sys:String>
-    <sys:String x:Key="S29">Détermine le nombre de phrases contextuelles lorsque</sys:String>
-    <sys:String x:Key="S30">Contexte Intelligent</sys:String>
-    <sys:String x:Key="S31">est activé.</sys:String>
-    <sys:String x:Key="S32">Phrases en Overlay :</sys:String>
-    <sys:String x:Key="S33">Détermine le nombre de cartes affichées lorsque</sys:String>
-    <sys:String x:Key="S34">Cartes de Journal</sys:String>
-    <sys:String x:Key="S35">est activé, ainsi que le nombre maximum de phrases affichées dans la fenêtre Overlay.</sys:String>
-    <sys:String x:Key="S36">Les contextes doivent être</sys:String>
-    <sys:String x:Key="S37">supérieurs ou égaux à</sys:String>
-    <sys:String x:Key="S38">Phrases à Afficher</sys:String>
-    <sys:String x:Key="S39">. Sinon, le programme les ajustera automatiquement.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Phrases à Afficher</sys:String>
 
-    <sys:String x:Key="S40">Phrases à Afficher</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Traduire dans le contexte.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Peut améliorer la précision de la traduction, mais consommera plus de jetons.</sys:String>
 
-    <sys:String x:Key="S41">Traduire dans le contexte.</sys:String>
-    <sys:String x:Key="S42">Peut améliorer la précision de la traduction, mais consommera plus de jetons.</sys:String>
-
-    <sys:String x:Key="S43">Langue de l'IU</sys:String>
-    <sys:String x:Key="S44">Sélectionnez la langue utilisée par l'interface de l'application.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Langue de l'IU</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Sélectionnez la langue utilisée par l'interface de l'application.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Les modifications sont appliquées immédiatement et sauvegardées automatiquement.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Précédent</sys:String>
-    <sys:String x:Key="H1">Page Suivante</sys:String>
-    <sys:String x:Key="H2">Rechercher</sys:String>
-    <sys:String x:Key="H3">Exporter</sys:String>
-    <sys:String x:Key="H4">Tout Supprimer</sys:String>
-    <sys:String x:Key="H5">Actualiser</sys:String>
-    <sys:String x:Key="H6">Heure</sys:String>
-    <sys:String x:Key="H7">Sous-titre</sys:String>
-    <sys:String x:Key="H8">Traduit</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/page</sys:String>
-    <sys:String x:Key="H11">30/page</sys:String>
-    <sys:String x:Key="H12">50/page</sys:String>
-    <sys:String x:Key="H13">100/page</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Précédent</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Page Suivante</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Rechercher</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Exporter</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Tout Supprimer</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Actualiser</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Heure</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Sous-titre</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Traduit</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/page</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/page</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/page</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/page</sys:String>
 
     <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">Voulez-vous supprimer tout l'historique ?</sys:String>
-    <sys:String x:Key="H21">Cette opération est irréversible !</sys:String>
-    <sys:String x:Key="H22">Oui</sys:String>
-    <sys:String x:Key="H23">Non</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Tous les fichiers (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Enregistrement Réussi</sys:String>
-    <sys:String x:Key="H26">Fichier enregistré dans : {0}</sys:String>
-    <sys:String x:Key="H27">Échec de l'enregistrement</sys:String>
-    <sys:String x:Key="H28">Échec de l'enregistrement du fichier : {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Voulez-vous supprimer tout l'historique ?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Cette opération est irréversible !</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Oui</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Non</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Tous les fichiers (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Enregistrement Réussi</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Fichier enregistré dans : {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Échec de l'enregistrement</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Échec de l'enregistrement du fichier : {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Fenêtre Overlay</sys:String>
-    <sys:String x:Key="O1">Augmenter la Taille de Police</sys:String>
-    <sys:String x:Key="O2">Diminuer la Taille de Police</sys:String>
-    <sys:String x:Key="O3">Augmenter le Contour de Police</sys:String>
-    <sys:String x:Key="O4">Diminuer le Contour de Police</sys:String>
-    <sys:String x:Key="O5">Gras</sys:String>
-    <sys:String x:Key="O6">Couleur de Police</sys:String>
-    <sys:String x:Key="O7">Augmenter l'Opacité du Fond</sys:String>
-    <sys:String x:Key="O8">Diminuer l'Opacité du Fond</sys:String>
-    <sys:String x:Key="O9">Couleur de Fond</sys:String>
-    <sys:String x:Key="O10">Afficher uniquement les sous-titres ou traductions</sys:String>
-    <sys:String x:Key="O11">Changer la position sous-titre/traduction</sys:String>
-    <sys:String x:Key="O12">Ignorer Clic</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Fenêtre Overlay</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Augmenter la Taille de Police</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Diminuer la Taille de Police</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Augmenter le Contour de Police</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Diminuer le Contour de Police</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Gras</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Couleur de Police</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Augmenter l'Opacité du Fond</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Diminuer l'Opacité du Fond</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Couleur de Fond</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Afficher uniquement les sous-titres ou traductions</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Changer la position sous-titre/traduction</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Ignorer Clic</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Nous accueillons toute forme de contribution ! Vous pouvez proposer des suggestions ou signaler des bugs via GitHub, ou contribuer directement au code via des Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Si ce programme vous est utile, veuillez envisager de nous donner une étoile !</sys:String>
-    <sys:String x:Key="I2">Dépôt :</sys:String>
-    <sys:String x:Key="I3">Wiki :</sys:String>
-    <sys:String x:Key="I4">Mainteneur :</sys:String>
-    <sys:String x:Key="I5">(Auteur) et</sys:String>
-    <sys:String x:Key="I6">Version :</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Nous accueillons toute forme de contribution ! Vous pouvez proposer des suggestions ou signaler des bugs via GitHub, ou contribuer directement au code via des Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Si ce programme vous est utile, veuillez envisager de nous donner une étoile !</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Dépôt :</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki :</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Mainteneur :</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Auteur) et</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Version :</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Premiers Pas</sys:String>
-    <sys:String x:Key="W1">Bienvenue dans LiveCaptions Translator !</sys:String>
-
-    <sys:String x:Key="W2">LiveCaptions Translator est basé sur Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Avant de lancer pour la première fois, vous devez le configurer selon les étapes suivantes :&#x0A;</sys:String>
-
-    <sys:String x:Key="W4">&#x0A;1. Ouvrez Windows LiveCaptions et suivez le guide pour télécharger les fichiers nécessaires à la reconnaissance vocale locale et les packs de langues.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Cliquez sur l</sys:String>
-    <sys:String x:Key="W6">⚙️ icône d'engrenage</sys:String>
-    <sys:String x:Key="W7">dans Windows LiveCaptions pour ouvrir le menu des paramètres, puis sélectionnez</sys:String>
-    <sys:String x:Key="W8">"Position > Superposé à l'écran"</sys:String>
-    <sys:String x:Key="W9">3. Cliquez sur le bouton</sys:String>
-    <sys:String x:Key="W10">"Masquer"</sys:String>
-    <sys:String x:Key="W11">dans la page des paramètres de LiveCaptions Translator pour masquer Windows LiveCaptions.&#x0A;</sys:String>
-
-    <sys:String x:Key="W12">&#x0A;Le programme a automatiquement ouvert la page de paramètres et Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Une fois la configuration terminée, vous pouvez revenir à la page principale et profiter de la traduction audio en temps réel.&#x0A;</sys:String>
-
-    <sys:String x:Key="W14">&#x0A;Pour plus de détails, visitez notre wiki : </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-
-    <sys:String x:Key="W16">&#x0A;&#x0A;Conseil :&#x0A;</sys:String>
-    <sys:String x:Key="W17">Pour changer la </sys:String>
-    <sys:String x:Key="W18">Langue Source</sys:String>
-    <sys:String x:Key="W19">, veuillez [Afficher] LiveCaptions dans la page de paramètres et le faire dans Windows LiveCaptions.</sys:String>
-
-    <sys:String x:Key="W20">J'ai entièrement compris et configuré.</sys:String>
-
-    <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Bien démarrer</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Bienvenue dans LiveCaptions Translator !</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator est basé sur Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Avant de lancer pour la première fois, vous devez le configurer selon les étapes suivantes :&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Ouvrez Windows LiveCaptions et suivez le guide pour télécharger les fichiers nécessaires à la reconnaissance vocale locale et les packs de langues.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Cliquez sur l</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ icône d'engrenage</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">dans Windows LiveCaptions pour ouvrir le menu des paramètres, puis sélectionnez</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Position > Superposé à l'écran"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Cliquez sur le bouton</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Masquer"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">dans la page des paramètres de LiveCaptions Translator pour masquer Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Le programme a automatiquement ouvert la page de paramètres et Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Une fois la configuration terminée, vous pouvez revenir à la page principale et profiter de la traduction audio en temps réel.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Pour plus de détails, visitez notre wiki : </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Conseil :&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Pour changer la </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Langue Source</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, veuillez [Afficher] LiveCaptions dans la page de paramètres et le faire dans Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">J'ai entièrement compris et configuré.</sys:String>
 
     <!-- Navigation menu -->
-    <sys:String x:Key="M10">Sous-titres</sys:String>
-    <sys:String x:Key="M11">Paramètres</sys:String>
-    <sys:String x:Key="M12">Historique</sys:String>
-    <sys:String x:Key="M13">Infos</sys:String>
+    <sys:String x:Key="Navigation_Captions">Sous-titres</sys:String>
+    <sys:String x:Key="Navigation_Settings">Paramètres</sys:String>
+    <sys:String x:Key="Navigation_History">Historique</sys:String>
+    <sys:String x:Key="Navigation_Info">Infos</sys:String>
 
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">Cartes de Journal des Sous-titres</sys:String>
-    <sys:String x:Key="M21">Pause Traduction (Journal seulement)</sys:String>
-    <sys:String x:Key="M22">Fenêtre Overlay</sys:String>
-    <sys:String x:Key="M23">Toujours au Premier Plan</sys:String>
+    <!-- MainWindow strings -->
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Cartes de Journal des Sous-titres</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pause Traduction (Journal seulement)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Fenêtre Overlay</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Toujours au Premier Plan</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[ERREUR] Échec de la Vérification de Mise à Jour.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">erreur</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Nouvelle Version Disponible</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Une nouvelle version a été détectée : {0} Version actuelle : {1} Veuillez visiter GitHub pour télécharger la dernière version.</sys:String>
 
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[ERREUR] Échec de la Vérification de Mise à Jour.</sys:String>
-    <sys:String x:Key="MC1">erreur</sys:String>
-
-    <sys:String x:Key="MC2">Nouvelle Version Disponible</sys:String>
-    <sys:String x:Key="MC3">Une nouvelle version a été détectée : {0}
-Version actuelle : {1}
-Veuillez visiter GitHub pour télécharger la dernière version.</sys:String>
-    <sys:String x:Key="MC4">Mettre à Jour</sys:String>
-    <sys:String x:Key="MC5">Ignorer cette version</sys:String>
-
-    <sys:String x:Key="MC6">[ERREUR] Échec d'ouverture du navigateur.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[ATTENTION] LiveCaptions s'est fermé de manière inattendue, redémarrage...</sys:String>
-    <sys:String x:Key="T1">[En Pause]</sys:String>
-    <sys:String x:Key="T2">Erreur !</sys:String>
-    <sys:String x:Key="T3">Échec de l'enregistrement de l'historique : {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[ATTENTION] LiveCaptions s'est fermé de manière inattendue, redémarrage...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[En Pause]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Erreur !</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Échec de l'enregistrement de l'historique : {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Cliquer pour Copier</sys:String>
-    <sys:String x:Key="C1">Copié</sys:String>
-    <sys:String x:Key="C2">Échec de la Copie</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Cliquer pour Copier</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Copié</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Échec de la Copie</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/fr-fr.xaml
+++ b/src/localization/fr-fr.xaml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Sous-titres en Direct</sys:String>
+    <sys:String x:Key="S1">Après la version 24H2 de Windows 11, vous pouvez uniquement modifier la</sys:String>
+    <sys:String x:Key="S2">Langue Source</sys:String>
+    <sys:String x:Key="S3">dans les Sous-titres en Direct.</sys:String>
+    <sys:String x:Key="S4">Remarque :</sys:String>
+    <sys:String x:Key="S5">Veuillez cliquer</sys:String>
+    <sys:String x:Key="S6">"Masquer"</sys:String>
+    <sys:String x:Key="S7">pour masquer les Sous-titres en Direct au lieu de les fermer directement.</sys:String>
+
+    <sys:String x:Key="S8">Afficher</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Masquer</sys:String>
+    <sys:String x:Key="S46">Afficher</sys:String>
+
+    <sys:String x:Key="S9">Intervalle API</sys:String>
+    <sys:String x:Key="S10">Détermine la fréquence des appels à l'API de traduction. Plus la valeur est petite, plus les appels sont fréquents.</sys:String>
+    <sys:String x:Key="S11">L'API de traduction est appelée une fois après chaque changement de sous-titre</sys:String>
+    <sys:String x:Key="S12">[Intervalle API]</sys:String>
+    <sys:String x:Key="S13">fois.</sys:String>
+
+    <sys:String x:Key="S14">API de Traduction</sys:String>
+    <sys:String x:Key="S15">Sauf pour Google et Google2, toutes les autres APIs nécessitent une configuration avant utilisation.</sys:String>
+
+    <sys:String x:Key="S16">Langue Cible</sys:String>
+    <sys:String x:Key="S17">La langue cible souhaitée n'est pas disponible !</sys:String>
+    <sys:String x:Key="S18">Vous pouvez modifier directement le contenu de cette liste déroulante pour personnaliser la langue, il est recommandé de suivre la</sys:String>
+    <sys:String x:Key="S19">balise de langue BCP 47.</sys:String>
+    <sys:String x:Key="S20">Certaines APIs (comme DeepL) nécessitent une autre méthode pour définir la langue cible, consultez leur documentation officielle pour plus de détails.</sys:String>
+    <sys:String x:Key="S21">Pas besoin de se préoccuper de cela pour les langues incluses, car nous avons intégré les correspondances de balises. Mais si votre langue attendue n'est pas dans la liste, gardez cela à l'esprit.</sys:String>
+
+    <sys:String x:Key="S22">Paramètres API</sys:String>
+    <sys:String x:Key="S23">Ouvrir</sys:String>
+
+    <sys:String x:Key="S24">Afficher la Latence</sys:String>
+    <sys:String x:Key="S25">Désactivé</sys:String>
+    <sys:String x:Key="S26">Activé</sys:String>
+
+    <sys:String x:Key="S27">Contextes</sys:String>
+    <sys:String x:Key="S28">Contextes :</sys:String>
+    <sys:String x:Key="S29">Détermine le nombre de phrases contextuelles lorsque</sys:String>
+    <sys:String x:Key="S30">Contexte Intelligent</sys:String>
+    <sys:String x:Key="S31">est activé.</sys:String>
+    <sys:String x:Key="S32">Phrases en Overlay :</sys:String>
+    <sys:String x:Key="S33">Détermine le nombre de cartes affichées lorsque</sys:String>
+    <sys:String x:Key="S34">Cartes de Journal</sys:String>
+    <sys:String x:Key="S35">est activé, ainsi que le nombre maximum de phrases affichées dans la fenêtre Overlay.</sys:String>
+    <sys:String x:Key="S36">Les contextes doivent être</sys:String>
+    <sys:String x:Key="S37">supérieurs ou égaux à</sys:String>
+    <sys:String x:Key="S38">Phrases à Afficher</sys:String>
+    <sys:String x:Key="S39">. Sinon, le programme les ajustera automatiquement.</sys:String>
+
+    <sys:String x:Key="S40">Phrases à Afficher</sys:String>
+
+    <sys:String x:Key="S41">Traduire dans le contexte.</sys:String>
+    <sys:String x:Key="S42">Peut améliorer la précision de la traduction, mais consommera plus de jetons.</sys:String>
+
+    <sys:String x:Key="S43">Langue de l'IU</sys:String>
+    <sys:String x:Key="S44">Sélectionnez la langue utilisée par l'interface de l'application.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Précédent</sys:String>
+    <sys:String x:Key="H1">Page Suivante</sys:String>
+    <sys:String x:Key="H2">Rechercher</sys:String>
+    <sys:String x:Key="H3">Exporter</sys:String>
+    <sys:String x:Key="H4">Tout Supprimer</sys:String>
+    <sys:String x:Key="H5">Actualiser</sys:String>
+    <sys:String x:Key="H6">Heure</sys:String>
+    <sys:String x:Key="H7">Sous-titre</sys:String>
+    <sys:String x:Key="H8">Traduit</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/page</sys:String>
+    <sys:String x:Key="H11">30/page</sys:String>
+    <sys:String x:Key="H12">50/page</sys:String>
+    <sys:String x:Key="H13">100/page</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">Voulez-vous supprimer tout l'historique ?</sys:String>
+    <sys:String x:Key="H21">Cette opération est irréversible !</sys:String>
+    <sys:String x:Key="H22">Oui</sys:String>
+    <sys:String x:Key="H23">Non</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Tous les fichiers (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Enregistrement Réussi</sys:String>
+    <sys:String x:Key="H26">Fichier enregistré dans : {0}</sys:String>
+    <sys:String x:Key="H27">Échec de l'enregistrement</sys:String>
+    <sys:String x:Key="H28">Échec de l'enregistrement du fichier : {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Fenêtre Overlay</sys:String>
+    <sys:String x:Key="O1">Augmenter la Taille de Police</sys:String>
+    <sys:String x:Key="O2">Diminuer la Taille de Police</sys:String>
+    <sys:String x:Key="O3">Augmenter le Contour de Police</sys:String>
+    <sys:String x:Key="O4">Diminuer le Contour de Police</sys:String>
+    <sys:String x:Key="O5">Gras</sys:String>
+    <sys:String x:Key="O6">Couleur de Police</sys:String>
+    <sys:String x:Key="O7">Augmenter l'Opacité du Fond</sys:String>
+    <sys:String x:Key="O8">Diminuer l'Opacité du Fond</sys:String>
+    <sys:String x:Key="O9">Couleur de Fond</sys:String>
+    <sys:String x:Key="O10">Afficher uniquement les sous-titres ou traductions</sys:String>
+    <sys:String x:Key="O11">Changer la position sous-titre/traduction</sys:String>
+    <sys:String x:Key="O12">Ignorer Clic</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Nous accueillons toute forme de contribution ! Vous pouvez proposer des suggestions ou signaler des bugs via GitHub, ou contribuer directement au code via des Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Si ce programme vous est utile, veuillez envisager de nous donner une étoile !</sys:String>
+    <sys:String x:Key="I2">Dépôt :</sys:String>
+    <sys:String x:Key="I3">Wiki :</sys:String>
+    <sys:String x:Key="I4">Mainteneur :</sys:String>
+    <sys:String x:Key="I5">(Auteur) et</sys:String>
+    <sys:String x:Key="I6">Version :</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Premiers Pas</sys:String>
+    <sys:String x:Key="W1">Bienvenue dans LiveCaptions Translator !</sys:String>
+
+    <sys:String x:Key="W2">LiveCaptions Translator est basé sur Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Avant de lancer pour la première fois, vous devez le configurer selon les étapes suivantes :&#x0A;</sys:String>
+
+    <sys:String x:Key="W4">&#x0A;1. Ouvrez Windows LiveCaptions et suivez le guide pour télécharger les fichiers nécessaires à la reconnaissance vocale locale et les packs de langues.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Cliquez sur l</sys:String>
+    <sys:String x:Key="W6">⚙️ icône d'engrenage</sys:String>
+    <sys:String x:Key="W7">dans Windows LiveCaptions pour ouvrir le menu des paramètres, puis sélectionnez</sys:String>
+    <sys:String x:Key="W8">"Position > Superposé à l'écran"</sys:String>
+    <sys:String x:Key="W9">3. Cliquez sur le bouton</sys:String>
+    <sys:String x:Key="W10">"Masquer"</sys:String>
+    <sys:String x:Key="W11">dans la page des paramètres de LiveCaptions Translator pour masquer Windows LiveCaptions.&#x0A;</sys:String>
+
+    <sys:String x:Key="W12">&#x0A;Le programme a automatiquement ouvert la page de paramètres et Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Une fois la configuration terminée, vous pouvez revenir à la page principale et profiter de la traduction audio en temps réel.&#x0A;</sys:String>
+
+    <sys:String x:Key="W14">&#x0A;Pour plus de détails, visitez notre wiki : </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+
+    <sys:String x:Key="W16">&#x0A;&#x0A;Conseil :&#x0A;</sys:String>
+    <sys:String x:Key="W17">Pour changer la </sys:String>
+    <sys:String x:Key="W18">Langue Source</sys:String>
+    <sys:String x:Key="W19">, veuillez [Afficher] LiveCaptions dans la page de paramètres et le faire dans Windows LiveCaptions.</sys:String>
+
+    <sys:String x:Key="W20">J'ai entièrement compris et configuré.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">Sous-titres</sys:String>
+    <sys:String x:Key="M11">Paramètres</sys:String>
+    <sys:String x:Key="M12">Historique</sys:String>
+    <sys:String x:Key="M13">Infos</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">Cartes de Journal des Sous-titres</sys:String>
+    <sys:String x:Key="M21">Pause Traduction (Journal seulement)</sys:String>
+    <sys:String x:Key="M22">Fenêtre Overlay</sys:String>
+    <sys:String x:Key="M23">Toujours au Premier Plan</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[ERREUR] Échec de la Vérification de Mise à Jour.</sys:String>
+    <sys:String x:Key="MC1">erreur</sys:String>
+
+    <sys:String x:Key="MC2">Nouvelle Version Disponible</sys:String>
+    <sys:String x:Key="MC3">Une nouvelle version a été détectée : {0}
+Version actuelle : {1}
+Veuillez visiter GitHub pour télécharger la dernière version.</sys:String>
+    <sys:String x:Key="MC4">Mettre à Jour</sys:String>
+    <sys:String x:Key="MC5">Ignorer cette version</sys:String>
+
+    <sys:String x:Key="MC6">[ERREUR] Échec d'ouverture du navigateur.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[ATTENTION] LiveCaptions s'est fermé de manière inattendue, redémarrage...</sys:String>
+    <sys:String x:Key="T1">[En Pause]</sys:String>
+    <sys:String x:Key="T2">Erreur !</sys:String>
+    <sys:String x:Key="T3">Échec de l'enregistrement de l'historique : {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Cliquer pour Copier</sys:String>
+    <sys:String x:Key="C1">Copié</sys:String>
+    <sys:String x:Key="C2">Échec de la Copie</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/it-it.xaml
+++ b/src/localization/it-it.xaml
@@ -3,168 +3,156 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Sottotitoli Live</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Sottotitoli Live</sys:String>
     <sys:String x:Key="S1">Dopo Windows 11 versione 24H2, è possibile modificare solo</sys:String>
-    <sys:String x:Key="S2">Lingua di origine</sys:String>
-    <sys:String x:Key="S3">nei Sottotitoli Live.</sys:String>
-    <sys:String x:Key="S4">Nota:</sys:String>
-    <sys:String x:Key="S5">Per favore clicca</sys:String>
-    <sys:String x:Key="S6">"Nascondi"</sys:String>
-    <sys:String x:Key="S7">per nascondere i Sottotitoli Live invece di chiuderli direttamente.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Lingua di origine</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">nei Sottotitoli Live.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Nota:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Per favore clicca</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Nascondi"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">per nascondere i Sottotitoli Live invece di chiuderli direttamente.</sys:String>
 
-    <sys:String x:Key="S8">Mostra</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Mostra</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Nascondi</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Nascondi</sys:String>
-    <sys:String x:Key="S46">Mostra</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Intervallo API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Determina la frequenza delle chiamate all'API di traduzione. Più è piccolo, più frequenti sono le chiamate.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">L'API di traduzione viene chiamata una volta dopo che il sottotitolo cambia</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Intervallo API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">volte.</sys:String>
 
-    <sys:String x:Key="S9">Intervallo API</sys:String>
-    <sys:String x:Key="S10">Determina la frequenza delle chiamate all'API di traduzione. Più è piccolo, più frequenti sono le chiamate.</sys:String>
-    <sys:String x:Key="S11">L'API di traduzione viene chiamata una volta dopo che il sottotitolo cambia</sys:String>
-    <sys:String x:Key="S12">[Intervallo API]</sys:String>
-    <sys:String x:Key="S13">volte.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">API di traduzione</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Ad eccezione di Google e Google2, tutte le altre API devono essere configurate prima dell'uso.</sys:String>
 
-    <sys:String x:Key="S14">API di traduzione</sys:String>
-    <sys:String x:Key="S15">Ad eccezione di Google e Google2, tutte le altre API devono essere configurate prima dell'uso.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Lingua di destinazione</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">La lingua di destinazione desiderata non è disponibile!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Puoi modificare direttamente il contenuto di questa casella combinata per personalizzare la lingua, si consiglia di seguire il</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">tag linguistico BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Alcune API (come DeepL) richiedono un altro metodo per definire la lingua di destinazione, consulta la loro documentazione ufficiale per ulteriori dettagli.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Non è necessario considerare questo per le lingue di destinazione incluse, poiché abbiamo già integrato le mappature dei tag. Se la lingua desiderata non è nell'elenco, tienilo a mente.</sys:String>
 
-    <sys:String x:Key="S16">Lingua di destinazione</sys:String>
-    <sys:String x:Key="S17">La lingua di destinazione desiderata non è disponibile!</sys:String>
-    <sys:String x:Key="S18">Puoi modificare direttamente il contenuto di questa casella combinata per personalizzare la lingua, si consiglia di seguire il</sys:String>
-    <sys:String x:Key="S19">tag linguistico BCP 47.</sys:String>
-    <sys:String x:Key="S20">Alcune API (come DeepL) richiedono un altro metodo per definire la lingua di destinazione, consulta la loro documentazione ufficiale per ulteriori dettagli.</sys:String>
-    <sys:String x:Key="S21">Non è necessario considerare questo per le lingue di destinazione incluse, poiché abbiamo già integrato le mappature dei tag. Se la lingua desiderata non è nell'elenco, tienilo a mente.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Impostazioni API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Apri</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Mostra latenza</sys:String>
+    <sys:String x:Key="Common_Off">Disattivato</sys:String>
+    <sys:String x:Key="Common_On">Attivato</sys:String>
 
-    <sys:String x:Key="S22">Impostazioni API</sys:String>
-    <sys:String x:Key="S23">Apri</sys:String>
-    <sys:String x:Key="S24">Mostra latenza</sys:String>
-    <sys:String x:Key="S25">Disattivato</sys:String>
-    <sys:String x:Key="S26">Attivato</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Contesti</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Contesti:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Determina il numero di frasi contestuali quando</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Consapevolezza del contesto</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">è attivata.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Frasi sovrapposte:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Determina il numero di schede visualizzate quando</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Schede di registro</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">è attivato, così come il numero massimo di frasi visualizzate nella finestra Overlay.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">I contesti devono essere</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">maggiori o uguali a</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Frasi visualizzate</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Se non viene rispettato, il programma li regolerà automaticamente.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Frasi visualizzate</sys:String>
 
-    <sys:String x:Key="S27">Contesti</sys:String>
-    <sys:String x:Key="S28">Contesti:</sys:String>
-    <sys:String x:Key="S29">Determina il numero di frasi contestuali quando</sys:String>
-    <sys:String x:Key="S30">Consapevolezza del contesto</sys:String>
-    <sys:String x:Key="S31">è attivata.</sys:String>
-    <sys:String x:Key="S32">Frasi sovrapposte:</sys:String>
-    <sys:String x:Key="S33">Determina il numero di schede visualizzate quando</sys:String>
-    <sys:String x:Key="S34">Schede di registro</sys:String>
-    <sys:String x:Key="S35">è attivato, così come il numero massimo di frasi visualizzate nella finestra Overlay.</sys:String>
-    <sys:String x:Key="S36">I contesti devono essere</sys:String>
-    <sys:String x:Key="S37">maggiori o uguali a</sys:String>
-    <sys:String x:Key="S38">Frasi visualizzate</sys:String>
-    <sys:String x:Key="S39">. Se non viene rispettato, il programma li regolerà automaticamente.</sys:String>
-    <sys:String x:Key="S40">Frasi visualizzate</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Traduci nel contesto.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Può migliorare la precisione della traduzione, ma consumerà più token.</sys:String>
 
-    <sys:String x:Key="S41">Traduci nel contesto.</sys:String>
-    <sys:String x:Key="S42">Può migliorare la precisione della traduzione, ma consumerà più token.</sys:String>
-
-    <sys:String x:Key="S43">Lingua UI</sys:String>
-    <sys:String x:Key="S44">Seleziona la lingua utilizzata dall'interfaccia dell'applicazione.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Lingua UI</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Seleziona la lingua utilizzata dall'interfaccia dell'applicazione.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Le modifiche hanno effetto immediato e sono salvate automaticamente.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Precedente</sys:String>
-    <sys:String x:Key="H1">Pagina successiva</sys:String>
-    <sys:String x:Key="H2">Cerca</sys:String>
-    <sys:String x:Key="H3">Esporta</sys:String>
-    <sys:String x:Key="H4">Elimina tutto</sys:String>
-    <sys:String x:Key="H5">Aggiorna</sys:String>
-    <sys:String x:Key="H6">Ora</sys:String>
-    <sys:String x:Key="H7">Sottotitolo</sys:String>
-    <sys:String x:Key="H8">Tradotto</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/pagina</sys:String>
-    <sys:String x:Key="H11">30/pagina</sys:String>
-    <sys:String x:Key="H12">50/pagina</sys:String>
-    <sys:String x:Key="H13">100/pagina</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Precedente</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Pagina successiva</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Cerca</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Esporta</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Elimina tutto</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Aggiorna</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Ora</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Sottotitolo</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Tradotto</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/pagina</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/pagina</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/pagina</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/pagina</sys:String>
 
-    <sys:String x:Key="H20">Vuoi davvero eliminare tutta la cronologia?</sys:String>
-    <sys:String x:Key="H21">Questa operazione non può essere annullata!</sys:String>
-    <sys:String x:Key="H22">Sì</sys:String>
-    <sys:String x:Key="H23">No</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Tutti i file (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Salvato con successo</sys:String>
-    <sys:String x:Key="H26">File salvato in: {0}</sys:String>
-    <sys:String x:Key="H27">Salvataggio fallito</sys:String>
-    <sys:String x:Key="H28">Salvataggio file fallito: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Vuoi davvero eliminare tutta la cronologia?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Questa operazione non può essere annullata!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Sì</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">No</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Tutti i file (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Salvato con successo</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">File salvato in: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Salvataggio fallito</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Salvataggio file fallito: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Finestra Overlay</sys:String>
-    <sys:String x:Key="O1">Aumenta dimensione carattere</sys:String>
-    <sys:String x:Key="O2">Riduci dimensione carattere</sys:String>
-    <sys:String x:Key="O3">Aumenta contorno carattere</sys:String>
-    <sys:String x:Key="O4">Riduci contorno carattere</sys:String>
-    <sys:String x:Key="O5">Grassetto</sys:String>
-    <sys:String x:Key="O6">Colore carattere</sys:String>
-    <sys:String x:Key="O7">Aumenta opacità sfondo</sys:String>
-    <sys:String x:Key="O8">Diminuisci opacità sfondo</sys:String>
-    <sys:String x:Key="O9">Colore sfondo</sys:String>
-    <sys:String x:Key="O10">Mostra solo sottotitoli o traduzioni</sys:String>
-    <sys:String x:Key="O11">Cambia posizione sottotitolo/traduzione</sys:String>
-    <sys:String x:Key="O12">Clic tramite</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Finestra Overlay</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Aumenta dimensione carattere</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Riduci dimensione carattere</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Aumenta contorno carattere</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Riduci contorno carattere</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Grassetto</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Colore carattere</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Aumenta opacità sfondo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Diminuisci opacità sfondo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Colore sfondo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Mostra solo sottotitoli o traduzioni</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Cambia posizione sottotitolo/traduzione</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Clic tramite</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Accogliamo qualsiasi forma di contributo! Puoi fornire suggerimenti o segnalare bug tramite GitHub Issues, oppure contribuire direttamente con codice tramite Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Se questo programma ti è utile, considera di lasciarci una stella!</sys:String>
-    <sys:String x:Key="I2">Repository:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Manutentore:</sys:String>
-    <sys:String x:Key="I5">(Autore) e</sys:String>
-    <sys:String x:Key="I6">Versione:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Accogliamo qualsiasi forma di contributo! Puoi fornire suggerimenti o segnalare bug tramite GitHub Issues, oppure contribuire direttamente con codice tramite Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Se questo programma ti è utile, considera di lasciarci una stella!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repository:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Manutentore:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Autore) e</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Versione:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Inizio</sys:String>
-    <sys:String x:Key="W1">Benvenuto in LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator si basa su Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Prima della prima esecuzione, è necessario configurarlo secondo i seguenti passaggi:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Apri Windows LiveCaptions e segui la guida per scaricare i file necessari per il riconoscimento vocale locale e i pacchetti lingua.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Clicca sull'icona</sys:String>
-    <sys:String x:Key="W6">⚙️ ingranaggio</sys:String>
-    <sys:String x:Key="W7">in Windows LiveCaptions per aprire il menu impostazioni e seleziona</sys:String>
-    <sys:String x:Key="W8">"Posizione &gt; Sovrapposta sullo schermo"</sys:String>
-    <sys:String x:Key="W9">3. Clicca il pulsante</sys:String>
-    <sys:String x:Key="W10">"Nascondi"</sys:String>
-    <sys:String x:Key="W11">nella pagina delle impostazioni di LiveCaptions Translator per nascondere Windows LiveCaptions.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Il programma ha automaticamente aperto la pagina delle impostazioni e avviato Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Dopo aver completato la configurazione, puoi tornare alla pagina principale e goderti la traduzione audio in tempo reale.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;Per maggiori dettagli, visita il nostro wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Suggerimento:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Per cambiare la </sys:String>
-    <sys:String x:Key="W18">Lingua di origine</sys:String>
-    <sys:String x:Key="W19">, mostra [Mostra] LiveCaptions nella pagina delle impostazioni e modificala in Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">Ho compreso e configurato tutto.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Per iniziare</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Benvenuto in LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator si basa su Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Prima della prima esecuzione, è necessario configurarlo secondo i seguenti passaggi:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Apri Windows LiveCaptions e segui la guida per scaricare i file necessari per il riconoscimento vocale locale e i pacchetti lingua.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Clicca sull'icona</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ ingranaggio</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">in Windows LiveCaptions per aprire il menu impostazioni e seleziona</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Posizione &gt; Sovrapposta sullo schermo"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Clicca il pulsante</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Nascondi"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">nella pagina delle impostazioni di LiveCaptions Translator per nascondere Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Il programma ha automaticamente aperto la pagina delle impostazioni e avviato Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Dopo aver completato la configurazione, puoi tornare alla pagina principale e goderti la traduzione audio in tempo reale.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Per maggiori dettagli, visita il nostro wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Suggerimento:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Per cambiare la </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Lingua di origine</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, mostra [Mostra] LiveCaptions nella pagina delle impostazioni e modificala in Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Ho compreso e configurato tutto.</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Sottotitolo</sys:String>
-    <sys:String x:Key="M11">Impostazioni</sys:String>
-    <sys:String x:Key="M12">Cronologia</sys:String>
-    <sys:String x:Key="M13">Info</sys:String>
-    <sys:String x:Key="M20">Schede di registro dei sottotitoli</sys:String>
-    <sys:String x:Key="M21">Pausa traduzione (Solo registro)</sys:String>
-    <sys:String x:Key="M22">Finestra Overlay</sys:String>
-    <sys:String x:Key="M23">Sempre in primo piano</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Schede di registro dei sottotitoli</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pausa traduzione (Solo registro)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Finestra Overlay</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Sempre in primo piano</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[ERRORE] Controllo aggiornamenti fallito.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">Errore</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Nuova versione disponibile</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">È stata rilevata una nuova versione: {0} Versione attuale: {1} Visita GitHub per scaricare l'ultima versione.</sys:String>
 
-    <sys:String x:Key="MC0">[ERRORE] Controllo aggiornamenti fallito.</sys:String>
-    <sys:String x:Key="MC1">Errore</sys:String>
-    <sys:String x:Key="MC2">Nuova versione disponibile</sys:String>
-    <sys:String x:Key="MC3">È stata rilevata una nuova versione: {0}
-Versione attuale: {1}
-Visita GitHub per scaricare l'ultima versione.</sys:String>
-    <sys:String x:Key="MC4">Aggiorna</sys:String>
-    <sys:String x:Key="MC5">Ignora questa versione</sys:String>
-    <sys:String x:Key="MC6">[ERRORE] Apertura browser fallita.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[ATTENZIONE] LiveCaptions è stato chiuso inaspettatamente, riavvio...</sys:String>
-    <sys:String x:Key="T1">[In pausa]</sys:String>
-    <sys:String x:Key="T2">Errore!</sys:String>
-    <sys:String x:Key="T3">Registrazione cronologia fallita: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[ATTENZIONE] LiveCaptions è stato chiuso inaspettatamente, riavvio...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[In pausa]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Errore!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Registrazione cronologia fallita: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Clicca per copiare</sys:String>
-    <sys:String x:Key="C1">Copiato</sys:String>
-    <sys:String x:Key="C2">Copia fallita</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Clicca per copiare</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Copiato</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Copia fallita</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/it-it.xaml
+++ b/src/localization/it-it.xaml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Sottotitoli Live</sys:String>
+    <sys:String x:Key="S1">Dopo Windows 11 versione 24H2, è possibile modificare solo</sys:String>
+    <sys:String x:Key="S2">Lingua di origine</sys:String>
+    <sys:String x:Key="S3">nei Sottotitoli Live.</sys:String>
+    <sys:String x:Key="S4">Nota:</sys:String>
+    <sys:String x:Key="S5">Per favore clicca</sys:String>
+    <sys:String x:Key="S6">"Nascondi"</sys:String>
+    <sys:String x:Key="S7">per nascondere i Sottotitoli Live invece di chiuderli direttamente.</sys:String>
+
+    <sys:String x:Key="S8">Mostra</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Nascondi</sys:String>
+    <sys:String x:Key="S46">Mostra</sys:String>
+
+    <sys:String x:Key="S9">Intervallo API</sys:String>
+    <sys:String x:Key="S10">Determina la frequenza delle chiamate all'API di traduzione. Più è piccolo, più frequenti sono le chiamate.</sys:String>
+    <sys:String x:Key="S11">L'API di traduzione viene chiamata una volta dopo che il sottotitolo cambia</sys:String>
+    <sys:String x:Key="S12">[Intervallo API]</sys:String>
+    <sys:String x:Key="S13">volte.</sys:String>
+
+    <sys:String x:Key="S14">API di traduzione</sys:String>
+    <sys:String x:Key="S15">Ad eccezione di Google e Google2, tutte le altre API devono essere configurate prima dell'uso.</sys:String>
+
+    <sys:String x:Key="S16">Lingua di destinazione</sys:String>
+    <sys:String x:Key="S17">La lingua di destinazione desiderata non è disponibile!</sys:String>
+    <sys:String x:Key="S18">Puoi modificare direttamente il contenuto di questa casella combinata per personalizzare la lingua, si consiglia di seguire il</sys:String>
+    <sys:String x:Key="S19">tag linguistico BCP 47.</sys:String>
+    <sys:String x:Key="S20">Alcune API (come DeepL) richiedono un altro metodo per definire la lingua di destinazione, consulta la loro documentazione ufficiale per ulteriori dettagli.</sys:String>
+    <sys:String x:Key="S21">Non è necessario considerare questo per le lingue di destinazione incluse, poiché abbiamo già integrato le mappature dei tag. Se la lingua desiderata non è nell'elenco, tienilo a mente.</sys:String>
+
+    <sys:String x:Key="S22">Impostazioni API</sys:String>
+    <sys:String x:Key="S23">Apri</sys:String>
+    <sys:String x:Key="S24">Mostra latenza</sys:String>
+    <sys:String x:Key="S25">Disattivato</sys:String>
+    <sys:String x:Key="S26">Attivato</sys:String>
+
+    <sys:String x:Key="S27">Contesti</sys:String>
+    <sys:String x:Key="S28">Contesti:</sys:String>
+    <sys:String x:Key="S29">Determina il numero di frasi contestuali quando</sys:String>
+    <sys:String x:Key="S30">Consapevolezza del contesto</sys:String>
+    <sys:String x:Key="S31">è attivata.</sys:String>
+    <sys:String x:Key="S32">Frasi sovrapposte:</sys:String>
+    <sys:String x:Key="S33">Determina il numero di schede visualizzate quando</sys:String>
+    <sys:String x:Key="S34">Schede di registro</sys:String>
+    <sys:String x:Key="S35">è attivato, così come il numero massimo di frasi visualizzate nella finestra Overlay.</sys:String>
+    <sys:String x:Key="S36">I contesti devono essere</sys:String>
+    <sys:String x:Key="S37">maggiori o uguali a</sys:String>
+    <sys:String x:Key="S38">Frasi visualizzate</sys:String>
+    <sys:String x:Key="S39">. Se non viene rispettato, il programma li regolerà automaticamente.</sys:String>
+    <sys:String x:Key="S40">Frasi visualizzate</sys:String>
+
+    <sys:String x:Key="S41">Traduci nel contesto.</sys:String>
+    <sys:String x:Key="S42">Può migliorare la precisione della traduzione, ma consumerà più token.</sys:String>
+
+    <sys:String x:Key="S43">Lingua UI</sys:String>
+    <sys:String x:Key="S44">Seleziona la lingua utilizzata dall'interfaccia dell'applicazione.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Precedente</sys:String>
+    <sys:String x:Key="H1">Pagina successiva</sys:String>
+    <sys:String x:Key="H2">Cerca</sys:String>
+    <sys:String x:Key="H3">Esporta</sys:String>
+    <sys:String x:Key="H4">Elimina tutto</sys:String>
+    <sys:String x:Key="H5">Aggiorna</sys:String>
+    <sys:String x:Key="H6">Ora</sys:String>
+    <sys:String x:Key="H7">Sottotitolo</sys:String>
+    <sys:String x:Key="H8">Tradotto</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/pagina</sys:String>
+    <sys:String x:Key="H11">30/pagina</sys:String>
+    <sys:String x:Key="H12">50/pagina</sys:String>
+    <sys:String x:Key="H13">100/pagina</sys:String>
+
+    <sys:String x:Key="H20">Vuoi davvero eliminare tutta la cronologia?</sys:String>
+    <sys:String x:Key="H21">Questa operazione non può essere annullata!</sys:String>
+    <sys:String x:Key="H22">Sì</sys:String>
+    <sys:String x:Key="H23">No</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Tutti i file (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Salvato con successo</sys:String>
+    <sys:String x:Key="H26">File salvato in: {0}</sys:String>
+    <sys:String x:Key="H27">Salvataggio fallito</sys:String>
+    <sys:String x:Key="H28">Salvataggio file fallito: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Finestra Overlay</sys:String>
+    <sys:String x:Key="O1">Aumenta dimensione carattere</sys:String>
+    <sys:String x:Key="O2">Riduci dimensione carattere</sys:String>
+    <sys:String x:Key="O3">Aumenta contorno carattere</sys:String>
+    <sys:String x:Key="O4">Riduci contorno carattere</sys:String>
+    <sys:String x:Key="O5">Grassetto</sys:String>
+    <sys:String x:Key="O6">Colore carattere</sys:String>
+    <sys:String x:Key="O7">Aumenta opacità sfondo</sys:String>
+    <sys:String x:Key="O8">Diminuisci opacità sfondo</sys:String>
+    <sys:String x:Key="O9">Colore sfondo</sys:String>
+    <sys:String x:Key="O10">Mostra solo sottotitoli o traduzioni</sys:String>
+    <sys:String x:Key="O11">Cambia posizione sottotitolo/traduzione</sys:String>
+    <sys:String x:Key="O12">Clic tramite</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Accogliamo qualsiasi forma di contributo! Puoi fornire suggerimenti o segnalare bug tramite GitHub Issues, oppure contribuire direttamente con codice tramite Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Se questo programma ti è utile, considera di lasciarci una stella!</sys:String>
+    <sys:String x:Key="I2">Repository:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Manutentore:</sys:String>
+    <sys:String x:Key="I5">(Autore) e</sys:String>
+    <sys:String x:Key="I6">Versione:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Inizio</sys:String>
+    <sys:String x:Key="W1">Benvenuto in LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator si basa su Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Prima della prima esecuzione, è necessario configurarlo secondo i seguenti passaggi:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Apri Windows LiveCaptions e segui la guida per scaricare i file necessari per il riconoscimento vocale locale e i pacchetti lingua.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Clicca sull'icona</sys:String>
+    <sys:String x:Key="W6">⚙️ ingranaggio</sys:String>
+    <sys:String x:Key="W7">in Windows LiveCaptions per aprire il menu impostazioni e seleziona</sys:String>
+    <sys:String x:Key="W8">"Posizione &gt; Sovrapposta sullo schermo"</sys:String>
+    <sys:String x:Key="W9">3. Clicca il pulsante</sys:String>
+    <sys:String x:Key="W10">"Nascondi"</sys:String>
+    <sys:String x:Key="W11">nella pagina delle impostazioni di LiveCaptions Translator per nascondere Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Il programma ha automaticamente aperto la pagina delle impostazioni e avviato Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Dopo aver completato la configurazione, puoi tornare alla pagina principale e goderti la traduzione audio in tempo reale.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;Per maggiori dettagli, visita il nostro wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Suggerimento:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Per cambiare la </sys:String>
+    <sys:String x:Key="W18">Lingua di origine</sys:String>
+    <sys:String x:Key="W19">, mostra [Mostra] LiveCaptions nella pagina delle impostazioni e modificala in Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">Ho compreso e configurato tutto.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Sottotitolo</sys:String>
+    <sys:String x:Key="M11">Impostazioni</sys:String>
+    <sys:String x:Key="M12">Cronologia</sys:String>
+    <sys:String x:Key="M13">Info</sys:String>
+    <sys:String x:Key="M20">Schede di registro dei sottotitoli</sys:String>
+    <sys:String x:Key="M21">Pausa traduzione (Solo registro)</sys:String>
+    <sys:String x:Key="M22">Finestra Overlay</sys:String>
+    <sys:String x:Key="M23">Sempre in primo piano</sys:String>
+
+    <sys:String x:Key="MC0">[ERRORE] Controllo aggiornamenti fallito.</sys:String>
+    <sys:String x:Key="MC1">Errore</sys:String>
+    <sys:String x:Key="MC2">Nuova versione disponibile</sys:String>
+    <sys:String x:Key="MC3">È stata rilevata una nuova versione: {0}
+Versione attuale: {1}
+Visita GitHub per scaricare l'ultima versione.</sys:String>
+    <sys:String x:Key="MC4">Aggiorna</sys:String>
+    <sys:String x:Key="MC5">Ignora questa versione</sys:String>
+    <sys:String x:Key="MC6">[ERRORE] Apertura browser fallita.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[ATTENZIONE] LiveCaptions è stato chiuso inaspettatamente, riavvio...</sys:String>
+    <sys:String x:Key="T1">[In pausa]</sys:String>
+    <sys:String x:Key="T2">Errore!</sys:String>
+    <sys:String x:Key="T3">Registrazione cronologia fallita: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Clicca per copiare</sys:String>
+    <sys:String x:Key="C1">Copiato</sys:String>
+    <sys:String x:Key="C2">Copia fallita</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/ja-jp.xaml
+++ b/src/localization/ja-jp.xaml
@@ -3,169 +3,155 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">ライブキャプション</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">ライブキャプション</sys:String>
     <sys:String x:Key="S1">Windows 11 バージョン24H2以降では、変更できるのは</sys:String>
-    <sys:String x:Key="S2">ソース言語</sys:String>
-    <sys:String x:Key="S3">のみです（ライブキャプション内）。</sys:String>
-    <sys:String x:Key="S4">注意：</sys:String>
-    <sys:String x:Key="S5">必ず</sys:String>
-    <sys:String x:Key="S6">「非表示」</sys:String>
-    <sys:String x:Key="S7">をクリックしてライブキャプションを閉じずに非表示にしてください。</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">ソース言語</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">のみです（ライブキャプション内）。</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">注意：</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">必ず</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">「非表示」</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">をクリックしてライブキャプションを閉じずに非表示にしてください。</sys:String>
 
-    <sys:String x:Key="S8">表示</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">表示</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">非表示</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">非表示</sys:String>
-    <sys:String x:Key="S46">表示</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API間隔</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">翻訳API呼び出しの頻度を決定します。小さいほどAPI呼び出しが頻繁になります。</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">キャプションが変更された後、APIは一度呼び出されます</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API間隔]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">回。</sys:String>
 
-    <sys:String x:Key="S9">API間隔</sys:String>
-    <sys:String x:Key="S10">翻訳API呼び出しの頻度を決定します。小さいほどAPI呼び出しが頻繁になります。</sys:String>
-    <sys:String x:Key="S11">キャプションが変更された後、APIは一度呼び出されます</sys:String>
-    <sys:String x:Key="S12">[API間隔]</sys:String>
-    <sys:String x:Key="S13">回。</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">翻訳API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">GoogleとGoogle2を除き、他のAPIは使用前に設定が必要です。</sys:String>
 
-    <sys:String x:Key="S14">翻訳API</sys:String>
-    <sys:String x:Key="S15">GoogleとGoogle2を除き、他のAPIは使用前に設定が必要です。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">ターゲット言語</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">期待するターゲット言語がありません！</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">このコンボボックスの内容を直接編集して言語をカスタマイズできます。BCP 47言語タグに従うことを推奨します。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47言語タグ</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">DeepLなどの一部APIでは別の方法でターゲット言語を指定する必要があります。詳細は公式ドキュメントをご確認ください。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">組み込みのターゲット言語については考慮不要ですが、希望の言語がリストにない場合は注意してください。</sys:String>
 
-    <sys:String x:Key="S16">ターゲット言語</sys:String>
-    <sys:String x:Key="S17">期待するターゲット言語がありません！</sys:String>
-    <sys:String x:Key="S18">このコンボボックスの内容を直接編集して言語をカスタマイズできます。BCP 47言語タグに従うことを推奨します。</sys:String>
-    <sys:String x:Key="S19">BCP 47言語タグ</sys:String>
-    <sys:String x:Key="S20">DeepLなどの一部APIでは別の方法でターゲット言語を指定する必要があります。詳細は公式ドキュメントをご確認ください。</sys:String>
-    <sys:String x:Key="S21">組み込みのターゲット言語については考慮不要ですが、希望の言語がリストにない場合は注意してください。</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API設定</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">開く</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">レイテンシ表示</sys:String>
+    <sys:String x:Key="Common_Off">オフ</sys:String>
+    <sys:String x:Key="Common_On">オン</sys:String>
 
-    <sys:String x:Key="S22">API設定</sys:String>
-    <sys:String x:Key="S23">開く</sys:String>
-    <sys:String x:Key="S24">レイテンシ表示</sys:String>
-    <sys:String x:Key="S25">オフ</sys:String>
-    <sys:String x:Key="S26">オン</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">コンテキスト</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">コンテキスト：</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">「コンテキスト認識」が有効の際に考慮する文の数を決定します。</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">コンテキスト認識</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">が有効です。</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">オーバーレイ表示文：</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">「ログカード」が有効の際に表示されるカードの数、及びオーバーレイウィンドウで表示される最大文数を決定します。</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">ログカード</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">が有効です。</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">コンテキストは</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">以上である必要があります</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">表示文数</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">。満たされない場合、プログラムが自動調整します。</sys:String>
 
-    <sys:String x:Key="S27">コンテキスト</sys:String>
-    <sys:String x:Key="S28">コンテキスト：</sys:String>
-    <sys:String x:Key="S29">「コンテキスト認識」が有効の際に考慮する文の数を決定します。</sys:String>
-    <sys:String x:Key="S30">コンテキスト認識</sys:String>
-    <sys:String x:Key="S31">が有効です。</sys:String>
-    <sys:String x:Key="S32">オーバーレイ表示文：</sys:String>
-    <sys:String x:Key="S33">「ログカード」が有効の際に表示されるカードの数、及びオーバーレイウィンドウで表示される最大文数を決定します。</sys:String>
-    <sys:String x:Key="S34">ログカード</sys:String>
-    <sys:String x:Key="S35">が有効です。</sys:String>
-    <sys:String x:Key="S36">コンテキストは</sys:String>
-    <sys:String x:Key="S37">以上である必要があります</sys:String>
-    <sys:String x:Key="S38">表示文数</sys:String>
-    <sys:String x:Key="S39">。満たされない場合、プログラムが自動調整します。</sys:String>
-    <sys:String x:Key="S40">表示文数</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">表示文数</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">コンテキストで翻訳</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">翻訳精度が向上しますが、より多くのトークンを消費します。</sys:String>
 
-    <sys:String x:Key="S41">コンテキストで翻訳</sys:String>
-    <sys:String x:Key="S42">翻訳精度が向上しますが、より多くのトークンを消費します。</sys:String>
-
-    <sys:String x:Key="S43">UI言語</sys:String>
-    <sys:String x:Key="S44">アプリケーションのUIで使用する言語を選択します。</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI言語</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">アプリケーションのUIで使用する言語を選択します。</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">変更は即座に反映され、自動保存されます。</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">前へ</sys:String>
-    <sys:String x:Key="H1">次のページ</sys:String>
-    <sys:String x:Key="H2">検索</sys:String>
-    <sys:String x:Key="H3">エクスポート</sys:String>
-    <sys:String x:Key="H4">すべて削除</sys:String>
-    <sys:String x:Key="H5">更新</sys:String>
-    <sys:String x:Key="H6">時間</sys:String>
-    <sys:String x:Key="H7">キャプション</sys:String>
-    <sys:String x:Key="H8">翻訳済み</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/ページ</sys:String>
-    <sys:String x:Key="H11">30/ページ</sys:String>
-    <sys:String x:Key="H12">50/ページ</sys:String>
-    <sys:String x:Key="H13">100/ページ</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">前へ</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">次のページ</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">検索</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">エクスポート</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">すべて削除</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">更新</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">時間</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">キャプション</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">翻訳済み</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/ページ</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/ページ</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/ページ</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/ページ</sys:String>
 
-    <sys:String x:Key="H20">すべての履歴を削除しますか？</sys:String>
-    <sys:String x:Key="H21">この操作は元に戻せません！</sys:String>
-    <sys:String x:Key="H22">はい</sys:String>
-    <sys:String x:Key="H23">いいえ</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|すべてのファイル (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">保存成功</sys:String>
-    <sys:String x:Key="H26">ファイルを保存しました: {0}</sys:String>
-    <sys:String x:Key="H27">保存失敗</sys:String>
-    <sys:String x:Key="H28">ファイルの保存に失敗しました: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">すべての履歴を削除しますか？</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">この操作は元に戻せません！</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">はい</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">いいえ</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|すべてのファイル (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">保存成功</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">ファイルを保存しました: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">保存失敗</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">ファイルの保存に失敗しました: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">オーバーレイウィンドウ</sys:String>
-    <sys:String x:Key="O1">フォントサイズを大きく</sys:String>
-    <sys:String x:Key="O2">フォントサイズを小さく</sys:String>
-    <sys:String x:Key="O3">フォントの縁取りを太く</sys:String>
-    <sys:String x:Key="O4">フォントの縁取りを細く</sys:String>
-    <sys:String x:Key="O5">太字</sys:String>
-    <sys:String x:Key="O6">フォント色</sys:String>
-    <sys:String x:Key="O7">背景の不透明度を上げる</sys:String>
-    <sys:String x:Key="O8">背景の不透明度を下げる</sys:String>
-    <sys:String x:Key="O9">背景色</sys:String>
-    <sys:String x:Key="O10">字幕または翻訳のみ表示</sys:String>
-    <sys:String x:Key="O11">字幕/翻訳の位置切替</sys:String>
-    <sys:String x:Key="O12">クリックスルー</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">オーバーレイウィンドウ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">フォントサイズを大きく</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">フォントサイズを小さく</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">フォントの縁取りを太く</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">フォントの縁取りを細く</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">太字</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">フォント色</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">背景の不透明度を上げる</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">背景の不透明度を下げる</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">背景色</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">字幕または翻訳のみ表示</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">字幕/翻訳の位置切替</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">クリックスルー</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">どんな形でも貢献を歓迎します！提案やバグ報告はGitHub Issuesで、コード貢献はPull Requestで行えます。</sys:String>
-    <sys:String x:Key="I1">このプログラムが役に立った場合、スターをお願いします！</sys:String>
-    <sys:String x:Key="I2">リポジトリ:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">メンテナー:</sys:String>
-    <sys:String x:Key="I5">(著者) と</sys:String>
-    <sys:String x:Key="I6">バージョン:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">どんな形でも貢献を歓迎します！提案やバグ報告はGitHub Issuesで、コード貢献はPull Requestで行えます。</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">このプログラムが役に立った場合、スターをお願いします！</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">リポジトリ:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">メンテナー:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(著者) と</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">バージョン:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">はじめに</sys:String>
-    <sys:String x:Key="W1">LiveCaptions Translator へようこそ！</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator は Windows LiveCaptions に基づいています。</sys:String>
-    <sys:String x:Key="W3">&#x0A;初回実行前に、以下の手順で設定してください:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Windows LiveCaptions を開き、オンデバイス音声認識および言語パックをダウンロードするガイドに従います。</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Windows LiveCaptions の</sys:String>
-    <sys:String x:Key="W6">⚙️ 設定アイコン</sys:String>
-    <sys:String x:Key="W7">をクリックし、設定メニューを開いて</sys:String>
-    <sys:String x:Key="W8">「位置 &gt; 画面上に重ねて表示」</sys:String>
-    <sys:String x:Key="W9">を選択します。</sys:String>
-    <sys:String x:Key="W10">3. LiveCaptions Translator の設定ページにある</sys:String>
-    <sys:String x:Key="W11">「非表示」</sys:String>
-    <sys:String x:Key="W12">ボタンをクリックして Windows LiveCaptions を非表示にします。&#x0A;</sys:String>
-    <sys:String x:Key="W13">設定完了後、メインページに戻ってリアルタイム音声翻訳を楽しめます。&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;詳細はWikiをご覧ください: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;ヒント:&#x0A;</sys:String>
-    <sys:String x:Key="W17">ソース言語を変更するには、設定ページで [表示] をクリックして </sys:String>
-    <sys:String x:Key="W18">ソース言語</sys:String>
-    <sys:String x:Key="W19"> を Windows LiveCaptions 上で変更してください。</sys:String>
-
-    <sys:String x:Key="W20">設定を理解し、完了しました。</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">はじめに</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">LiveCaptions Translator へようこそ！</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator は Windows LiveCaptions に基づいています。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;初回実行前に、以下の手順で設定してください:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Windows LiveCaptions を開き、オンデバイス音声認識および言語パックをダウンロードするガイドに従います。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Windows LiveCaptions の</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ 設定アイコン</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">をクリックし、設定メニューを開いて</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">「位置 &gt; 画面上に重ねて表示」</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. LiveCaptions Translator の設定ページにある</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">「非表示」</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">ボタンをクリックして Windows LiveCaptions を非表示にします。&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">設定完了後、メインページに戻ってリアルタイム音声翻訳を楽しめます。&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;詳細はWikiをご覧ください: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;ヒント:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">ソース言語を変更するには、設定ページで [表示] をクリックして </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">ソース言語</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction"> を Windows LiveCaptions 上で変更してください。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">設定を理解し、完了しました。</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">キャプション</sys:String>
-    <sys:String x:Key="M11">設定</sys:String>
-    <sys:String x:Key="M12">履歴</sys:String>
-    <sys:String x:Key="M13">情報</sys:String>
-    <sys:String x:Key="M20">キャプションのログカード</sys:String>
-    <sys:String x:Key="M21">翻訳一時停止（ログのみ）</sys:String>
-    <sys:String x:Key="M22">オーバーレイウィンドウ</sys:String>
-    <sys:String x:Key="M23">常に最前面</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">キャプションのログカード</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">翻訳一時停止（ログのみ）</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">オーバーレイウィンドウ</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">常に最前面</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[エラー] 更新チェックに失敗しました。</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">エラー</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">新しいバージョンがあります</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">新しいバージョンが検出されました: {0} 現在のバージョン: {1} 最新リリースをGitHubからダウンロードしてください。</sys:String>
 
-    <sys:String x:Key="MC0">[エラー] 更新チェックに失敗しました。</sys:String>
-    <sys:String x:Key="MC1">エラー</sys:String>
-    <sys:String x:Key="MC2">新しいバージョンがあります</sys:String>
-    <sys:String x:Key="MC3">新しいバージョンが検出されました: {0}
-現在のバージョン: {1}
-最新リリースをGitHubからダウンロードしてください。</sys:String>
-    <sys:String x:Key="MC4">更新</sys:String>
-    <sys:String x:Key="MC5">このバージョンを無視</sys:String>
-    <sys:String x:Key="MC6">[エラー] ブラウザを開くことに失敗しました。</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[警告] LiveCaptions が予期せず終了しました。再起動中...</sys:String>
-    <sys:String x:Key="T1">[一時停止]</sys:String>
-    <sys:String x:Key="T2">エラー！</sys:String>
-    <sys:String x:Key="T3">履歴の記録に失敗しました: {0}</sys:String>
+    <!-- Translator strings -->
+    <sys:String x:Key="Translator_Status_Restarting">[警告] LiveCaptions が予期せず終了しました。再起動中...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[一時停止]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">エラー！</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">履歴の記録に失敗しました: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">クリックしてコピー</sys:String>
-    <sys:String x:Key="C1">コピーしました</sys:String>
-    <sys:String x:Key="C2">コピーに失敗しました</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">クリックしてコピー</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">コピーしました</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">コピーに失敗しました</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/ja-jp.xaml
+++ b/src/localization/ja-jp.xaml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">ライブキャプション</sys:String>
+    <sys:String x:Key="S1">Windows 11 バージョン24H2以降では、変更できるのは</sys:String>
+    <sys:String x:Key="S2">ソース言語</sys:String>
+    <sys:String x:Key="S3">のみです（ライブキャプション内）。</sys:String>
+    <sys:String x:Key="S4">注意：</sys:String>
+    <sys:String x:Key="S5">必ず</sys:String>
+    <sys:String x:Key="S6">「非表示」</sys:String>
+    <sys:String x:Key="S7">をクリックしてライブキャプションを閉じずに非表示にしてください。</sys:String>
+
+    <sys:String x:Key="S8">表示</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">非表示</sys:String>
+    <sys:String x:Key="S46">表示</sys:String>
+
+    <sys:String x:Key="S9">API間隔</sys:String>
+    <sys:String x:Key="S10">翻訳API呼び出しの頻度を決定します。小さいほどAPI呼び出しが頻繁になります。</sys:String>
+    <sys:String x:Key="S11">キャプションが変更された後、APIは一度呼び出されます</sys:String>
+    <sys:String x:Key="S12">[API間隔]</sys:String>
+    <sys:String x:Key="S13">回。</sys:String>
+
+    <sys:String x:Key="S14">翻訳API</sys:String>
+    <sys:String x:Key="S15">GoogleとGoogle2を除き、他のAPIは使用前に設定が必要です。</sys:String>
+
+    <sys:String x:Key="S16">ターゲット言語</sys:String>
+    <sys:String x:Key="S17">期待するターゲット言語がありません！</sys:String>
+    <sys:String x:Key="S18">このコンボボックスの内容を直接編集して言語をカスタマイズできます。BCP 47言語タグに従うことを推奨します。</sys:String>
+    <sys:String x:Key="S19">BCP 47言語タグ</sys:String>
+    <sys:String x:Key="S20">DeepLなどの一部APIでは別の方法でターゲット言語を指定する必要があります。詳細は公式ドキュメントをご確認ください。</sys:String>
+    <sys:String x:Key="S21">組み込みのターゲット言語については考慮不要ですが、希望の言語がリストにない場合は注意してください。</sys:String>
+
+    <sys:String x:Key="S22">API設定</sys:String>
+    <sys:String x:Key="S23">開く</sys:String>
+    <sys:String x:Key="S24">レイテンシ表示</sys:String>
+    <sys:String x:Key="S25">オフ</sys:String>
+    <sys:String x:Key="S26">オン</sys:String>
+
+    <sys:String x:Key="S27">コンテキスト</sys:String>
+    <sys:String x:Key="S28">コンテキスト：</sys:String>
+    <sys:String x:Key="S29">「コンテキスト認識」が有効の際に考慮する文の数を決定します。</sys:String>
+    <sys:String x:Key="S30">コンテキスト認識</sys:String>
+    <sys:String x:Key="S31">が有効です。</sys:String>
+    <sys:String x:Key="S32">オーバーレイ表示文：</sys:String>
+    <sys:String x:Key="S33">「ログカード」が有効の際に表示されるカードの数、及びオーバーレイウィンドウで表示される最大文数を決定します。</sys:String>
+    <sys:String x:Key="S34">ログカード</sys:String>
+    <sys:String x:Key="S35">が有効です。</sys:String>
+    <sys:String x:Key="S36">コンテキストは</sys:String>
+    <sys:String x:Key="S37">以上である必要があります</sys:String>
+    <sys:String x:Key="S38">表示文数</sys:String>
+    <sys:String x:Key="S39">。満たされない場合、プログラムが自動調整します。</sys:String>
+    <sys:String x:Key="S40">表示文数</sys:String>
+
+    <sys:String x:Key="S41">コンテキストで翻訳</sys:String>
+    <sys:String x:Key="S42">翻訳精度が向上しますが、より多くのトークンを消費します。</sys:String>
+
+    <sys:String x:Key="S43">UI言語</sys:String>
+    <sys:String x:Key="S44">アプリケーションのUIで使用する言語を選択します。</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">前へ</sys:String>
+    <sys:String x:Key="H1">次のページ</sys:String>
+    <sys:String x:Key="H2">検索</sys:String>
+    <sys:String x:Key="H3">エクスポート</sys:String>
+    <sys:String x:Key="H4">すべて削除</sys:String>
+    <sys:String x:Key="H5">更新</sys:String>
+    <sys:String x:Key="H6">時間</sys:String>
+    <sys:String x:Key="H7">キャプション</sys:String>
+    <sys:String x:Key="H8">翻訳済み</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/ページ</sys:String>
+    <sys:String x:Key="H11">30/ページ</sys:String>
+    <sys:String x:Key="H12">50/ページ</sys:String>
+    <sys:String x:Key="H13">100/ページ</sys:String>
+
+    <sys:String x:Key="H20">すべての履歴を削除しますか？</sys:String>
+    <sys:String x:Key="H21">この操作は元に戻せません！</sys:String>
+    <sys:String x:Key="H22">はい</sys:String>
+    <sys:String x:Key="H23">いいえ</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|すべてのファイル (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">保存成功</sys:String>
+    <sys:String x:Key="H26">ファイルを保存しました: {0}</sys:String>
+    <sys:String x:Key="H27">保存失敗</sys:String>
+    <sys:String x:Key="H28">ファイルの保存に失敗しました: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">オーバーレイウィンドウ</sys:String>
+    <sys:String x:Key="O1">フォントサイズを大きく</sys:String>
+    <sys:String x:Key="O2">フォントサイズを小さく</sys:String>
+    <sys:String x:Key="O3">フォントの縁取りを太く</sys:String>
+    <sys:String x:Key="O4">フォントの縁取りを細く</sys:String>
+    <sys:String x:Key="O5">太字</sys:String>
+    <sys:String x:Key="O6">フォント色</sys:String>
+    <sys:String x:Key="O7">背景の不透明度を上げる</sys:String>
+    <sys:String x:Key="O8">背景の不透明度を下げる</sys:String>
+    <sys:String x:Key="O9">背景色</sys:String>
+    <sys:String x:Key="O10">字幕または翻訳のみ表示</sys:String>
+    <sys:String x:Key="O11">字幕/翻訳の位置切替</sys:String>
+    <sys:String x:Key="O12">クリックスルー</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">どんな形でも貢献を歓迎します！提案やバグ報告はGitHub Issuesで、コード貢献はPull Requestで行えます。</sys:String>
+    <sys:String x:Key="I1">このプログラムが役に立った場合、スターをお願いします！</sys:String>
+    <sys:String x:Key="I2">リポジトリ:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">メンテナー:</sys:String>
+    <sys:String x:Key="I5">(著者) と</sys:String>
+    <sys:String x:Key="I6">バージョン:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">はじめに</sys:String>
+    <sys:String x:Key="W1">LiveCaptions Translator へようこそ！</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator は Windows LiveCaptions に基づいています。</sys:String>
+    <sys:String x:Key="W3">&#x0A;初回実行前に、以下の手順で設定してください:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Windows LiveCaptions を開き、オンデバイス音声認識および言語パックをダウンロードするガイドに従います。</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Windows LiveCaptions の</sys:String>
+    <sys:String x:Key="W6">⚙️ 設定アイコン</sys:String>
+    <sys:String x:Key="W7">をクリックし、設定メニューを開いて</sys:String>
+    <sys:String x:Key="W8">「位置 &gt; 画面上に重ねて表示」</sys:String>
+    <sys:String x:Key="W9">を選択します。</sys:String>
+    <sys:String x:Key="W10">3. LiveCaptions Translator の設定ページにある</sys:String>
+    <sys:String x:Key="W11">「非表示」</sys:String>
+    <sys:String x:Key="W12">ボタンをクリックして Windows LiveCaptions を非表示にします。&#x0A;</sys:String>
+    <sys:String x:Key="W13">設定完了後、メインページに戻ってリアルタイム音声翻訳を楽しめます。&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;詳細はWikiをご覧ください: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;ヒント:&#x0A;</sys:String>
+    <sys:String x:Key="W17">ソース言語を変更するには、設定ページで [表示] をクリックして </sys:String>
+    <sys:String x:Key="W18">ソース言語</sys:String>
+    <sys:String x:Key="W19"> を Windows LiveCaptions 上で変更してください。</sys:String>
+
+    <sys:String x:Key="W20">設定を理解し、完了しました。</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">キャプション</sys:String>
+    <sys:String x:Key="M11">設定</sys:String>
+    <sys:String x:Key="M12">履歴</sys:String>
+    <sys:String x:Key="M13">情報</sys:String>
+    <sys:String x:Key="M20">キャプションのログカード</sys:String>
+    <sys:String x:Key="M21">翻訳一時停止（ログのみ）</sys:String>
+    <sys:String x:Key="M22">オーバーレイウィンドウ</sys:String>
+    <sys:String x:Key="M23">常に最前面</sys:String>
+
+    <sys:String x:Key="MC0">[エラー] 更新チェックに失敗しました。</sys:String>
+    <sys:String x:Key="MC1">エラー</sys:String>
+    <sys:String x:Key="MC2">新しいバージョンがあります</sys:String>
+    <sys:String x:Key="MC3">新しいバージョンが検出されました: {0}
+現在のバージョン: {1}
+最新リリースをGitHubからダウンロードしてください。</sys:String>
+    <sys:String x:Key="MC4">更新</sys:String>
+    <sys:String x:Key="MC5">このバージョンを無視</sys:String>
+    <sys:String x:Key="MC6">[エラー] ブラウザを開くことに失敗しました。</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[警告] LiveCaptions が予期せず終了しました。再起動中...</sys:String>
+    <sys:String x:Key="T1">[一時停止]</sys:String>
+    <sys:String x:Key="T2">エラー！</sys:String>
+    <sys:String x:Key="T3">履歴の記録に失敗しました: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">クリックしてコピー</sys:String>
+    <sys:String x:Key="C1">コピーしました</sys:String>
+    <sys:String x:Key="C2">コピーに失敗しました</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/ko-kr.xaml
+++ b/src/localization/ko-kr.xaml
@@ -3,169 +3,164 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">라이브 캡션</sys:String>
-    <sys:String x:Key="S1">Windows 11 버전 24H2 이후에는</sys:String>
-    <sys:String x:Key="S2">원본 언어</sys:String>
-    <sys:String x:Key="S3">만 변경할 수 있습니다 (라이브 캡션에서).</sys:String>
-    <sys:String x:Key="S4">참고:</sys:String>
-    <sys:String x:Key="S5">반드시 클릭하세요</sys:String>
-    <sys:String x:Key="S6">"숨기기"</sys:String>
-    <sys:String x:Key="S7">버튼을 눌러 라이브 캡션을 바로 닫지 말고 숨기세요.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">라이브 캡션</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_Intro">Windows 11 버전 24H2 이후에는</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">원본 언어</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">만 변경할 수 있습니다 (라이브 캡션에서).</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">참고:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">반드시 클릭하세요</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"숨기기"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">버튼을 눌러 라이브 캡션을 바로 닫지 말고 숨기세요.</sys:String>
 
-    <sys:String x:Key="S8">표시</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">표시</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">숨기기</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">숨기기</sys:String>
-    <sys:String x:Key="S46">표시</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API 간격</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">번역 API 호출 빈도를 결정합니다. 값이 작을수록 호출이 더 빈번해집니다.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">자막이 변경된 후 API가 한 번 호출됩니다</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API 간격]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">번.</sys:String>
 
-    <sys:String x:Key="S9">API 간격</sys:String>
-    <sys:String x:Key="S10">번역 API 호출 빈도를 결정합니다. 값이 작을수록 호출이 더 빈번해집니다.</sys:String>
-    <sys:String x:Key="S11">자막이 변경된 후 API가 한 번 호출됩니다</sys:String>
-    <sys:String x:Key="S12">[API 간격]</sys:String>
-    <sys:String x:Key="S13">번.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">번역 API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Google과 Google2를 제외한 모든 API는 사용 전에 설정이 필요합니다.</sys:String>
 
-    <sys:String x:Key="S14">번역 API</sys:String>
-    <sys:String x:Key="S15">Google과 Google2를 제외한 모든 API는 사용 전에 설정이 필요합니다.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">대상 언어</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">원하는 대상 언어가 없습니다!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">이 콤보박스 내용을 직접 편집하여 언어를 맞춤 설정할 수 있으며,</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47 언어 태그를 따르는 것이 좋습니다.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">DeepL과 같은 일부 API는 대상 언어를 지정하는 다른 방법이 필요합니다. 자세한 내용은 공식 문서를 참조하세요.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">포함된 대상 언어에 대해서는 신경 쓸 필요가 없지만, 원하는 언어가 목록에 없으면 유념하세요.</sys:String>
 
-    <sys:String x:Key="S16">대상 언어</sys:String>
-    <sys:String x:Key="S17">원하는 대상 언어가 없습니다!</sys:String>
-    <sys:String x:Key="S18">이 콤보박스 내용을 직접 편집하여 언어를 맞춤 설정할 수 있으며, BCP 47 언어 태그를 따르는 것이 좋습니다.</sys:String>
-    <sys:String x:Key="S19">BCP 47 언어 태그</sys:String>
-    <sys:String x:Key="S20">DeepL과 같은 일부 API는 대상 언어를 지정하는 다른 방법이 필요합니다. 자세한 내용은 공식 문서를 참조하세요.</sys:String>
-    <sys:String x:Key="S21">포함된 대상 언어에 대해서는 신경 쓸 필요가 없지만, 원하는 언어가 목록에 없으면 유념하세요.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API 설정</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">열기</sys:String>
 
-    <sys:String x:Key="S22">API 설정</sys:String>
-    <sys:String x:Key="S23">열기</sys:String>
-    <sys:String x:Key="S24">지연 시간 표시</sys:String>
-    <sys:String x:Key="S25">끔</sys:String>
-    <sys:String x:Key="S26">켬</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">지연 시간 표시</sys:String>
+    <sys:String x:Key="Common_Off">끔</sys:String>
+    <sys:String x:Key="Common_On">켬</sys:String>
 
-    <sys:String x:Key="S27">컨텍스트</sys:String>
-    <sys:String x:Key="S28">컨텍스트:</sys:String>
-    <sys:String x:Key="S29">컨텍스트 인식이 활성화되었을 때 고려할 문장의 수를 결정합니다.</sys:String>
-    <sys:String x:Key="S30">컨텍스트 인식</sys:String>
-    <sys:String x:Key="S31">이 활성화되었습니다.</sys:String>
-    <sys:String x:Key="S32">오버레이 문장:</sys:String>
-    <sys:String x:Key="S33">로그 카드가 활성화되었을 때 표시되는 카드 수와 오버레이 창에 표시되는 최대 문장 수를 결정합니다.</sys:String>
-    <sys:String x:Key="S34">로그 카드</sys:String>
-    <sys:String x:Key="S35">활성화됨</sys:String>
-    <sys:String x:Key="S36">컨텍스트는</sys:String>
-    <sys:String x:Key="S37">이상이어야 합니다</sys:String>
-    <sys:String x:Key="S38">표시 문장 수</sys:String>
-    <sys:String x:Key="S39">. 조건이 충족되지 않으면 프로그램이 자동으로 조정합니다.</sys:String>
-    <sys:String x:Key="S40">표시 문장 수</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">컨텍스트</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">컨텍스트:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">컨텍스트 인식이 활성화되었을 때 고려할 문장의 수를 결정합니다.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">컨텍스트 인식</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">이 활성화되었습니다.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">오버레이 문장:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">로그 카드가 활성화되었을 때 표시되는 카드 수와 오버레이 창에 표시되는 최대 문장 수를 결정합니다.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">로그 카드</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">활성화됨</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">컨텍스트는</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">이상이어야 합니다</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">표시 문장 수</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. 조건이 충족되지 않으면 프로그램이 자동으로 조정합니다.</sys:String>
 
-    <sys:String x:Key="S41">컨텍스트 기반 번역</sys:String>
-    <sys:String x:Key="S42">번역 정확도를 향상시키지만 더 많은 토큰을 소비합니다.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">표시 문장 수</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">컨텍스트 기반 번역</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">번역 정확도를 향상시키지만 더 많은 토큰을 소비합니다.</sys:String>
 
-    <sys:String x:Key="S43">UI 언어</sys:String>
-    <sys:String x:Key="S44">앱 UI에서 사용할 언어를 선택합니다.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI 언어</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">앱 UI에서 사용할 언어를 선택합니다.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">변경 사항은 즉시 적용되고 자동 저장됩니다.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">이전</sys:String>
-    <sys:String x:Key="H1">다음 페이지</sys:String>
-    <sys:String x:Key="H2">검색</sys:String>
-    <sys:String x:Key="H3">내보내기</sys:String>
-    <sys:String x:Key="H4">모두 삭제</sys:String>
-    <sys:String x:Key="H5">새로고침</sys:String>
-    <sys:String x:Key="H6">시간</sys:String>
-    <sys:String x:Key="H7">자막</sys:String>
-    <sys:String x:Key="H8">번역됨</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/페이지</sys:String>
-    <sys:String x:Key="H11">30/페이지</sys:String>
-    <sys:String x:Key="H12">50/페이지</sys:String>
-    <sys:String x:Key="H13">100/페이지</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">이전</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">다음 페이지</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">검색</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">내보내기</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">모두 삭제</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">새로고침</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">시간</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">자막</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">번역됨</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/페이지</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/페이지</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/페이지</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/페이지</sys:String>
 
-    <sys:String x:Key="H20">모든 기록을 삭제하시겠습니까?</sys:String>
-    <sys:String x:Key="H21">이 작업은 되돌릴 수 없습니다!</sys:String>
-    <sys:String x:Key="H22">예</sys:String>
-    <sys:String x:Key="H23">아니오</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|모든 파일 (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">저장 성공</sys:String>
-    <sys:String x:Key="H26">파일이 저장되었습니다: {0}</sys:String>
-    <sys:String x:Key="H27">저장 실패</sys:String>
-    <sys:String x:Key="H28">파일 저장 실패: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">모든 기록을 삭제하시겠습니까?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">이 작업은 되돌릴 수 없습니다!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">예</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">아니오</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|모든 파일 (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">저장 성공</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">파일이 저장되었습니다: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">저장 실패</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">파일 저장 실패: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">오버레이 창</sys:String>
-    <sys:String x:Key="O1">글꼴 크기 증가</sys:String>
-    <sys:String x:Key="O2">글꼴 크기 감소</sys:String>
-    <sys:String x:Key="O3">글꼴 테두리 증가</sys:String>
-    <sys:String x:Key="O4">글꼴 테두리 감소</sys:String>
-    <sys:String x:Key="O5">굵게</sys:String>
-    <sys:String x:Key="O6">글꼴 색상</sys:String>
-    <sys:String x:Key="O7">배경 불투명도 증가</sys:String>
-    <sys:String x:Key="O8">배경 불투명도 감소</sys:String>
-    <sys:String x:Key="O9">배경 색상</sys:String>
-    <sys:String x:Key="O10">자막 또는 번역만 표시</sys:String>
-    <sys:String x:Key="O11">자막/번역 위치 전환</sys:String>
-    <sys:String x:Key="O12">클릭 통과</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">오버레이 창</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">글꼴 크기 증가</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">글꼴 크기 감소</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">글꼴 테두리 증가</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">글꼴 테두리 감소</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">굵게</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">글꼴 색상</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">배경 불투명도 증가</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">배경 불투명도 감소</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">배경 색상</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">자막 또는 번역만 표시</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">자막/번역 위치 전환</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">클릭 통과</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">모든 형태의 기여를 환영합니다! 제안이나 버그 신고는 GitHub Issues를 통해, 코드 기여는 Pull Request로 제출할 수 있습니다.</sys:String>
-    <sys:String x:Key="I1">이 프로그램이 유용했다면 별을 눌러주세요!</sys:String>
-    <sys:String x:Key="I2">저장소:</sys:String>
-    <sys:String x:Key="I3">위키:</sys:String>
-    <sys:String x:Key="I4">관리자:</sys:String>
-    <sys:String x:Key="I5">(저자) 및</sys:String>
-    <sys:String x:Key="I6">버전:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">모든 형태의 기여를 환영합니다! 제안이나 버그 신고는 GitHub Issues를 통해, 코드 기여는 Pull Request로 제출할 수 있습니다.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">이 프로그램이 유용했다면 별을 눌러주세요!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">저장소:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">위키:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">관리자:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(저자) 및</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">버전:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">시작하기</sys:String>
-    <sys:String x:Key="W1">LiveCaptions Translator에 오신 것을 환영합니다!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator는 Windows LiveCaptions를 기반으로 합니다.</sys:String>
-    <sys:String x:Key="W3">&#x0A;첫 실행 전, 아래 단계를 따라 설정하세요:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Windows LiveCaptions를 열고, 기기 내 음성 인식 및 언어 팩 다운로드 안내를 따릅니다.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Windows LiveCaptions에서</sys:String>
-    <sys:String x:Key="W6">⚙️ 설정 아이콘</sys:String>
-    <sys:String x:Key="W7">을 클릭하고 설정 메뉴에서</sys:String>
-    <sys:String x:Key="W8">"위치 &gt; 화면 위에 오버레이"</sys:String>
-    <sys:String x:Key="W9">를 선택합니다.</sys:String>
-    <sys:String x:Key="W10">3. LiveCaptions Translator 설정 페이지에 있는</sys:String>
-    <sys:String x:Key="W11">"숨기기"</sys:String>
-    <sys:String x:Key="W12">버튼을 클릭하여 Windows LiveCaptions를 숨깁니다.&#x0A;</sys:String>
-    <sys:String x:Key="W13">설정 완료 후, 메인 페이지로 돌아가 실시간 음성 번역을 즐기세요.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;자세한 내용은 위키를 참조하세요: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;팁:&#x0A;</sys:String>
-    <sys:String x:Key="W17">원본 언어를 변경하려면 </sys:String>
-    <sys:String x:Key="W18">원본 언어</sys:String>
-    <sys:String x:Key="W19">, 설정 페이지에서 LiveCaptions를 [표시]한 다음 Windows LiveCaptions에서 변경하세요.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">시작하기</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">LiveCaptions Translator에 오신 것을 환영합니다!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator는 Windows LiveCaptions를 기반으로 합니다.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;첫 실행 전, 아래 단계를 따라 설정하세요:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Windows LiveCaptions를 열고, 기기 내 음성 인식 및 언어 팩 다운로드 안내를 따릅니다.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Windows LiveCaptions에서</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ 설정 아이콘</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">을 클릭하고 설정 메뉴에서</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"위치 &gt; 화면 위에 오버레이"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. LiveCaptions Translator 설정 페이지에 있는</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"숨기기"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">버튼을 클릭하여 Windows LiveCaptions를 숨깁니다.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">설정 완료 후, 메인 페이지로 돌아가 실시간 음성 번역을 즐기세요.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;자세한 내용은 위키를 참조하세요: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;팁:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">원본 언어를 변경하려면 </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">원본 언어</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, 설정 페이지에서 LiveCaptions를 [표시]한 다음 Windows LiveCaptions에서 변경하세요.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">모든 설정을 이해하고 완료했습니다.</sys:String>
 
-    <sys:String x:Key="W20">모든 설정을 이해하고 완료했습니다.</sys:String>
+    <!-- Navigation menu -->
+    <sys:String x:Key="Navigation_Captions">자막</sys:String>
+    <sys:String x:Key="Navigation_Settings">설정</sys:String>
+    <sys:String x:Key="Navigation_History">기록</sys:String>
+    <sys:String x:Key="Navigation_Info">정보</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">자막</sys:String>
-    <sys:String x:Key="M11">설정</sys:String>
-    <sys:String x:Key="M12">기록</sys:String>
-    <sys:String x:Key="M13">정보</sys:String>
-    <sys:String x:Key="M20">자막 로그 카드</sys:String>
-    <sys:String x:Key="M21">번역 일시정지 (로그만)</sys:String>
-    <sys:String x:Key="M22">오버레이 창</sys:String>
-    <sys:String x:Key="M23">항상 위에 표시</sys:String>
-
-    <sys:String x:Key="MC0">[오류] 업데이트 확인 실패</sys:String>
-    <sys:String x:Key="MC1">오류</sys:String>
-    <sys:String x:Key="MC2">새 버전 이용 가능</sys:String>
-    <sys:String x:Key="MC3">새 버전이 감지되었습니다: {0}
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">자막 로그 카드</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">번역 일시정지 (로그만)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">오버레이 창</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">항상 위에 표시</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[오류] 업데이트 확인 실패</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">오류</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">새 버전 이용 가능</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">새 버전이 감지되었습니다: {0}
 현재 버전: {1}
 최신 릴리스를 GitHub에서 다운로드하세요.</sys:String>
-    <sys:String x:Key="MC4">업데이트</sys:String>
-    <sys:String x:Key="MC5">이 버전 무시</sys:String>
-    <sys:String x:Key="MC6">[오류] 브라우저 열기 실패</sys:String>
 
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[경고] LiveCaptions가 예기치 않게 종료되었습니다. 재시작 중...</sys:String>
-    <sys:String x:Key="T1">[일시정지]</sys:String>
-    <sys:String x:Key="T2">오류!</sys:String>
-    <sys:String x:Key="T3">기록 저장 실패: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[경고] LiveCaptions가 예기치 않게 종료되었습니다. 재시작 중...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[일시정지]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">오류!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">기록 저장 실패: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">클릭하여 복사</sys:String>
-    <sys:String x:Key="C1">복사됨</sys:String>
-    <sys:String x:Key="C2">복사 실패</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">클릭하여 복사</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">복사됨</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">복사 실패</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/ko-kr.xaml
+++ b/src/localization/ko-kr.xaml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">라이브 캡션</sys:String>
+    <sys:String x:Key="S1">Windows 11 버전 24H2 이후에는</sys:String>
+    <sys:String x:Key="S2">원본 언어</sys:String>
+    <sys:String x:Key="S3">만 변경할 수 있습니다 (라이브 캡션에서).</sys:String>
+    <sys:String x:Key="S4">참고:</sys:String>
+    <sys:String x:Key="S5">반드시 클릭하세요</sys:String>
+    <sys:String x:Key="S6">"숨기기"</sys:String>
+    <sys:String x:Key="S7">버튼을 눌러 라이브 캡션을 바로 닫지 말고 숨기세요.</sys:String>
+
+    <sys:String x:Key="S8">표시</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">숨기기</sys:String>
+    <sys:String x:Key="S46">표시</sys:String>
+
+    <sys:String x:Key="S9">API 간격</sys:String>
+    <sys:String x:Key="S10">번역 API 호출 빈도를 결정합니다. 값이 작을수록 호출이 더 빈번해집니다.</sys:String>
+    <sys:String x:Key="S11">자막이 변경된 후 API가 한 번 호출됩니다</sys:String>
+    <sys:String x:Key="S12">[API 간격]</sys:String>
+    <sys:String x:Key="S13">번.</sys:String>
+
+    <sys:String x:Key="S14">번역 API</sys:String>
+    <sys:String x:Key="S15">Google과 Google2를 제외한 모든 API는 사용 전에 설정이 필요합니다.</sys:String>
+
+    <sys:String x:Key="S16">대상 언어</sys:String>
+    <sys:String x:Key="S17">원하는 대상 언어가 없습니다!</sys:String>
+    <sys:String x:Key="S18">이 콤보박스 내용을 직접 편집하여 언어를 맞춤 설정할 수 있으며, BCP 47 언어 태그를 따르는 것이 좋습니다.</sys:String>
+    <sys:String x:Key="S19">BCP 47 언어 태그</sys:String>
+    <sys:String x:Key="S20">DeepL과 같은 일부 API는 대상 언어를 지정하는 다른 방법이 필요합니다. 자세한 내용은 공식 문서를 참조하세요.</sys:String>
+    <sys:String x:Key="S21">포함된 대상 언어에 대해서는 신경 쓸 필요가 없지만, 원하는 언어가 목록에 없으면 유념하세요.</sys:String>
+
+    <sys:String x:Key="S22">API 설정</sys:String>
+    <sys:String x:Key="S23">열기</sys:String>
+    <sys:String x:Key="S24">지연 시간 표시</sys:String>
+    <sys:String x:Key="S25">끔</sys:String>
+    <sys:String x:Key="S26">켬</sys:String>
+
+    <sys:String x:Key="S27">컨텍스트</sys:String>
+    <sys:String x:Key="S28">컨텍스트:</sys:String>
+    <sys:String x:Key="S29">컨텍스트 인식이 활성화되었을 때 고려할 문장의 수를 결정합니다.</sys:String>
+    <sys:String x:Key="S30">컨텍스트 인식</sys:String>
+    <sys:String x:Key="S31">이 활성화되었습니다.</sys:String>
+    <sys:String x:Key="S32">오버레이 문장:</sys:String>
+    <sys:String x:Key="S33">로그 카드가 활성화되었을 때 표시되는 카드 수와 오버레이 창에 표시되는 최대 문장 수를 결정합니다.</sys:String>
+    <sys:String x:Key="S34">로그 카드</sys:String>
+    <sys:String x:Key="S35">활성화됨</sys:String>
+    <sys:String x:Key="S36">컨텍스트는</sys:String>
+    <sys:String x:Key="S37">이상이어야 합니다</sys:String>
+    <sys:String x:Key="S38">표시 문장 수</sys:String>
+    <sys:String x:Key="S39">. 조건이 충족되지 않으면 프로그램이 자동으로 조정합니다.</sys:String>
+    <sys:String x:Key="S40">표시 문장 수</sys:String>
+
+    <sys:String x:Key="S41">컨텍스트 기반 번역</sys:String>
+    <sys:String x:Key="S42">번역 정확도를 향상시키지만 더 많은 토큰을 소비합니다.</sys:String>
+
+    <sys:String x:Key="S43">UI 언어</sys:String>
+    <sys:String x:Key="S44">앱 UI에서 사용할 언어를 선택합니다.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">이전</sys:String>
+    <sys:String x:Key="H1">다음 페이지</sys:String>
+    <sys:String x:Key="H2">검색</sys:String>
+    <sys:String x:Key="H3">내보내기</sys:String>
+    <sys:String x:Key="H4">모두 삭제</sys:String>
+    <sys:String x:Key="H5">새로고침</sys:String>
+    <sys:String x:Key="H6">시간</sys:String>
+    <sys:String x:Key="H7">자막</sys:String>
+    <sys:String x:Key="H8">번역됨</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/페이지</sys:String>
+    <sys:String x:Key="H11">30/페이지</sys:String>
+    <sys:String x:Key="H12">50/페이지</sys:String>
+    <sys:String x:Key="H13">100/페이지</sys:String>
+
+    <sys:String x:Key="H20">모든 기록을 삭제하시겠습니까?</sys:String>
+    <sys:String x:Key="H21">이 작업은 되돌릴 수 없습니다!</sys:String>
+    <sys:String x:Key="H22">예</sys:String>
+    <sys:String x:Key="H23">아니오</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|모든 파일 (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">저장 성공</sys:String>
+    <sys:String x:Key="H26">파일이 저장되었습니다: {0}</sys:String>
+    <sys:String x:Key="H27">저장 실패</sys:String>
+    <sys:String x:Key="H28">파일 저장 실패: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">오버레이 창</sys:String>
+    <sys:String x:Key="O1">글꼴 크기 증가</sys:String>
+    <sys:String x:Key="O2">글꼴 크기 감소</sys:String>
+    <sys:String x:Key="O3">글꼴 테두리 증가</sys:String>
+    <sys:String x:Key="O4">글꼴 테두리 감소</sys:String>
+    <sys:String x:Key="O5">굵게</sys:String>
+    <sys:String x:Key="O6">글꼴 색상</sys:String>
+    <sys:String x:Key="O7">배경 불투명도 증가</sys:String>
+    <sys:String x:Key="O8">배경 불투명도 감소</sys:String>
+    <sys:String x:Key="O9">배경 색상</sys:String>
+    <sys:String x:Key="O10">자막 또는 번역만 표시</sys:String>
+    <sys:String x:Key="O11">자막/번역 위치 전환</sys:String>
+    <sys:String x:Key="O12">클릭 통과</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">모든 형태의 기여를 환영합니다! 제안이나 버그 신고는 GitHub Issues를 통해, 코드 기여는 Pull Request로 제출할 수 있습니다.</sys:String>
+    <sys:String x:Key="I1">이 프로그램이 유용했다면 별을 눌러주세요!</sys:String>
+    <sys:String x:Key="I2">저장소:</sys:String>
+    <sys:String x:Key="I3">위키:</sys:String>
+    <sys:String x:Key="I4">관리자:</sys:String>
+    <sys:String x:Key="I5">(저자) 및</sys:String>
+    <sys:String x:Key="I6">버전:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">시작하기</sys:String>
+    <sys:String x:Key="W1">LiveCaptions Translator에 오신 것을 환영합니다!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator는 Windows LiveCaptions를 기반으로 합니다.</sys:String>
+    <sys:String x:Key="W3">&#x0A;첫 실행 전, 아래 단계를 따라 설정하세요:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Windows LiveCaptions를 열고, 기기 내 음성 인식 및 언어 팩 다운로드 안내를 따릅니다.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Windows LiveCaptions에서</sys:String>
+    <sys:String x:Key="W6">⚙️ 설정 아이콘</sys:String>
+    <sys:String x:Key="W7">을 클릭하고 설정 메뉴에서</sys:String>
+    <sys:String x:Key="W8">"위치 &gt; 화면 위에 오버레이"</sys:String>
+    <sys:String x:Key="W9">를 선택합니다.</sys:String>
+    <sys:String x:Key="W10">3. LiveCaptions Translator 설정 페이지에 있는</sys:String>
+    <sys:String x:Key="W11">"숨기기"</sys:String>
+    <sys:String x:Key="W12">버튼을 클릭하여 Windows LiveCaptions를 숨깁니다.&#x0A;</sys:String>
+    <sys:String x:Key="W13">설정 완료 후, 메인 페이지로 돌아가 실시간 음성 번역을 즐기세요.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;자세한 내용은 위키를 참조하세요: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;팁:&#x0A;</sys:String>
+    <sys:String x:Key="W17">원본 언어를 변경하려면 </sys:String>
+    <sys:String x:Key="W18">원본 언어</sys:String>
+    <sys:String x:Key="W19">, 설정 페이지에서 LiveCaptions를 [표시]한 다음 Windows LiveCaptions에서 변경하세요.</sys:String>
+
+    <sys:String x:Key="W20">모든 설정을 이해하고 완료했습니다.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">자막</sys:String>
+    <sys:String x:Key="M11">설정</sys:String>
+    <sys:String x:Key="M12">기록</sys:String>
+    <sys:String x:Key="M13">정보</sys:String>
+    <sys:String x:Key="M20">자막 로그 카드</sys:String>
+    <sys:String x:Key="M21">번역 일시정지 (로그만)</sys:String>
+    <sys:String x:Key="M22">오버레이 창</sys:String>
+    <sys:String x:Key="M23">항상 위에 표시</sys:String>
+
+    <sys:String x:Key="MC0">[오류] 업데이트 확인 실패</sys:String>
+    <sys:String x:Key="MC1">오류</sys:String>
+    <sys:String x:Key="MC2">새 버전 이용 가능</sys:String>
+    <sys:String x:Key="MC3">새 버전이 감지되었습니다: {0}
+현재 버전: {1}
+최신 릴리스를 GitHub에서 다운로드하세요.</sys:String>
+    <sys:String x:Key="MC4">업데이트</sys:String>
+    <sys:String x:Key="MC5">이 버전 무시</sys:String>
+    <sys:String x:Key="MC6">[오류] 브라우저 열기 실패</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[경고] LiveCaptions가 예기치 않게 종료되었습니다. 재시작 중...</sys:String>
+    <sys:String x:Key="T1">[일시정지]</sys:String>
+    <sys:String x:Key="T2">오류!</sys:String>
+    <sys:String x:Key="T3">기록 저장 실패: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">클릭하여 복사</sys:String>
+    <sys:String x:Key="C1">복사됨</sys:String>
+    <sys:String x:Key="C2">복사 실패</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/lt-lt.xaml
+++ b/src/localization/lt-lt.xaml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Tiesioginės antraštės</sys:String>
+    <sys:String x:Key="S1">Po Windows 11 24H2 versijos galite pakeisti tik</sys:String>
+    <sys:String x:Key="S2">Šaltinio kalbą</sys:String>
+    <sys:String x:Key="S3">Tiesioginėse antraštėse.</sys:String>
+    <sys:String x:Key="S4">Pastaba:</sys:String>
+    <sys:String x:Key="S5">Prašome spustelėti</sys:String>
+    <sys:String x:Key="S6">"Slėpti"</sys:String>
+    <sys:String x:Key="S7">norėdami paslėpti Tiesiogines antraštes, o ne uždaryti jas tiesiogiai.</sys:String>
+    <sys:String x:Key="S8">Rodyti</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Slėpti</sys:String>
+    <sys:String x:Key="S46">Rodyti</sys:String>
+
+    <sys:String x:Key="S9">API intervalas</sys:String>
+    <sys:String x:Key="S10">Nustato vertimo API kvietimų dažnį. Mažesnė reikšmė reiškia dažnesnius kvietimus.</sys:String>
+    <sys:String x:Key="S11">Vertimo API kviečiama vieną kartą po antraštės pakeitimo</sys:String>
+    <sys:String x:Key="S12">[API intervalas]</sys:String>
+    <sys:String x:Key="S13">kartų.</sys:String>
+
+    <sys:String x:Key="S14">Vertimo API</sys:String>
+    <sys:String x:Key="S15">Išskyrus Google ir Google2, kitos API turi būti sukonfigūruotos prieš naudojimą.</sys:String>
+
+    <sys:String x:Key="S16">Tikslinė kalba</sys:String>
+    <sys:String x:Key="S17">Norimos tikslinės kalbos nėra!</sys:String>
+    <sys:String x:Key="S18">Galite tiesiogiai redaguoti šio kombinuoto sąrašo turinį, kad pritaikytumėte kalbą; rekomenduojama naudoti</sys:String>
+    <sys:String x:Key="S19">BCP 47 kalbos žymą.</sys:String>
+    <sys:String x:Key="S20">Kai kurios API (pvz., DeepL) reikalauja kito būdo tikslinės kalbos nustatymui, žr. jų oficialią dokumentaciją.</sys:String>
+    <sys:String x:Key="S21">Įtrauktoms kalboms apie tai galvoti nereikia, bet jei norima kalba nėra sąraše, atsiminkite tai.</sys:String>
+
+    <sys:String x:Key="S22">API nustatymai</sys:String>
+    <sys:String x:Key="S23">Atidaryti</sys:String>
+
+    <sys:String x:Key="S24">Rodyti delsą</sys:String>
+    <sys:String x:Key="S25">Išjungta</sys:String>
+    <sys:String x:Key="S26">Įjungta</sys:String>
+
+    <sys:String x:Key="S27">Kontekstai</sys:String>
+    <sys:String x:Key="S28">Kontekstai:</sys:String>
+    <sys:String x:Key="S29">Nustato kontekstinių sakinių skaičių, kai įjungtas</sys:String>
+    <sys:String x:Key="S30">Konteksto suvokimas</sys:String>
+    <sys:String x:Key="S31">.</sys:String>
+    <sys:String x:Key="S32">Peržiūros sakiniai:</sys:String>
+    <sys:String x:Key="S33">Nustato rodomų kortelių skaičių, kai įjungtas</sys:String>
+    <sys:String x:Key="S34">Žurnalo kortelės</sys:String>
+    <sys:String x:Key="S35">, taip pat maksimalų sakinių skaičių, rodomą peržiūros lange.</sys:String>
+    <sys:String x:Key="S36">Kontekstai turi būti</sys:String>
+    <sys:String x:Key="S37">didesni arba lygūs</sys:String>
+    <sys:String x:Key="S38">Peržiūros sakiniai</sys:String>
+    <sys:String x:Key="S39">. Jei nebus įvykdyta, programa automatiškai pakoreguos.</sys:String>
+    <sys:String x:Key="S40">Peržiūros sakiniai</sys:String>
+
+    <sys:String x:Key="S41">Versti kontekste.</sys:String>
+    <sys:String x:Key="S42">Tai gali pagerinti vertimo tikslumą, bet sunaudos daugiau žetonų.</sys:String>
+
+    <sys:String x:Key="S43">UI kalba</sys:String>
+    <sys:String x:Key="S44">Pasirinkite kalbą, kurią naudos programos vartotojo sąsaja.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Ankstesnis</sys:String>
+    <sys:String x:Key="H1">Kitas puslapis</sys:String>
+    <sys:String x:Key="H2">Ieškoti</sys:String>
+    <sys:String x:Key="H3">Eksportuoti</sys:String>
+    <sys:String x:Key="H4">Ištrinti viską</sys:String>
+    <sys:String x:Key="H5">Atnaujinti</sys:String>
+    <sys:String x:Key="H6">Laikas</sys:String>
+    <sys:String x:Key="H7">Antraštė</sys:String>
+    <sys:String x:Key="H8">Išversta</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/puslapis</sys:String>
+    <sys:String x:Key="H11">30/puslapis</sys:String>
+    <sys:String x:Key="H12">50/puslapis</sys:String>
+    <sys:String x:Key="H13">100/puslapis</sys:String>
+    <sys:String x:Key="H20">Ar tikrai norite ištrinti visą istoriją?</sys:String>
+    <sys:String x:Key="H21">Šio veiksmo nebus galima atšaukti!</sys:String>
+    <sys:String x:Key="H22">Taip</sys:String>
+    <sys:String x:Key="H23">Ne</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Visi failai (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Išsaugota sėkmingai</sys:String>
+    <sys:String x:Key="H26">Failas išsaugotas: {0}</sys:String>
+    <sys:String x:Key="H27">Išsaugojimas nepavyko</sys:String>
+    <sys:String x:Key="H28">Failo išsaugojimas nepavyko: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Peržiūros langas</sys:String>
+    <sys:String x:Key="O1">Padidinti šrifto dydį</sys:String>
+    <sys:String x:Key="O2">Sumažinti šrifto dydį</sys:String>
+    <sys:String x:Key="O3">Padidinti šrifto kontūrą</sys:String>
+    <sys:String x:Key="O4">Sumažinti šrifto kontūrą</sys:String>
+    <sys:String x:Key="O5">Paryškintas</sys:String>
+    <sys:String x:Key="O6">Šrifto spalva</sys:String>
+    <sys:String x:Key="O7">Padidinti fono skaidrumą</sys:String>
+    <sys:String x:Key="O8">Sumažinti fono skaidrumą</sys:String>
+    <sys:String x:Key="O9">Fono spalva</sys:String>
+    <sys:String x:Key="O10">Rodyti tik subtitrus arba vertimus</sys:String>
+    <sys:String x:Key="O11">Keisti subtitrų/vertimo poziciją</sys:String>
+    <sys:String x:Key="O12">Spustelėjimo praleidimas</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Mes sveikiname bet kokį indėlį! Galite pateikti pasiūlymus ar pranešti apie klaidas per GitHub issues arba prisidėti prie kodo pateikdami Pull Request.</sys:String>
+    <sys:String x:Key="I1">Jei ši programa jums naudinga, apsvarstykite galimybę suteikti mums žvaigždutę!</sys:String>
+    <sys:String x:Key="I2">Saugykla:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Palaikytojas:</sys:String>
+    <sys:String x:Key="I5">(Autorius) ir</sys:String>
+    <sys:String x:Key="I6">Versija:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Pradžia</sys:String>
+    <sys:String x:Key="W1">Sveiki atvykę į LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator pagrįstas Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Prieš pirmą kartą paleisdami, sukonfigūruokite pagal šiuos veiksmus:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Atidarykite Windows LiveCaptions ir sekite gido nurodymus atsisiųsti reikalingus vietinius kalbos atpažinimo failus ir kalbų paketus.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Spustelėkite</sys:String>
+    <sys:String x:Key="W6">⚙️ piktogramą</sys:String>
+    <sys:String x:Key="W7">Windows LiveCaptions nustatymuose ir pasirinkite</sys:String>
+    <sys:String x:Key="W8">"Pozicija &gt; Ant ekrano"</sys:String>
+    <sys:String x:Key="W9">3. Spustelėkite</sys:String>
+    <sys:String x:Key="W10">"Slėpti"</sys:String>
+    <sys:String x:Key="W11">mygtuką LiveCaptions Translator nustatymų puslapyje, kad paslėptumėte Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Programa automatiškai nukreipė jus į nustatymų puslapį ir atidarė Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Užbaigus konfigūraciją, galite grįžti į pagrindinį puslapį ir mėgautis realaus laiko garso vertimu.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;Daugiau informacijos rasite mūsų wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Patarimas:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Norėdami pakeisti </sys:String>
+    <sys:String x:Key="W18">Šaltinio kalbą</sys:String>
+    <sys:String x:Key="W19">, spustelėkite [Rodyti] nustatymų puslapyje ir padarykite tai Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">Aš visiškai supratau ir sukonfigūravau.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Antraštė</sys:String>
+    <sys:String x:Key="M11">Nustatymai</sys:String>
+    <sys:String x:Key="M12">Istorija</sys:String>
+    <sys:String x:Key="M13">Informacija</sys:String>
+    <sys:String x:Key="M20">Antraščių žurnalo kortelės</sys:String>
+    <sys:String x:Key="M21">Sustabdyti vertimą (tik žurnalas)</sys:String>
+    <sys:String x:Key="M22">Peržiūros langas</sys:String>
+    <sys:String x:Key="M23">Visada viršuje</sys:String>
+
+    <sys:String x:Key="MC0">[KLAIDA] Atnaujinimo tikrinimas nepavyko.</sys:String>
+    <sys:String x:Key="MC1">klaida</sys:String>
+    <sys:String x:Key="MC2">Nauja versija pasiekiama</sys:String>
+    <sys:String x:Key="MC3">Nustatyta nauja versija: {0}
+Dabartinė versija: {1}
+Atsisiųskite naujausią versiją iš GitHub.</sys:String>
+    <sys:String x:Key="MC4">Atnaujinti</sys:String>
+    <sys:String x:Key="MC5">Ignoruoti šią versiją</sys:String>
+    <sys:String x:Key="MC6">[KLAIDA] Naršyklės atidarymas nepavyko.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[ĮSPĖJIMAS] LiveCaptions buvo netikėtai uždaryta, paleidžiama iš naujo...</sys:String>
+    <sys:String x:Key="T1">[Sustabdyta]</sys:String>
+    <sys:String x:Key="T2">Klaida!</sys:String>
+    <sys:String x:Key="T3">Istorijos registravimas nepavyko: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Spustelėkite, kad nukopijuotumėte</sys:String>
+    <sys:String x:Key="C1">Nukopijuota</sys:String>
+    <sys:String x:Key="C2">Kopijavimas nepavyko</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/lt-lt.xaml
+++ b/src/localization/lt-lt.xaml
@@ -3,167 +3,157 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Tiesioginės antraštės</sys:String>
-    <sys:String x:Key="S1">Po Windows 11 24H2 versijos galite pakeisti tik</sys:String>
-    <sys:String x:Key="S2">Šaltinio kalbą</sys:String>
-    <sys:String x:Key="S3">Tiesioginėse antraštėse.</sys:String>
-    <sys:String x:Key="S4">Pastaba:</sys:String>
-    <sys:String x:Key="S5">Prašome spustelėti</sys:String>
-    <sys:String x:Key="S6">"Slėpti"</sys:String>
-    <sys:String x:Key="S7">norėdami paslėpti Tiesiogines antraštes, o ne uždaryti jas tiesiogiai.</sys:String>
-    <sys:String x:Key="S8">Rodyti</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Tiesioginės antraštės</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_Notice">Po Windows 11 24H2 versijos galite pakeisti tik</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Šaltinio kalbą</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">Tiesioginėse antraštėse.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Pastaba:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Prašome spustelėti</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Slėpti"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">norėdami paslėpti Tiesiogines antraštes, o ne uždaryti jas tiesiogiai.</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Slėpti</sys:String>
-    <sys:String x:Key="S46">Rodyti</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Rodyti</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Slėpti</sys:String>
 
-    <sys:String x:Key="S9">API intervalas</sys:String>
-    <sys:String x:Key="S10">Nustato vertimo API kvietimų dažnį. Mažesnė reikšmė reiškia dažnesnius kvietimus.</sys:String>
-    <sys:String x:Key="S11">Vertimo API kviečiama vieną kartą po antraštės pakeitimo</sys:String>
-    <sys:String x:Key="S12">[API intervalas]</sys:String>
-    <sys:String x:Key="S13">kartų.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API intervalas</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Nustato vertimo API kvietimų dažnį. Mažesnė reikšmė reiškia dažnesnius kvietimus.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">Vertimo API kviečiama vieną kartą po antraštės pakeitimo</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API intervalas]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">kartų.</sys:String>
 
-    <sys:String x:Key="S14">Vertimo API</sys:String>
-    <sys:String x:Key="S15">Išskyrus Google ir Google2, kitos API turi būti sukonfigūruotos prieš naudojimą.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">Vertimo API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Išskyrus Google ir Google2, kitos API turi būti sukonfigūruotos prieš naudojimą.</sys:String>
 
-    <sys:String x:Key="S16">Tikslinė kalba</sys:String>
-    <sys:String x:Key="S17">Norimos tikslinės kalbos nėra!</sys:String>
-    <sys:String x:Key="S18">Galite tiesiogiai redaguoti šio kombinuoto sąrašo turinį, kad pritaikytumėte kalbą; rekomenduojama naudoti</sys:String>
-    <sys:String x:Key="S19">BCP 47 kalbos žymą.</sys:String>
-    <sys:String x:Key="S20">Kai kurios API (pvz., DeepL) reikalauja kito būdo tikslinės kalbos nustatymui, žr. jų oficialią dokumentaciją.</sys:String>
-    <sys:String x:Key="S21">Įtrauktoms kalboms apie tai galvoti nereikia, bet jei norima kalba nėra sąraše, atsiminkite tai.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Tikslinė kalba</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Norimos tikslinės kalbos nėra!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Galite tiesiogiai redaguoti šio kombinuoto sąrašo turinį, kad pritaikytumėte kalbą; rekomenduojama naudoti</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47 kalbos žymą.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Kai kurios API (pvz., DeepL) reikalauja kito būdo tikslinės kalbos nustatymui, žr. jų oficialią dokumentaciją.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Įtrauktoms kalboms apie tai galvoti nereikia, bet jei norima kalba nėra sąraše, atsiminkite tai.</sys:String>
 
-    <sys:String x:Key="S22">API nustatymai</sys:String>
-    <sys:String x:Key="S23">Atidaryti</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API nustatymai</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Atidaryti</sys:String>
 
-    <sys:String x:Key="S24">Rodyti delsą</sys:String>
-    <sys:String x:Key="S25">Išjungta</sys:String>
-    <sys:String x:Key="S26">Įjungta</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Rodyti delsą</sys:String>
+    <sys:String x:Key="Common_Off">Išjungta</sys:String>
+    <sys:String x:Key="Common_On">Įjungta</sys:String>
 
-    <sys:String x:Key="S27">Kontekstai</sys:String>
-    <sys:String x:Key="S28">Kontekstai:</sys:String>
-    <sys:String x:Key="S29">Nustato kontekstinių sakinių skaičių, kai įjungtas</sys:String>
-    <sys:String x:Key="S30">Konteksto suvokimas</sys:String>
-    <sys:String x:Key="S31">.</sys:String>
-    <sys:String x:Key="S32">Peržiūros sakiniai:</sys:String>
-    <sys:String x:Key="S33">Nustato rodomų kortelių skaičių, kai įjungtas</sys:String>
-    <sys:String x:Key="S34">Žurnalo kortelės</sys:String>
-    <sys:String x:Key="S35">, taip pat maksimalų sakinių skaičių, rodomą peržiūros lange.</sys:String>
-    <sys:String x:Key="S36">Kontekstai turi būti</sys:String>
-    <sys:String x:Key="S37">didesni arba lygūs</sys:String>
-    <sys:String x:Key="S38">Peržiūros sakiniai</sys:String>
-    <sys:String x:Key="S39">. Jei nebus įvykdyta, programa automatiškai pakoreguos.</sys:String>
-    <sys:String x:Key="S40">Peržiūros sakiniai</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Kontekstai</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Kontekstai:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Nustato kontekstinių sakinių skaičių, kai įjungtas</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Konteksto suvokimas</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Peržiūros sakiniai:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Nustato rodomų kortelių skaičių, kai įjungtas</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Žurnalo kortelės</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">, taip pat maksimalų sakinių skaičių, rodomą peržiūros lange.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Kontekstai turi būti</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">didesni arba lygūs</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Peržiūros sakiniai</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Jei nebus įvykdyta, programa automatiškai pakoreguos.</sys:String>
 
-    <sys:String x:Key="S41">Versti kontekste.</sys:String>
-    <sys:String x:Key="S42">Tai gali pagerinti vertimo tikslumą, bet sunaudos daugiau žetonų.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Peržiūros sakiniai</sys:String>
 
-    <sys:String x:Key="S43">UI kalba</sys:String>
-    <sys:String x:Key="S44">Pasirinkite kalbą, kurią naudos programos vartotojo sąsaja.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Versti kontekste.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Tai gali pagerinti vertimo tikslumą, bet sunaudos daugiau žetonų.</sys:String>
+
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI kalba</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Pasirinkite kalbą, kurią naudos programos vartotojo sąsaja.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Pakeitimai įsigalioja iš karto ir automatiškai išsaugomi.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Ankstesnis</sys:String>
-    <sys:String x:Key="H1">Kitas puslapis</sys:String>
-    <sys:String x:Key="H2">Ieškoti</sys:String>
-    <sys:String x:Key="H3">Eksportuoti</sys:String>
-    <sys:String x:Key="H4">Ištrinti viską</sys:String>
-    <sys:String x:Key="H5">Atnaujinti</sys:String>
-    <sys:String x:Key="H6">Laikas</sys:String>
-    <sys:String x:Key="H7">Antraštė</sys:String>
-    <sys:String x:Key="H8">Išversta</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/puslapis</sys:String>
-    <sys:String x:Key="H11">30/puslapis</sys:String>
-    <sys:String x:Key="H12">50/puslapis</sys:String>
-    <sys:String x:Key="H13">100/puslapis</sys:String>
-    <sys:String x:Key="H20">Ar tikrai norite ištrinti visą istoriją?</sys:String>
-    <sys:String x:Key="H21">Šio veiksmo nebus galima atšaukti!</sys:String>
-    <sys:String x:Key="H22">Taip</sys:String>
-    <sys:String x:Key="H23">Ne</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Visi failai (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Išsaugota sėkmingai</sys:String>
-    <sys:String x:Key="H26">Failas išsaugotas: {0}</sys:String>
-    <sys:String x:Key="H27">Išsaugojimas nepavyko</sys:String>
-    <sys:String x:Key="H28">Failo išsaugojimas nepavyko: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Ankstesnis</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Kitas puslapis</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Ieškoti</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Eksportuoti</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Ištrinti viską</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Atnaujinti</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Laikas</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Antraštė</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Išversta</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/puslapis</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/puslapis</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/puslapis</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/puslapis</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Ar tikrai norite ištrinti visą istoriją?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Šio veiksmo nebus galima atšaukti!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Taip</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Ne</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Visi failai (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Išsaugota sėkmingai</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Failas išsaugotas: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Išsaugojimas nepavyko</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Failo išsaugojimas nepavyko: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Peržiūros langas</sys:String>
-    <sys:String x:Key="O1">Padidinti šrifto dydį</sys:String>
-    <sys:String x:Key="O2">Sumažinti šrifto dydį</sys:String>
-    <sys:String x:Key="O3">Padidinti šrifto kontūrą</sys:String>
-    <sys:String x:Key="O4">Sumažinti šrifto kontūrą</sys:String>
-    <sys:String x:Key="O5">Paryškintas</sys:String>
-    <sys:String x:Key="O6">Šrifto spalva</sys:String>
-    <sys:String x:Key="O7">Padidinti fono skaidrumą</sys:String>
-    <sys:String x:Key="O8">Sumažinti fono skaidrumą</sys:String>
-    <sys:String x:Key="O9">Fono spalva</sys:String>
-    <sys:String x:Key="O10">Rodyti tik subtitrus arba vertimus</sys:String>
-    <sys:String x:Key="O11">Keisti subtitrų/vertimo poziciją</sys:String>
-    <sys:String x:Key="O12">Spustelėjimo praleidimas</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Peržiūros langas</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Padidinti šrifto dydį</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Sumažinti šrifto dydį</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Padidinti šrifto kontūrą</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Sumažinti šrifto kontūrą</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Paryškintas</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Šrifto spalva</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Padidinti fono skaidrumą</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Sumažinti fono skaidrumą</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Fono spalva</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Rodyti tik subtitrus arba vertimus</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Keisti subtitrų/vertimo poziciją</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Spustelėjimo praleidimas</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Mes sveikiname bet kokį indėlį! Galite pateikti pasiūlymus ar pranešti apie klaidas per GitHub issues arba prisidėti prie kodo pateikdami Pull Request.</sys:String>
-    <sys:String x:Key="I1">Jei ši programa jums naudinga, apsvarstykite galimybę suteikti mums žvaigždutę!</sys:String>
-    <sys:String x:Key="I2">Saugykla:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Palaikytojas:</sys:String>
-    <sys:String x:Key="I5">(Autorius) ir</sys:String>
-    <sys:String x:Key="I6">Versija:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Mes sveikiname bet kokį indėlį! Galite pateikti pasiūlymus ar pranešti apie klaidas per GitHub issues arba prisidėti prie kodo pateikdami Pull Request.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Jei ši programa jums naudinga, apsvarstykite galimybę suteikti mums žvaigždutę!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Saugykla:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Palaikytojas:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Autorius) ir</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Versija:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Pradžia</sys:String>
-    <sys:String x:Key="W1">Sveiki atvykę į LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator pagrįstas Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Prieš pirmą kartą paleisdami, sukonfigūruokite pagal šiuos veiksmus:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Atidarykite Windows LiveCaptions ir sekite gido nurodymus atsisiųsti reikalingus vietinius kalbos atpažinimo failus ir kalbų paketus.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Spustelėkite</sys:String>
-    <sys:String x:Key="W6">⚙️ piktogramą</sys:String>
-    <sys:String x:Key="W7">Windows LiveCaptions nustatymuose ir pasirinkite</sys:String>
-    <sys:String x:Key="W8">"Pozicija &gt; Ant ekrano"</sys:String>
-    <sys:String x:Key="W9">3. Spustelėkite</sys:String>
-    <sys:String x:Key="W10">"Slėpti"</sys:String>
-    <sys:String x:Key="W11">mygtuką LiveCaptions Translator nustatymų puslapyje, kad paslėptumėte Windows LiveCaptions.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Programa automatiškai nukreipė jus į nustatymų puslapį ir atidarė Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Užbaigus konfigūraciją, galite grįžti į pagrindinį puslapį ir mėgautis realaus laiko garso vertimu.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;Daugiau informacijos rasite mūsų wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Patarimas:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Norėdami pakeisti </sys:String>
-    <sys:String x:Key="W18">Šaltinio kalbą</sys:String>
-    <sys:String x:Key="W19">, spustelėkite [Rodyti] nustatymų puslapyje ir padarykite tai Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">Aš visiškai supratau ir sukonfigūravau.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Pradėti</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Sveiki atvykę į LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator pagrįstas Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Prieš pirmą kartą paleisdami, sukonfigūruokite pagal šiuos veiksmus:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Atidarykite Windows LiveCaptions ir sekite gido nurodymus atsisiųsti reikalingus vietinius kalbos atpažinimo failus ir kalbų paketus.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Spustelėkite</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ piktogramą</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">Windows LiveCaptions nustatymuose ir pasirinkite</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Pozicija &gt; Ant ekrano"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Spustelėkite</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Slėpti"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">mygtuką LiveCaptions Translator nustatymų puslapyje, kad paslėptumėte Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Programa automatiškai nukreipė jus į nustatymų puslapį ir atidarė Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Užbaigus konfigūraciją, galite grįžti į pagrindinį puslapį ir mėgautis realaus laiko garso vertimu.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Daugiau informacijos rasite mūsų wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Patarimas:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Norėdami pakeisti </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Šaltinio kalbą</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, spustelėkite [Rodyti] nustatymų puslapyje ir padarykite tai Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Aš visiškai supratau ir sukonfigūravau.</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Antraštė</sys:String>
-    <sys:String x:Key="M11">Nustatymai</sys:String>
-    <sys:String x:Key="M12">Istorija</sys:String>
-    <sys:String x:Key="M13">Informacija</sys:String>
-    <sys:String x:Key="M20">Antraščių žurnalo kortelės</sys:String>
-    <sys:String x:Key="M21">Sustabdyti vertimą (tik žurnalas)</sys:String>
-    <sys:String x:Key="M22">Peržiūros langas</sys:String>
-    <sys:String x:Key="M23">Visada viršuje</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Antraščių žurnalo kortelės</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Sustabdyti vertimą (tik žurnalas)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Peržiūros langas</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Visada viršuje</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[KLAIDA] Atnaujinimo tikrinimas nepavyko.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">klaida</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Nauja versija pasiekiama</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Nustatyta nauja versija: {0} Dabartinė versija: {1} Atsisiųskite naujausią versiją iš GitHub.</sys:String>
 
-    <sys:String x:Key="MC0">[KLAIDA] Atnaujinimo tikrinimas nepavyko.</sys:String>
-    <sys:String x:Key="MC1">klaida</sys:String>
-    <sys:String x:Key="MC2">Nauja versija pasiekiama</sys:String>
-    <sys:String x:Key="MC3">Nustatyta nauja versija: {0}
-Dabartinė versija: {1}
-Atsisiųskite naujausią versiją iš GitHub.</sys:String>
-    <sys:String x:Key="MC4">Atnaujinti</sys:String>
-    <sys:String x:Key="MC5">Ignoruoti šią versiją</sys:String>
-    <sys:String x:Key="MC6">[KLAIDA] Naršyklės atidarymas nepavyko.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[ĮSPĖJIMAS] LiveCaptions buvo netikėtai uždaryta, paleidžiama iš naujo...</sys:String>
-    <sys:String x:Key="T1">[Sustabdyta]</sys:String>
-    <sys:String x:Key="T2">Klaida!</sys:String>
-    <sys:String x:Key="T3">Istorijos registravimas nepavyko: {0}</sys:String>
+    <!-- Translator strings -->
+    <sys:String x:Key="Translator_Status_Restarting">[ĮSPĖJIMAS] LiveCaptions buvo netikėtai uždaryta, paleidžiama iš naujo...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Sustabdyta]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Klaida!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Istorijos registravimas nepavyko: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Spustelėkite, kad nukopijuotumėte</sys:String>
-    <sys:String x:Key="C1">Nukopijuota</sys:String>
-    <sys:String x:Key="C2">Kopijavimas nepavyko</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Spustelėkite, kad nukopijuotumėte</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Nukopijuota</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Kopijavimas nepavyko</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/nl-nl.xaml
+++ b/src/localization/nl-nl.xaml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">LiveCaptions</sys:String>
+    <sys:String x:Key="S1">Na Windows 11 versie 24H2 kunt u alleen de</sys:String>
+    <sys:String x:Key="S2">Bron Taal</sys:String>
+    <sys:String x:Key="S3">in LiveCaptions wijzigen.</sys:String>
+    <sys:String x:Key="S4">Opmerking:</sys:String>
+    <sys:String x:Key="S5">Klik alstublieft</sys:String>
+    <sys:String x:Key="S6">"Verbergen"</sys:String>
+    <sys:String x:Key="S7">om LiveCaptions te verbergen in plaats van het direct te sluiten.</sys:String>
+
+    <sys:String x:Key="S8">Tonen</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Verbergen</sys:String>
+    <sys:String x:Key="S46">Tonen</sys:String>
+
+    <sys:String x:Key="S9">API-interval</sys:String>
+    <sys:String x:Key="S10">Bepaalt hoe vaak de vertaal-API wordt aangeroepen. Hoe kleiner, hoe vaker de oproepen.</sys:String>
+    <sys:String x:Key="S11">De vertaal-API wordt één keer aangeroepen nadat het onderschrift is gewijzigd</sys:String>
+    <sys:String x:Key="S12">[API-interval]</sys:String>
+    <sys:String x:Key="S13">keer.</sys:String>
+
+    <sys:String x:Key="S14">Vertaal-API</sys:String>
+    <sys:String x:Key="S15">Behalve Google en Google2, moeten alle andere API's worden geconfigureerd voordat ze gebruikt kunnen worden.</sys:String>
+
+    <sys:String x:Key="S16">Doeltaal</sys:String>
+    <sys:String x:Key="S17">De gewenste doeltaal is niet beschikbaar!</sys:String>
+    <sys:String x:Key="S18">U kunt de inhoud van dit keuzemenu direct bewerken om de taal aan te passen; het wordt aanbevolen de</sys:String>
+    <sys:String x:Key="S19">BCP 47-taalcode te volgen.</sys:String>
+    <sys:String x:Key="S20">Sommige API's (zoals DeepL) hebben een andere manier nodig om de doeltaal te definiëren; zie hun officiële documentatie voor details.</sys:String>
+    <sys:String x:Key="S21">Voor de ingebouwde doeltalen hoeft u hier geen rekening mee te houden. Als uw gewenste taal echter niet in de lijst staat, houd hier dan rekening mee.</sys:String>
+
+    <sys:String x:Key="S22">API-instellingen</sys:String>
+    <sys:String x:Key="S23">Openen</sys:String>
+
+    <sys:String x:Key="S24">Vertraging tonen</sys:String>
+    <sys:String x:Key="S25">Uit</sys:String>
+    <sys:String x:Key="S26">Aan</sys:String>
+
+    <sys:String x:Key="S27">Contexten</sys:String>
+    <sys:String x:Key="S28">Contexten:</sys:String>
+    <sys:String x:Key="S29">Bepaalt het aantal contextzinnen wanneer</sys:String>
+    <sys:String x:Key="S30">Contextbewust</sys:String>
+    <sys:String x:Key="S31">is ingeschakeld.</sys:String>
+    <sys:String x:Key="S32">Overlay-zinnen:</sys:String>
+    <sys:String x:Key="S33">Bepaalt het aantal weergegeven kaarten wanneer</sys:String>
+    <sys:String x:Key="S34">Logkaarten</sys:String>
+    <sys:String x:Key="S35">is ingeschakeld, evenals het maximum aantal zinnen dat in het overlay-venster wordt weergegeven.</sys:String>
+    <sys:String x:Key="S36">Contexten moeten</sys:String>
+    <sys:String x:Key="S37">groter dan of gelijk aan</sys:String>
+    <sys:String x:Key="S38">Weergavezinnen</sys:String>
+    <sys:String x:Key="S39">zijn. Zo niet, dan past het programma dit automatisch aan.</sys:String>
+    <sys:String x:Key="S40">Weergavezinnen</sys:String>
+
+    <sys:String x:Key="S41">Vertalen in context.</sys:String>
+    <sys:String x:Key="S42">Dit kan de vertaalsnelheid verbeteren, maar verbruikt meer tokens.</sys:String>
+
+    <sys:String x:Key="S43">UI-taal</sys:String>
+    <sys:String x:Key="S44">Selecteer de taal die door de gebruikersinterface van de applicatie wordt gebruikt.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Vorige</sys:String>
+    <sys:String x:Key="H1">Volgende pagina</sys:String>
+    <sys:String x:Key="H2">Zoeken</sys:String>
+    <sys:String x:Key="H3">Exporteren</sys:String>
+    <sys:String x:Key="H4">Alles verwijderen</sys:String>
+    <sys:String x:Key="H5">Vernieuwen</sys:String>
+    <sys:String x:Key="H6">Tijd</sys:String>
+    <sys:String x:Key="H7">Onderschrift</sys:String>
+    <sys:String x:Key="H8">Vertaald</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/pagina</sys:String>
+    <sys:String x:Key="H11">30/pagina</sys:String>
+    <sys:String x:Key="H12">50/pagina</sys:String>
+    <sys:String x:Key="H13">100/pagina</sys:String>
+    <sys:String x:Key="H20">Weet u zeker dat u alle geschiedenis wilt verwijderen?</sys:String>
+    <sys:String x:Key="H21">Deze actie kan niet ongedaan worden gemaakt!</sys:String>
+    <sys:String x:Key="H22">Ja</sys:String>
+    <sys:String x:Key="H23">Nee</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Alle bestanden (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Succesvol opgeslagen</sys:String>
+    <sys:String x:Key="H26">Bestand opgeslagen op: {0}</sys:String>
+    <sys:String x:Key="H27">Opslaan mislukt</sys:String>
+    <sys:String x:Key="H28">Bestand opslaan mislukt: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Overlay-venster</sys:String>
+    <sys:String x:Key="O1">Lettergrootte vergroten</sys:String>
+    <sys:String x:Key="O2">Lettergrootte verkleinen</sys:String>
+    <sys:String x:Key="O3">Letteromtrek vergroten</sys:String>
+    <sys:String x:Key="O4">Letteromtrek verkleinen</sys:String>
+    <sys:String x:Key="O5">Vet</sys:String>
+    <sys:String x:Key="O6">Letterkleur</sys:String>
+    <sys:String x:Key="O7">Achtergronddekking verhogen</sys:String>
+    <sys:String x:Key="O8">Achtergronddekking verlagen</sys:String>
+    <sys:String x:Key="O9">Achtergrondkleur</sys:String>
+    <sys:String x:Key="O10">Alleen ondertitels of vertalingen tonen</sys:String>
+    <sys:String x:Key="O11">Onder-/vertaling positie wisselen</sys:String>
+    <sys:String x:Key="O12">Doorklikken toestaan</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">We verwelkomen elke vorm van bijdrage! U kunt suggesties doen of bugs melden via GitHub issues, of rechtstreeks code bijdragen door Pull Requests in te dienen.</sys:String>
+    <sys:String x:Key="I1">Als dit programma nuttig voor u is, overweeg dan ons een ster te geven!</sys:String>
+    <sys:String x:Key="I2">Repository:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Onderhouder:</sys:String>
+    <sys:String x:Key="I5">(Auteur) en</sys:String>
+    <sys:String x:Key="I6">Versie:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Aan de slag</sys:String>
+    <sys:String x:Key="W1">Welkom bij LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator is gebaseerd op Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Voordat u het voor het eerst uitvoert, moet u het als volgt configureren:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Open Windows LiveCaptions en volg de gids om de benodigde bestanden voor on-device spraakherkenning en taalpakketten te downloaden.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Klik op</sys:String>
+    <sys:String x:Key="W6">⚙️ pictogram</sys:String>
+    <sys:String x:Key="W7">in Windows LiveCaptions instellingen en selecteer</sys:String>
+    <sys:String x:Key="W8">"Positie &gt; Over het scherm"</sys:String>
+    <sys:String x:Key="W9">3. Klik op</sys:String>
+    <sys:String x:Key="W10">"Verbergen"</sys:String>
+    <sys:String x:Key="W11">knop op de instellingenpagina van LiveCaptions Translator om Windows LiveCaptions te verbergen.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Het programma heeft automatisch naar de instellingenpagina genavigeerd en Windows LiveCaptions geopend.</sys:String>
+    <sys:String x:Key="W13">Na het voltooien van de configuratie kunt u terugkeren naar de hoofdpagina en genieten van realtime audiotranslatie.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;Voor meer details, bezoek onze wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Om de </sys:String>
+    <sys:String x:Key="W18">Bron Taal</sys:String>
+    <sys:String x:Key="W19">te wijzigen, klik op [Tonen] op de instellingenpagina en doe dit in Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">Ik heb het volledig begrepen en geconfigureerd.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Onderschrift</sys:String>
+    <sys:String x:Key="M11">Instellingen</sys:String>
+    <sys:String x:Key="M12">Geschiedenis</sys:String>
+    <sys:String x:Key="M13">Info</sys:String>
+    <sys:String x:Key="M20">Logkaarten van onderschriften</sys:String>
+    <sys:String x:Key="M21">Vertaling pauzeren (alleen log)</sys:String>
+    <sys:String x:Key="M22">Overlay-venster</sys:String>
+    <sys:String x:Key="M23">Altijd bovenaan</sys:String>
+
+    <sys:String x:Key="MC0">[FOUT] Updatecontrole mislukt.</sys:String>
+    <sys:String x:Key="MC1">fout</sys:String>
+    <sys:String x:Key="MC2">Nieuwe versie beschikbaar</sys:String>
+    <sys:String x:Key="MC3">Een nieuwe versie is gedetecteerd: {0}
+Huidige versie: {1}
+Bezoek GitHub om de nieuwste release te downloaden.</sys:String>
+    <sys:String x:Key="MC4">Bijwerken</sys:String>
+    <sys:String x:Key="MC5">Deze versie negeren</sys:String>
+    <sys:String x:Key="MC6">[FOUT] Browser openen mislukt.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[WAARSCHUWING] LiveCaptions is onverwacht afgesloten, wordt opnieuw gestart...</sys:String>
+    <sys:String x:Key="T1">[Gepauzeerd]</sys:String>
+    <sys:String x:Key="T2">Fout!</sys:String>
+    <sys:String x:Key="T3">Geschiedenislog mislukt: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Klik om te kopiëren</sys:String>
+    <sys:String x:Key="C1">Gekopieerd</sys:String>
+    <sys:String x:Key="C2">Kopiëren mislukt</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/nl-nl.xaml
+++ b/src/localization/nl-nl.xaml
@@ -3,168 +3,164 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">LiveCaptions</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">LiveCaptions</sys:String>
     <sys:String x:Key="S1">Na Windows 11 versie 24H2 kunt u alleen de</sys:String>
-    <sys:String x:Key="S2">Bron Taal</sys:String>
-    <sys:String x:Key="S3">in LiveCaptions wijzigen.</sys:String>
-    <sys:String x:Key="S4">Opmerking:</sys:String>
-    <sys:String x:Key="S5">Klik alstublieft</sys:String>
-    <sys:String x:Key="S6">"Verbergen"</sys:String>
-    <sys:String x:Key="S7">om LiveCaptions te verbergen in plaats van het direct te sluiten.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Bron Taal</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">in LiveCaptions wijzigen.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Opmerking:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Klik alstublieft</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Verbergen"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">om LiveCaptions te verbergen in plaats van het direct te sluiten.</sys:String>
 
-    <sys:String x:Key="S8">Tonen</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Tonen</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Verbergen</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Verbergen</sys:String>
-    <sys:String x:Key="S46">Tonen</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API-interval</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Bepaalt hoe vaak de vertaal-API wordt aangeroepen. Hoe kleiner, hoe vaker de oproepen.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">De vertaal-API wordt één keer aangeroepen nadat het onderschrift is gewijzigd</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API-interval]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">keer.</sys:String>
 
-    <sys:String x:Key="S9">API-interval</sys:String>
-    <sys:String x:Key="S10">Bepaalt hoe vaak de vertaal-API wordt aangeroepen. Hoe kleiner, hoe vaker de oproepen.</sys:String>
-    <sys:String x:Key="S11">De vertaal-API wordt één keer aangeroepen nadat het onderschrift is gewijzigd</sys:String>
-    <sys:String x:Key="S12">[API-interval]</sys:String>
-    <sys:String x:Key="S13">keer.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">Vertaal-API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Behalve Google en Google2, moeten alle andere API's worden geconfigureerd voordat ze gebruikt kunnen worden.</sys:String>
 
-    <sys:String x:Key="S14">Vertaal-API</sys:String>
-    <sys:String x:Key="S15">Behalve Google en Google2, moeten alle andere API's worden geconfigureerd voordat ze gebruikt kunnen worden.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Doeltaal</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">De gewenste doeltaal is niet beschikbaar!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">U kunt de inhoud van dit keuzemenu direct bewerken om de taal aan te passen; het wordt aanbevolen de</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47-taalcode te volgen.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Sommige API's (zoals DeepL) hebben een andere manier nodig om de doeltaal te definiëren; zie hun officiële documentatie voor details.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Voor de ingebouwde doeltalen hoeft u hier geen rekening mee te houden. Als uw gewenste taal echter niet in de lijst staat, houd hier dan rekening mee.</sys:String>
 
-    <sys:String x:Key="S16">Doeltaal</sys:String>
-    <sys:String x:Key="S17">De gewenste doeltaal is niet beschikbaar!</sys:String>
-    <sys:String x:Key="S18">U kunt de inhoud van dit keuzemenu direct bewerken om de taal aan te passen; het wordt aanbevolen de</sys:String>
-    <sys:String x:Key="S19">BCP 47-taalcode te volgen.</sys:String>
-    <sys:String x:Key="S20">Sommige API's (zoals DeepL) hebben een andere manier nodig om de doeltaal te definiëren; zie hun officiële documentatie voor details.</sys:String>
-    <sys:String x:Key="S21">Voor de ingebouwde doeltalen hoeft u hier geen rekening mee te houden. Als uw gewenste taal echter niet in de lijst staat, houd hier dan rekening mee.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API-instellingen</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Openen</sys:String>
 
-    <sys:String x:Key="S22">API-instellingen</sys:String>
-    <sys:String x:Key="S23">Openen</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Vertraging tonen</sys:String>
+    <sys:String x:Key="Common_Off">Uit</sys:String>
+    <sys:String x:Key="Common_On">Aan</sys:String>
 
-    <sys:String x:Key="S24">Vertraging tonen</sys:String>
-    <sys:String x:Key="S25">Uit</sys:String>
-    <sys:String x:Key="S26">Aan</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Contexten</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Contexten:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Bepaalt het aantal contextzinnen wanneer</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Contextbewust</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">is ingeschakeld.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Overlay-zinnen:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Bepaalt het aantal weergegeven kaarten wanneer</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Logkaarten</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">is ingeschakeld, evenals het maximum aantal zinnen dat in het overlay-venster wordt weergegeven.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Contexten moeten</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">groter dan of gelijk aan</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Weergavezinnen</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">zijn. Zo niet, dan past het programma dit automatisch aan.</sys:String>
 
-    <sys:String x:Key="S27">Contexten</sys:String>
-    <sys:String x:Key="S28">Contexten:</sys:String>
-    <sys:String x:Key="S29">Bepaalt het aantal contextzinnen wanneer</sys:String>
-    <sys:String x:Key="S30">Contextbewust</sys:String>
-    <sys:String x:Key="S31">is ingeschakeld.</sys:String>
-    <sys:String x:Key="S32">Overlay-zinnen:</sys:String>
-    <sys:String x:Key="S33">Bepaalt het aantal weergegeven kaarten wanneer</sys:String>
-    <sys:String x:Key="S34">Logkaarten</sys:String>
-    <sys:String x:Key="S35">is ingeschakeld, evenals het maximum aantal zinnen dat in het overlay-venster wordt weergegeven.</sys:String>
-    <sys:String x:Key="S36">Contexten moeten</sys:String>
-    <sys:String x:Key="S37">groter dan of gelijk aan</sys:String>
-    <sys:String x:Key="S38">Weergavezinnen</sys:String>
-    <sys:String x:Key="S39">zijn. Zo niet, dan past het programma dit automatisch aan.</sys:String>
-    <sys:String x:Key="S40">Weergavezinnen</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Weergavezinnen</sys:String>
 
-    <sys:String x:Key="S41">Vertalen in context.</sys:String>
-    <sys:String x:Key="S42">Dit kan de vertaalsnelheid verbeteren, maar verbruikt meer tokens.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Vertalen in context.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Dit kan de vertaalsnelheid verbeteren, maar verbruikt meer tokens.</sys:String>
 
-    <sys:String x:Key="S43">UI-taal</sys:String>
-    <sys:String x:Key="S44">Selecteer de taal die door de gebruikersinterface van de applicatie wordt gebruikt.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI-taal</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Selecteer de taal die door de gebruikersinterface van de applicatie wordt gebruikt.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Wijzigingen worden direct toegepast en automatisch opgeslagen.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Vorige</sys:String>
-    <sys:String x:Key="H1">Volgende pagina</sys:String>
-    <sys:String x:Key="H2">Zoeken</sys:String>
-    <sys:String x:Key="H3">Exporteren</sys:String>
-    <sys:String x:Key="H4">Alles verwijderen</sys:String>
-    <sys:String x:Key="H5">Vernieuwen</sys:String>
-    <sys:String x:Key="H6">Tijd</sys:String>
-    <sys:String x:Key="H7">Onderschrift</sys:String>
-    <sys:String x:Key="H8">Vertaald</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/pagina</sys:String>
-    <sys:String x:Key="H11">30/pagina</sys:String>
-    <sys:String x:Key="H12">50/pagina</sys:String>
-    <sys:String x:Key="H13">100/pagina</sys:String>
-    <sys:String x:Key="H20">Weet u zeker dat u alle geschiedenis wilt verwijderen?</sys:String>
-    <sys:String x:Key="H21">Deze actie kan niet ongedaan worden gemaakt!</sys:String>
-    <sys:String x:Key="H22">Ja</sys:String>
-    <sys:String x:Key="H23">Nee</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Alle bestanden (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Succesvol opgeslagen</sys:String>
-    <sys:String x:Key="H26">Bestand opgeslagen op: {0}</sys:String>
-    <sys:String x:Key="H27">Opslaan mislukt</sys:String>
-    <sys:String x:Key="H28">Bestand opslaan mislukt: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Vorige pagina</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Volgende pagina</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Zoeken</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Exporteren</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Alles verwijderen</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Vernieuwen</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Tijd</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Onderschrift</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Vertaald</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/pagina</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/pagina</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/pagina</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/pagina</sys:String>
+
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Weet u zeker dat u alle geschiedenis wilt verwijderen?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Deze actie kan niet ongedaan worden gemaakt!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Ja</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Nee</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Alle bestanden (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Succesvol opgeslagen</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Bestand opgeslagen op: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Opslaan mislukt</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Bestand opslaan mislukt: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Overlay-venster</sys:String>
-    <sys:String x:Key="O1">Lettergrootte vergroten</sys:String>
-    <sys:String x:Key="O2">Lettergrootte verkleinen</sys:String>
-    <sys:String x:Key="O3">Letteromtrek vergroten</sys:String>
-    <sys:String x:Key="O4">Letteromtrek verkleinen</sys:String>
-    <sys:String x:Key="O5">Vet</sys:String>
-    <sys:String x:Key="O6">Letterkleur</sys:String>
-    <sys:String x:Key="O7">Achtergronddekking verhogen</sys:String>
-    <sys:String x:Key="O8">Achtergronddekking verlagen</sys:String>
-    <sys:String x:Key="O9">Achtergrondkleur</sys:String>
-    <sys:String x:Key="O10">Alleen ondertitels of vertalingen tonen</sys:String>
-    <sys:String x:Key="O11">Onder-/vertaling positie wisselen</sys:String>
-    <sys:String x:Key="O12">Doorklikken toestaan</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Overlay-venster</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Lettergrootte vergroten</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Lettergrootte verkleinen</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Letteromtrek vergroten</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Letteromtrek verkleinen</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Vet</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Letterkleur</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Achtergronddekking verhogen</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Achtergronddekking verlagen</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Achtergrondkleur</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Alleen ondertitels of vertalingen tonen</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Onder-/vertaling positie wisselen</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Doorklikken toestaan</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">We verwelkomen elke vorm van bijdrage! U kunt suggesties doen of bugs melden via GitHub issues, of rechtstreeks code bijdragen door Pull Requests in te dienen.</sys:String>
-    <sys:String x:Key="I1">Als dit programma nuttig voor u is, overweeg dan ons een ster te geven!</sys:String>
-    <sys:String x:Key="I2">Repository:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Onderhouder:</sys:String>
-    <sys:String x:Key="I5">(Auteur) en</sys:String>
-    <sys:String x:Key="I6">Versie:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">We verwelkomen elke vorm van bijdrage! U kunt suggesties doen of bugs melden via GitHub issues, of rechtstreeks code bijdragen door Pull Requests in te dienen.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Als dit programma nuttig voor u is, overweeg dan ons een ster te geven!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repository:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Onderhouder:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Auteur) en</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Versie:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Aan de slag</sys:String>
-    <sys:String x:Key="W1">Welkom bij LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator is gebaseerd op Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Voordat u het voor het eerst uitvoert, moet u het als volgt configureren:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Open Windows LiveCaptions en volg de gids om de benodigde bestanden voor on-device spraakherkenning en taalpakketten te downloaden.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Klik op</sys:String>
-    <sys:String x:Key="W6">⚙️ pictogram</sys:String>
-    <sys:String x:Key="W7">in Windows LiveCaptions instellingen en selecteer</sys:String>
-    <sys:String x:Key="W8">"Positie &gt; Over het scherm"</sys:String>
-    <sys:String x:Key="W9">3. Klik op</sys:String>
-    <sys:String x:Key="W10">"Verbergen"</sys:String>
-    <sys:String x:Key="W11">knop op de instellingenpagina van LiveCaptions Translator om Windows LiveCaptions te verbergen.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Het programma heeft automatisch naar de instellingenpagina genavigeerd en Windows LiveCaptions geopend.</sys:String>
-    <sys:String x:Key="W13">Na het voltooien van de configuratie kunt u terugkeren naar de hoofdpagina en genieten van realtime audiotranslatie.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;Voor meer details, bezoek onze wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Om de </sys:String>
-    <sys:String x:Key="W18">Bron Taal</sys:String>
-    <sys:String x:Key="W19">te wijzigen, klik op [Tonen] op de instellingenpagina en doe dit in Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">Ik heb het volledig begrepen en geconfigureerd.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Aan de slag</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Welkom bij LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator is gebaseerd op Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Voordat u het voor het eerst uitvoert, moet u het als volgt configureren:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Open Windows LiveCaptions en volg de gids om de benodigde bestanden voor on-device spraakherkenning en taalpakketten te downloaden.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Klik op</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ pictogram</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">in Windows LiveCaptions instellingen en selecteer</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Positie &gt; Over het scherm"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Klik op</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Verbergen"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">knop op de instellingenpagina van LiveCaptions Translator om Windows LiveCaptions te verbergen.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Het programma heeft automatisch naar de instellingenpagina genavigeerd en Windows LiveCaptions geopend.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Na het voltooien van de configuratie kunt u terugkeren naar de hoofdpagina en genieten van realtime audiotranslatie.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Voor meer details, bezoek onze wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Tip:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Om de </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Bron Taal</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">te wijzigen, klik op [Tonen] op de instellingenpagina en doe dit in Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Ik heb het volledig begrepen en geconfigureerd.</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="Navigation_Captions">Onderschrift</sys:String>
+    <sys:String x:Key="Navigation_Settings">Instellingen</sys:String>
+    <sys:String x:Key="Navigation_History">Geschiedenis</sys:String>
+    <sys:String x:Key="Navigation_Info">Info</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Onderschrift</sys:String>
-    <sys:String x:Key="M11">Instellingen</sys:String>
-    <sys:String x:Key="M12">Geschiedenis</sys:String>
-    <sys:String x:Key="M13">Info</sys:String>
-    <sys:String x:Key="M20">Logkaarten van onderschriften</sys:String>
-    <sys:String x:Key="M21">Vertaling pauzeren (alleen log)</sys:String>
-    <sys:String x:Key="M22">Overlay-venster</sys:String>
-    <sys:String x:Key="M23">Altijd bovenaan</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Logkaarten van onderschriften</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Vertaling pauzeren (alleen log)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Overlay-venster</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Altijd bovenaan</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[FOUT] Updatecontrole mislukt.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">fout</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Nieuwe versie beschikbaar</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Een nieuwe versie is gedetecteerd: {0} Huidige versie: {1} Bezoek GitHub om de nieuwste release te downloaden.</sys:String>
 
-    <sys:String x:Key="MC0">[FOUT] Updatecontrole mislukt.</sys:String>
-    <sys:String x:Key="MC1">fout</sys:String>
-    <sys:String x:Key="MC2">Nieuwe versie beschikbaar</sys:String>
-    <sys:String x:Key="MC3">Een nieuwe versie is gedetecteerd: {0}
-Huidige versie: {1}
-Bezoek GitHub om de nieuwste release te downloaden.</sys:String>
-    <sys:String x:Key="MC4">Bijwerken</sys:String>
-    <sys:String x:Key="MC5">Deze versie negeren</sys:String>
-    <sys:String x:Key="MC6">[FOUT] Browser openen mislukt.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[WAARSCHUWING] LiveCaptions is onverwacht afgesloten, wordt opnieuw gestart...</sys:String>
-    <sys:String x:Key="T1">[Gepauzeerd]</sys:String>
-    <sys:String x:Key="T2">Fout!</sys:String>
-    <sys:String x:Key="T3">Geschiedenislog mislukt: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[WAARSCHUWING] LiveCaptions is onverwacht afgesloten, wordt opnieuw gestart...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Gepauzeerd]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Fout!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Geschiedenislog mislukt: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Klik om te kopiëren</sys:String>
-    <sys:String x:Key="C1">Gekopieerd</sys:String>
-    <sys:String x:Key="C2">Kopiëren mislukt</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Klik om te kopiëren</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Gekopieerd</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Kopiëren mislukt</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/pl-pl.xaml
+++ b/src/localization/pl-pl.xaml
@@ -3,169 +3,163 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Napisy na żywo</sys:String>
-    <sys:String x:Key="S1">Po wersji Windows 11 24H2 można zmienić tylko</sys:String>
-    <sys:String x:Key="S2">Język źródłowy</sys:String>
-    <sys:String x:Key="S3">w Napisy na żywo.</sys:String>
-    <sys:String x:Key="S4">Uwaga:</sys:String>
-    <sys:String x:Key="S5">Proszę kliknąć</sys:String>
-    <sys:String x:Key="S6">"Ukryj"</sys:String>
-    <sys:String x:Key="S7">aby ukryć Napisy na żywo, zamiast zamykać je bezpośrednio.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Napisy na żywo</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Język źródłowy</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">w Napisy na żywo.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Uwaga:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Proszę kliknąć</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Ukryj"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">aby ukryć Napisy na żywo, zamiast zamykać je bezpośrednio.</sys:String>
 
-    <sys:String x:Key="S8">Pokaż</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Pokaż</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Ukryj</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Ukryj</sys:String>
-    <sys:String x:Key="S46">Pokaż</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Interwał API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Określa częstotliwość wywołań API tłumaczenia. Im mniejsza wartość, tym częstsze wywołania.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">API tłumaczenia wywoływane jest raz po zmianie napisu</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Interwał API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">razy.</sys:String>
 
-    <sys:String x:Key="S9">Interwał API</sys:String>
-    <sys:String x:Key="S10">Określa częstotliwość wywołań API tłumaczenia. Im mniejsza wartość, tym częstsze wywołania.</sys:String>
-    <sys:String x:Key="S11">API tłumaczenia wywoływane jest raz po zmianie napisu</sys:String>
-    <sys:String x:Key="S12">[Interwał API]</sys:String>
-    <sys:String x:Key="S13">razy.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">API tłumaczenia</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Poza Google i Google2, wszystkie inne API wymagają konfiguracji przed użyciem.</sys:String>
 
-    <sys:String x:Key="S14">API tłumaczenia</sys:String>
-    <sys:String x:Key="S15">Poza Google i Google2, wszystkie inne API wymagają konfiguracji przed użyciem.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Język docelowy</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Nie ma oczekiwanego języka docelowego!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Możesz bezpośrednio edytować zawartość tego pola kombi, aby dostosować język; zaleca się stosowanie</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">tagu językowego BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Niektóre API (np. DeepL) wymagają innego sposobu określenia języka docelowego; zobacz ich dokumentację.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Nie trzeba o tym myśleć dla wbudowanych języków docelowych, ponieważ mamy mapowanie tagów. Jeśli oczekiwany język nie znajduje się na liście, miej to na uwadze.</sys:String>
 
-    <sys:String x:Key="S16">Język docelowy</sys:String>
-    <sys:String x:Key="S17">Nie ma oczekiwanego języka docelowego!</sys:String>
-    <sys:String x:Key="S18">Możesz bezpośrednio edytować zawartość tego pola kombi, aby dostosować język; zaleca się stosowanie</sys:String>
-    <sys:String x:Key="S19">tagu językowego BCP 47.</sys:String>
-    <sys:String x:Key="S20">Niektóre API (np. DeepL) wymagają innego sposobu określenia języka docelowego; zobacz ich dokumentację.</sys:String>
-    <sys:String x:Key="S21">Nie trzeba o tym myśleć dla wbudowanych języków docelowych, ponieważ mamy mapowanie tagów. Jeśli oczekiwany język nie znajduje się na liście, miej to na uwadze.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Ustawienia API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Otwórz</sys:String>
 
-    <sys:String x:Key="S22">Ustawienia API</sys:String>
-    <sys:String x:Key="S23">Otwórz</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Pokaż opóźnienie</sys:String>
+    <sys:String x:Key="Common_Off">Wyłączone</sys:String>
+    <sys:String x:Key="Common_On">Włączone</sys:String>
 
-    <sys:String x:Key="S24">Pokaż opóźnienie</sys:String>
-    <sys:String x:Key="S25">Wyłączone</sys:String>
-    <sys:String x:Key="S26">Włączone</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Konteksty</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Konteksty:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Określa liczbę zdań kontekstowych, gdy</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Świadomość kontekstu</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">jest włączona.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Zdania w nakładce:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Określa liczbę wyświetlanych kart, gdy</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Karty logów</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">są włączone, a także maksymalną liczbę zdań wyświetlanych w oknie nakładki.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Konteksty muszą być</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">większe lub równe</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Wyświetlane zdania</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Jeśli nie, program dostosuje je automatycznie.</sys:String>
 
-    <sys:String x:Key="S27">Konteksty</sys:String>
-    <sys:String x:Key="S28">Konteksty:</sys:String>
-    <sys:String x:Key="S29">Określa liczbę zdań kontekstowych, gdy</sys:String>
-    <sys:String x:Key="S30">Świadomość kontekstu</sys:String>
-    <sys:String x:Key="S31">jest włączona.</sys:String>
-    <sys:String x:Key="S32">Zdania w nakładce:</sys:String>
-    <sys:String x:Key="S33">Określa liczbę wyświetlanych kart, gdy</sys:String>
-    <sys:String x:Key="S34">Karty logów</sys:String>
-    <sys:String x:Key="S35">są włączone, a także maksymalną liczbę zdań wyświetlanych w oknie nakładki.</sys:String>
-    <sys:String x:Key="S36">Konteksty muszą być</sys:String>
-    <sys:String x:Key="S37">większe lub równe</sys:String>
-    <sys:String x:Key="S38">Wyświetlane zdania</sys:String>
-    <sys:String x:Key="S39">. Jeśli nie, program dostosuje je automatycznie.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Wyświetlane zdania</sys:String>
 
-    <sys:String x:Key="S40">Wyświetlane zdania</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Tłumaczenie w kontekście.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Może to poprawić dokładność tłumaczenia, ale zużywa więcej tokenów.</sys:String>
 
-    <sys:String x:Key="S41">Tłumaczenie w kontekście.</sys:String>
-    <sys:String x:Key="S42">Może to poprawić dokładność tłumaczenia, ale zużywa więcej tokenów.</sys:String>
-
-    <sys:String x:Key="S43">Język UI</sys:String>
-    <sys:String x:Key="S44">Wybierz język używany przez interfejs aplikacji.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Język UI</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Wybierz język używany przez interfejs aplikacji.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Zmiany są zapisywane automatycznie i natychmiast stosowane.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Poprzednia</sys:String>
-    <sys:String x:Key="H1">Następna strona</sys:String>
-    <sys:String x:Key="H2">Szukaj</sys:String>
-    <sys:String x:Key="H3">Eksportuj</sys:String>
-    <sys:String x:Key="H4">Usuń wszystko</sys:String>
-    <sys:String x:Key="H5">Odśwież</sys:String>
-    <sys:String x:Key="H6">Czas</sys:String>
-    <sys:String x:Key="H7">Napisy</sys:String>
-    <sys:String x:Key="H8">Przetłumaczone</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/strona</sys:String>
-    <sys:String x:Key="H11">30/strona</sys:String>
-    <sys:String x:Key="H12">50/strona</sys:String>
-    <sys:String x:Key="H13">100/strona</sys:String>
-    <sys:String x:Key="H20">Czy na pewno chcesz usunąć całą historię?</sys:String>
-    <sys:String x:Key="H21">Ta operacja nie może zostać cofnięta!</sys:String>
-    <sys:String x:Key="H22">Tak</sys:String>
-    <sys:String x:Key="H23">Nie</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Wszystkie pliki (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Zapisano pomyślnie</sys:String>
-    <sys:String x:Key="H26">Plik zapisano do: {0}</sys:String>
-    <sys:String x:Key="H27">Zapis nie powiódł się</sys:String>
-    <sys:String x:Key="H28">Nie udało się zapisać pliku: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Poprzednia</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Następna strona</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Szukaj</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Eksportuj</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Usuń wszystko</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Odśwież</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Czas</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Napisy</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Przetłumaczone</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/strona</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/strona</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/strona</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/strona</sys:String>
+
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Czy na pewno chcesz usunąć całą historię?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Ta operacja nie może zostać cofnięta!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Tak</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Nie</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Wszystkie pliki (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Zapisano pomyślnie</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Plik zapisano do: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Zapis nie powiódł się</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Nie udało się zapisać pliku: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Okno nakładki</sys:String>
-    <sys:String x:Key="O1">Zwiększ rozmiar czcionki</sys:String>
-    <sys:String x:Key="O2">Zmniejsz rozmiar czcionki</sys:String>
-    <sys:String x:Key="O3">Zwiększ kontur czcionki</sys:String>
-    <sys:String x:Key="O4">Zmniejsz kontur czcionki</sys:String>
-    <sys:String x:Key="O5">Pogrubienie</sys:String>
-    <sys:String x:Key="O6">Kolor czcionki</sys:String>
-    <sys:String x:Key="O7">Zwiększ przezroczystość tła</sys:String>
-    <sys:String x:Key="O8">Zmniejsz przezroczystość tła</sys:String>
-    <sys:String x:Key="O9">Kolor tła</sys:String>
-    <sys:String x:Key="O10">Pokaż tylko napisy lub tłumaczenia</sys:String>
-    <sys:String x:Key="O11">Zmień pozycję napisu/tłumaczenia</sys:String>
-    <sys:String x:Key="O12">Klikalność w tle</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Okno nakładki</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Zwiększ rozmiar czcionki</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Zmniejsz rozmiar czcionki</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Zwiększ kontur czcionki</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Zmniejsz kontur czcionki</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Pogrubienie</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Kolor czcionki</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Zwiększ przezroczystość tła</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Zmniejsz przezroczystość tła</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Kolor tła</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Pokaż tylko napisy lub tłumaczenia</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Zmień pozycję napisu/tłumaczenia</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Klikalność w tle</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Witamy każdą formę wkładu! Możesz zgłaszać sugestie lub błędy przez GitHub issues lub przesyłać kod przez Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Jeśli program jest dla Ciebie pomocny, rozważ wystawienie nam gwiazdki!</sys:String>
-    <sys:String x:Key="I2">Repozytorium:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Opiekun:</sys:String>
-    <sys:String x:Key="I5">(Autor) i</sys:String>
-    <sys:String x:Key="I6">Wersja:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Witamy każdą formę wkładu! Możesz zgłaszać sugestie lub błędy przez GitHub issues lub przesyłać kod przez Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Jeśli program jest dla Ciebie pomocny, rozważ wystawienie nam gwiazdki!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repozytorium:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Opiekun:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Autor) i</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Wersja:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Rozpoczęcie</sys:String>
-    <sys:String x:Key="W1">Witamy w LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator opiera się na Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Przed pierwszym uruchomieniem należy skonfigurować program według poniższych kroków:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Otwórz Windows LiveCaptions i postępuj zgodnie z instrukcją, aby pobrać potrzebne pliki rozpoznawania mowy i pakiety językowe.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Kliknij</sys:String>
-    <sys:String x:Key="W6">⚙️ ikonę</sys:String>
-    <sys:String x:Key="W7">w Windows LiveCaptions, aby otworzyć ustawienia, i wybierz</sys:String>
-    <sys:String x:Key="W8">"Pozycja &gt; Na ekranie"</sys:String>
-    <sys:String x:Key="W9">3. Kliknij</sys:String>
-    <sys:String x:Key="W10">"Ukryj"</sys:String>
-    <sys:String x:Key="W11">przycisk na stronie ustawień LiveCaptions Translator, aby ukryć Windows LiveCaptions.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Program automatycznie przeszedł do strony ustawień i otworzył Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Po zakończeniu konfiguracji możesz wrócić do strony głównej i cieszyć się tłumaczeniem w czasie rzeczywistym.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;Więcej informacji znajdziesz w naszej wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Wskazówka:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Aby zmienić </sys:String>
-    <sys:String x:Key="W18">Język źródłowy</sys:String>
-    <sys:String x:Key="W19">, kliknij [Pokaż] na stronie ustawień i zrób to w Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">W pełni zrozumiałem i skonfigurowałem.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Rozpocznij</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Witamy w LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator opiera się na Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Przed pierwszym uruchomieniem należy skonfigurować program według poniższych kroków:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Otwórz Windows LiveCaptions i postępuj zgodnie z instrukcją, aby pobrać potrzebne pliki rozpoznawania mowy i pakiety językowe.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Kliknij</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ ikonę</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">w Windows LiveCaptions, aby otworzyć ustawienia, i wybierz</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Pozycja &gt; Na ekranie"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Kliknij</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Ukryj"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">przycisk na stronie ustawień LiveCaptions Translator, aby ukryć Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Program automatycznie przeszedł do strony ustawień i otworzył Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Po zakończeniu konfiguracji możesz wrócić do strony głównej i cieszyć się tłumaczeniem w czasie rzeczywistym.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Więcej informacji znajdziesz w naszej wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Wskazówka:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Aby zmienić </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Język źródłowy</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, kliknij [Pokaż] na stronie ustawień i zrób to w Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">W pełni zrozumiałem i skonfigurowałem.</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="Navigation_Captions">Napisy</sys:String>
+    <sys:String x:Key="Navigation_Settings">Ustawienia</sys:String>
+    <sys:String x:Key="Navigation_History">Historia</sys:String>
+    <sys:String x:Key="Navigation_Info">Info</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Napisy</sys:String>
-    <sys:String x:Key="M11">Ustawienia</sys:String>
-    <sys:String x:Key="M12">Historia</sys:String>
-    <sys:String x:Key="M13">Info</sys:String>
-    <sys:String x:Key="M20">Karty logów napisów</sys:String>
-    <sys:String x:Key="M21">Pauza tłumaczenia (tylko log)</sys:String>
-    <sys:String x:Key="M22">Okno nakładki</sys:String>
-    <sys:String x:Key="M23">Zawsze na wierzchu</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Karty logów napisów</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pauza tłumaczenia (tylko log)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Okno nakładki</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Zawsze na wierzchu</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[BŁĄD] Sprawdzenie aktualizacji nie powiodło się.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">błąd</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Dostępna nowa wersja</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Wykryto nową wersję: {0} Obecna wersja: {1} Odwiedź GitHub, aby pobrać najnowsze wydanie.</sys:String>
 
-    <sys:String x:Key="MC0">[BŁĄD] Sprawdzenie aktualizacji nie powiodło się.</sys:String>
-    <sys:String x:Key="MC1">błąd</sys:String>
-    <sys:String x:Key="MC2">Dostępna nowa wersja</sys:String>
-    <sys:String x:Key="MC3">Wykryto nową wersję: {0}
-Obecna wersja: {1}
-Odwiedź GitHub, aby pobrać najnowsze wydanie.</sys:String>
-    <sys:String x:Key="MC4">Aktualizuj</sys:String>
-    <sys:String x:Key="MC5">Ignoruj tę wersję</sys:String>
-    <sys:String x:Key="MC6">[BŁĄD] Nie udało się otworzyć przeglądarki.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[OSTRZEŻENIE] LiveCaptions został niespodziewanie zamknięty, ponowne uruchamianie...</sys:String>
-    <sys:String x:Key="T1">[Pauza]</sys:String>
-    <sys:String x:Key="T2">Błąd!</sys:String>
-    <sys:String x:Key="T3">Rejestrowanie historii nie powiodło się: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[OSTRZEŻENIE] LiveCaptions został niespodziewanie zamknięty, ponowne uruchamianie...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Pauza]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Błąd!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Rejestrowanie historii nie powiodło się: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Kliknij, aby skopiować</sys:String>
-    <sys:String x:Key="C1">Skopiowano</sys:String>
-    <sys:String x:Key="C2">Kopiowanie nie powiodło się</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Kliknij, aby skopiować</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Skopiowano</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Kopiowanie nie powiodło się</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/pl-pl.xaml
+++ b/src/localization/pl-pl.xaml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Napisy na żywo</sys:String>
+    <sys:String x:Key="S1">Po wersji Windows 11 24H2 można zmienić tylko</sys:String>
+    <sys:String x:Key="S2">Język źródłowy</sys:String>
+    <sys:String x:Key="S3">w Napisy na żywo.</sys:String>
+    <sys:String x:Key="S4">Uwaga:</sys:String>
+    <sys:String x:Key="S5">Proszę kliknąć</sys:String>
+    <sys:String x:Key="S6">"Ukryj"</sys:String>
+    <sys:String x:Key="S7">aby ukryć Napisy na żywo, zamiast zamykać je bezpośrednio.</sys:String>
+
+    <sys:String x:Key="S8">Pokaż</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Ukryj</sys:String>
+    <sys:String x:Key="S46">Pokaż</sys:String>
+
+    <sys:String x:Key="S9">Interwał API</sys:String>
+    <sys:String x:Key="S10">Określa częstotliwość wywołań API tłumaczenia. Im mniejsza wartość, tym częstsze wywołania.</sys:String>
+    <sys:String x:Key="S11">API tłumaczenia wywoływane jest raz po zmianie napisu</sys:String>
+    <sys:String x:Key="S12">[Interwał API]</sys:String>
+    <sys:String x:Key="S13">razy.</sys:String>
+
+    <sys:String x:Key="S14">API tłumaczenia</sys:String>
+    <sys:String x:Key="S15">Poza Google i Google2, wszystkie inne API wymagają konfiguracji przed użyciem.</sys:String>
+
+    <sys:String x:Key="S16">Język docelowy</sys:String>
+    <sys:String x:Key="S17">Nie ma oczekiwanego języka docelowego!</sys:String>
+    <sys:String x:Key="S18">Możesz bezpośrednio edytować zawartość tego pola kombi, aby dostosować język; zaleca się stosowanie</sys:String>
+    <sys:String x:Key="S19">tagu językowego BCP 47.</sys:String>
+    <sys:String x:Key="S20">Niektóre API (np. DeepL) wymagają innego sposobu określenia języka docelowego; zobacz ich dokumentację.</sys:String>
+    <sys:String x:Key="S21">Nie trzeba o tym myśleć dla wbudowanych języków docelowych, ponieważ mamy mapowanie tagów. Jeśli oczekiwany język nie znajduje się na liście, miej to na uwadze.</sys:String>
+
+    <sys:String x:Key="S22">Ustawienia API</sys:String>
+    <sys:String x:Key="S23">Otwórz</sys:String>
+
+    <sys:String x:Key="S24">Pokaż opóźnienie</sys:String>
+    <sys:String x:Key="S25">Wyłączone</sys:String>
+    <sys:String x:Key="S26">Włączone</sys:String>
+
+    <sys:String x:Key="S27">Konteksty</sys:String>
+    <sys:String x:Key="S28">Konteksty:</sys:String>
+    <sys:String x:Key="S29">Określa liczbę zdań kontekstowych, gdy</sys:String>
+    <sys:String x:Key="S30">Świadomość kontekstu</sys:String>
+    <sys:String x:Key="S31">jest włączona.</sys:String>
+    <sys:String x:Key="S32">Zdania w nakładce:</sys:String>
+    <sys:String x:Key="S33">Określa liczbę wyświetlanych kart, gdy</sys:String>
+    <sys:String x:Key="S34">Karty logów</sys:String>
+    <sys:String x:Key="S35">są włączone, a także maksymalną liczbę zdań wyświetlanych w oknie nakładki.</sys:String>
+    <sys:String x:Key="S36">Konteksty muszą być</sys:String>
+    <sys:String x:Key="S37">większe lub równe</sys:String>
+    <sys:String x:Key="S38">Wyświetlane zdania</sys:String>
+    <sys:String x:Key="S39">. Jeśli nie, program dostosuje je automatycznie.</sys:String>
+
+    <sys:String x:Key="S40">Wyświetlane zdania</sys:String>
+
+    <sys:String x:Key="S41">Tłumaczenie w kontekście.</sys:String>
+    <sys:String x:Key="S42">Może to poprawić dokładność tłumaczenia, ale zużywa więcej tokenów.</sys:String>
+
+    <sys:String x:Key="S43">Język UI</sys:String>
+    <sys:String x:Key="S44">Wybierz język używany przez interfejs aplikacji.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Poprzednia</sys:String>
+    <sys:String x:Key="H1">Następna strona</sys:String>
+    <sys:String x:Key="H2">Szukaj</sys:String>
+    <sys:String x:Key="H3">Eksportuj</sys:String>
+    <sys:String x:Key="H4">Usuń wszystko</sys:String>
+    <sys:String x:Key="H5">Odśwież</sys:String>
+    <sys:String x:Key="H6">Czas</sys:String>
+    <sys:String x:Key="H7">Napisy</sys:String>
+    <sys:String x:Key="H8">Przetłumaczone</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/strona</sys:String>
+    <sys:String x:Key="H11">30/strona</sys:String>
+    <sys:String x:Key="H12">50/strona</sys:String>
+    <sys:String x:Key="H13">100/strona</sys:String>
+    <sys:String x:Key="H20">Czy na pewno chcesz usunąć całą historię?</sys:String>
+    <sys:String x:Key="H21">Ta operacja nie może zostać cofnięta!</sys:String>
+    <sys:String x:Key="H22">Tak</sys:String>
+    <sys:String x:Key="H23">Nie</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Wszystkie pliki (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Zapisano pomyślnie</sys:String>
+    <sys:String x:Key="H26">Plik zapisano do: {0}</sys:String>
+    <sys:String x:Key="H27">Zapis nie powiódł się</sys:String>
+    <sys:String x:Key="H28">Nie udało się zapisać pliku: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Okno nakładki</sys:String>
+    <sys:String x:Key="O1">Zwiększ rozmiar czcionki</sys:String>
+    <sys:String x:Key="O2">Zmniejsz rozmiar czcionki</sys:String>
+    <sys:String x:Key="O3">Zwiększ kontur czcionki</sys:String>
+    <sys:String x:Key="O4">Zmniejsz kontur czcionki</sys:String>
+    <sys:String x:Key="O5">Pogrubienie</sys:String>
+    <sys:String x:Key="O6">Kolor czcionki</sys:String>
+    <sys:String x:Key="O7">Zwiększ przezroczystość tła</sys:String>
+    <sys:String x:Key="O8">Zmniejsz przezroczystość tła</sys:String>
+    <sys:String x:Key="O9">Kolor tła</sys:String>
+    <sys:String x:Key="O10">Pokaż tylko napisy lub tłumaczenia</sys:String>
+    <sys:String x:Key="O11">Zmień pozycję napisu/tłumaczenia</sys:String>
+    <sys:String x:Key="O12">Klikalność w tle</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Witamy każdą formę wkładu! Możesz zgłaszać sugestie lub błędy przez GitHub issues lub przesyłać kod przez Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Jeśli program jest dla Ciebie pomocny, rozważ wystawienie nam gwiazdki!</sys:String>
+    <sys:String x:Key="I2">Repozytorium:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Opiekun:</sys:String>
+    <sys:String x:Key="I5">(Autor) i</sys:String>
+    <sys:String x:Key="I6">Wersja:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Rozpoczęcie</sys:String>
+    <sys:String x:Key="W1">Witamy w LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator opiera się na Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Przed pierwszym uruchomieniem należy skonfigurować program według poniższych kroków:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Otwórz Windows LiveCaptions i postępuj zgodnie z instrukcją, aby pobrać potrzebne pliki rozpoznawania mowy i pakiety językowe.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Kliknij</sys:String>
+    <sys:String x:Key="W6">⚙️ ikonę</sys:String>
+    <sys:String x:Key="W7">w Windows LiveCaptions, aby otworzyć ustawienia, i wybierz</sys:String>
+    <sys:String x:Key="W8">"Pozycja &gt; Na ekranie"</sys:String>
+    <sys:String x:Key="W9">3. Kliknij</sys:String>
+    <sys:String x:Key="W10">"Ukryj"</sys:String>
+    <sys:String x:Key="W11">przycisk na stronie ustawień LiveCaptions Translator, aby ukryć Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Program automatycznie przeszedł do strony ustawień i otworzył Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Po zakończeniu konfiguracji możesz wrócić do strony głównej i cieszyć się tłumaczeniem w czasie rzeczywistym.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;Więcej informacji znajdziesz w naszej wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Wskazówka:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Aby zmienić </sys:String>
+    <sys:String x:Key="W18">Język źródłowy</sys:String>
+    <sys:String x:Key="W19">, kliknij [Pokaż] na stronie ustawień i zrób to w Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">W pełni zrozumiałem i skonfigurowałem.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Napisy</sys:String>
+    <sys:String x:Key="M11">Ustawienia</sys:String>
+    <sys:String x:Key="M12">Historia</sys:String>
+    <sys:String x:Key="M13">Info</sys:String>
+    <sys:String x:Key="M20">Karty logów napisów</sys:String>
+    <sys:String x:Key="M21">Pauza tłumaczenia (tylko log)</sys:String>
+    <sys:String x:Key="M22">Okno nakładki</sys:String>
+    <sys:String x:Key="M23">Zawsze na wierzchu</sys:String>
+
+    <sys:String x:Key="MC0">[BŁĄD] Sprawdzenie aktualizacji nie powiodło się.</sys:String>
+    <sys:String x:Key="MC1">błąd</sys:String>
+    <sys:String x:Key="MC2">Dostępna nowa wersja</sys:String>
+    <sys:String x:Key="MC3">Wykryto nową wersję: {0}
+Obecna wersja: {1}
+Odwiedź GitHub, aby pobrać najnowsze wydanie.</sys:String>
+    <sys:String x:Key="MC4">Aktualizuj</sys:String>
+    <sys:String x:Key="MC5">Ignoruj tę wersję</sys:String>
+    <sys:String x:Key="MC6">[BŁĄD] Nie udało się otworzyć przeglądarki.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[OSTRZEŻENIE] LiveCaptions został niespodziewanie zamknięty, ponowne uruchamianie...</sys:String>
+    <sys:String x:Key="T1">[Pauza]</sys:String>
+    <sys:String x:Key="T2">Błąd!</sys:String>
+    <sys:String x:Key="T3">Rejestrowanie historii nie powiodło się: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Kliknij, aby skopiować</sys:String>
+    <sys:String x:Key="C1">Skopiowano</sys:String>
+    <sys:String x:Key="C2">Kopiowanie nie powiodło się</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/pt-br.xaml
+++ b/src/localization/pt-br.xaml
@@ -1,186 +1,174 @@
-<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Legendas em Tempo Real</sys:String>
-    <sys:String x:Key="S1">Após a versão 24H2 do Windows 11, só é possível alterar o</sys:String>
-    <sys:String x:Key="S2">Idioma de Origem</sys:String>
-    <sys:String x:Key="S3">nas Legendas em Tempo Real.</sys:String>
-    <sys:String x:Key="S4">Observação:</sys:String>
-    <sys:String x:Key="S5">Por favor, clique</sys:String>
-    <sys:String x:Key="S6">"Ocultar"</sys:String>
-    <sys:String x:Key="S7">para ocultar as Legendas em Tempo Real, em vez de fechá-las diretamente.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Legendas ao Vivo</sys:String>
+    <sys:String x:Key="S1">Após o Windows 11 24H2, você só pode alterar</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">idioma de origem</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">nas Legendas ao Vivo.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Nota:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Por favor, clique</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Ocultar"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">para ocultar as Legendas ao Vivo em vez de fechá-las.</sys:String>
 
-    <sys:String x:Key="S8">Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Ocultar</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Ocultar</sys:String>
-    <sys:String x:Key="S46">Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Intervalo da API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Determina com que frequência a API de tradução é chamada. Valores menores chamam com mais frequência.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">Chamar a API de tradução uma vez após a legenda mudar</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Intervalo da API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">vezes.</sys:String>
 
-    <sys:String x:Key="S9">Intervalo da API</sys:String>
-    <sys:String x:Key="S10">Determina a frequência das chamadas da API de tradução. Quanto menor, mais frequentes serão as chamadas.</sys:String>
-    <sys:String x:Key="S11">A API de tradução é chamada uma vez após a legenda mudar</sys:String>
-    <sys:String x:Key="S12">[Intervalo da API]</sys:String>
-    <sys:String x:Key="S13">vezes.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">API de Tradução</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Exceto Google e Google2, outras APIs precisam ser configuradas antes de usar.</sys:String>
 
-    <sys:String x:Key="S14">API de Tradução</sys:String>
-    <sys:String x:Key="S15">Exceto Google e Google2, todas as outras APIs precisam ser configuradas antes de serem usadas.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Idioma de destino</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Não encontrou o idioma desejado?</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Você pode editar este texto do ComboBox para personalizar o idioma. É recomendado seguir</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">tags de idioma BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Algumas APIs (por exemplo, DeepL) requerem uma forma diferente de especificar o idioma de destino. Verifique a documentação.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Idiomas de destino integrados já estão mapeados. Se seu idioma não estiver na lista, lembre-se disso.</sys:String>
 
-    <sys:String x:Key="S16">Idioma de Destino</sys:String>
-    <sys:String x:Key="S17">O idioma de destino que você esperava não está disponível!</sys:String>
-    <sys:String x:Key="S18">Você pode editar diretamente o conteúdo desta combobox para personalizar o idioma; recomenda-se seguir a</sys:String>
-    <sys:String x:Key="S19">etiqueta de idioma BCP 47.</sys:String>
-    <sys:String x:Key="S20">Algumas APIs (como DeepL) precisam de outra forma de definir o idioma de destino; consulte a documentação oficial para mais detalhes.</sys:String>
-    <sys:String x:Key="S21">Não é necessário considerar isso para idiomas incluídos, pois já construímos mapeamentos de etiquetas. Mas se o idioma esperado não estiver na lista, lembre-se disso.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Configurações da API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Abrir</sys:String>
 
-    <sys:String x:Key="S22">Configuração da API</sys:String>
-    <sys:String x:Key="S23">Abrir</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Mostrar latência</sys:String>
+    <sys:String x:Key="Common_Off">Desligado</sys:String>
+    <sys:String x:Key="Common_On">Ligado</sys:String>
 
-    <sys:String x:Key="S24">Mostrar Latência</sys:String>
-    <sys:String x:Key="S25">Desligado</sys:String>
-    <sys:String x:Key="S26">Ligado</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Contextos</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Contextos:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Determina o número de sentenças de contexto quando</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Com consciência de contexto</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">está ativado.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Sentenças sobrepostas:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Determina o número de cartões exibidos quando</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Cartões de log</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">está ativado, e o número máximo de sentenças mostradas na janela sobreposta.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Os contextos devem ser</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">maiores ou iguais a</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Sentenças exibidas</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Caso contrário, o aplicativo ajustará automaticamente.</sys:String>
 
-    <sys:String x:Key="S27">Contextos</sys:String>
-    <sys:String x:Key="S28">Contextos:</sys:String>
-    <sys:String x:Key="S29">Determina o número de frases de contexto quando</sys:String>
-    <sys:String x:Key="S30">Contexto Inteligente</sys:String>
-    <sys:String x:Key="S31">está ativado.</sys:String>
-    <sys:String x:Key="S32">Frases no Overlay:</sys:String>
-    <sys:String x:Key="S33">Determina o número de cartões exibidos quando</sys:String>
-    <sys:String x:Key="S34">Registro de Cartões</sys:String>
-    <sys:String x:Key="S35">está ativado, bem como o número máximo de frases exibidas na Janela de Overlay.</sys:String>
-    <sys:String x:Key="S36">Os contextos devem ser</sys:String>
-    <sys:String x:Key="S37">maiores ou iguais a</sys:String>
-    <sys:String x:Key="S38">Frases a Exibir</sys:String>
-    <sys:String x:Key="S39">. Se não for atendido, o programa ajustará automaticamente.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Sentenças exibidas</sys:String>
 
-    <sys:String x:Key="S40">Frases a Exibir</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Traduzir com contexto.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Pode melhorar a precisão, mas consome mais tokens.</sys:String>
 
-    <sys:String x:Key="S41">Traduzir em contexto.</sys:String>
-    <sys:String x:Key="S42">Pode melhorar a precisão da tradução, mas consumirá mais tokens.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Idioma da interface</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Selecione o idioma usado pela interface do aplicativo.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">As alterações entram em vigor imediatamente e são salvas automaticamente.</sys:String>
 
-    <sys:String x:Key="S43">Idioma da Interface</sys:String>
-    <sys:String x:Key="S44">Selecione o idioma usado pela interface do aplicativo.</sys:String>
+    <!-- HistoryPage strings (semantic keys) -->
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Página anterior</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Próxima página</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Pesquisar</sys:String>
 
-    <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Anterior</sys:String>
-    <sys:String x:Key="H1">Próxima Página</sys:String>
-    <sys:String x:Key="H2">Pesquisar</sys:String>
-    <sys:String x:Key="H3">Exportar</sys:String>
-    <sys:String x:Key="H4">Excluir Tudo</sys:String>
-    <sys:String x:Key="H5">Atualizar</sys:String>
-    <sys:String x:Key="H6">Hora</sys:String>
-    <sys:String x:Key="H7">Legenda</sys:String>
-    <sys:String x:Key="H8">Traduzido</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/página</sys:String>
-    <sys:String x:Key="H11">30/página</sys:String>
-    <sys:String x:Key="H12">50/página</sys:String>
-    <sys:String x:Key="H13">100/página</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Exportar</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Excluir tudo</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Atualizar</sys:String>
+
+    <sys:String x:Key="HistoryPage_Column_Time">Hora</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Legenda</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Tradução</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+
+    <sys:String x:Key="HistoryPage_PageSize_20">20/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/página</sys:String>
 
     <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">Deseja excluir todo o histórico?</sys:String>
-    <sys:String x:Key="H21">Esta ação não pode ser desfeita!</sys:String>
-    <sys:String x:Key="H22">Sim</sys:String>
-    <sys:String x:Key="H23">Não</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Todos os arquivos (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Salvo com Sucesso</sys:String>
-    <sys:String x:Key="H26">Arquivo salvo em: {0}</sys:String>
-    <sys:String x:Key="H27">Falha ao Salvar</sys:String>
-    <sys:String x:Key="H28">Falha ao salvar o arquivo: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Tem certeza de que deseja excluir todo o histórico?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Esta ação não pode ser desfeita!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Sim</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Não</sys:String>
 
-    <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Janela de Sobreposição</sys:String>
-    <sys:String x:Key="O1">Aumentar Tamanho da Fonte</sys:String>
-    <sys:String x:Key="O2">Diminuir Tamanho da Fonte</sys:String>
-    <sys:String x:Key="O3">Aumentar Contorno da Fonte</sys:String>
-    <sys:String x:Key="O4">Diminuir Contorno da Fonte</sys:String>
-    <sys:String x:Key="O5">Fonte Negrito</sys:String>
-    <sys:String x:Key="O6">Cor da Fonte</sys:String>
-    <sys:String x:Key="O7">Aumentar Opacidade do Fundo</sys:String>
-    <sys:String x:Key="O8">Diminuir Opacidade do Fundo</sys:String>
-    <sys:String x:Key="O9">Cor do Fundo</sys:String>
-    <sys:String x:Key="O10">Mostrar apenas legendas ou traduções</sys:String>
-    <sys:String x:Key="O11">Alterar posição legenda/tradução</sys:String>
-    <sys:String x:Key="O12">Ignorar Clique</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Todos os arquivos (*.*)|*.*</sys:String>
+
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Salvo com sucesso</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Arquivo salvo em: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Falha ao salvar</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Falha ao salvar o arquivo: {0}</sys:String>
+
+    <!-- OverlayWindow strings (semantic tooltips) -->
+    <sys:String x:Key="OverlayWindow_Title">Janela sobreposta</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Aumentar tamanho da fonte</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Diminuir tamanho da fonte</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Aumentar contorno</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Diminuir contorno</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Negrito</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Cor da fonte</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Aumentar opacidade do fundo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Diminuir opacidade do fundo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Cor do fundo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Mostrar apenas legenda ou tradução</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Alternar posição legenda/tradução</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Permitir clique através</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Agradecemos qualquer tipo de contribuição! Você pode enviar sugestões ou relatar bugs via GitHub, ou contribuir com código diretamente através de Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Se este programa for útil, considere nos dar uma estrela!</sys:String>
-    <sys:String x:Key="I2">Repositório:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Mantenedor:</sys:String>
-    <sys:String x:Key="I5">(Autor) e</sys:String>
-    <sys:String x:Key="I6">Versão:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Todos os tipos de contribuições são bem-vindas! Você pode sugerir recursos ou relatar bugs através do GitHub, ou contribuir com código enviando Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Se este programa te ajudar, considere dar uma estrela ao projeto!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repositório:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Mantenedor:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Autor) e</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Versão:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Introdução</sys:String>
-    <sys:String x:Key="W1">Bem-vindo ao LiveCaptions Translator!</sys:String>
-
-    <sys:String x:Key="W2">O LiveCaptions Translator é baseado no Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Antes de executar pela primeira vez, configure-o seguindo os passos abaixo:&#x0A;</sys:String>
-
-    <sys:String x:Key="W4">&#x0A;1. Abra o Windows LiveCaptions e siga o guia para baixar os arquivos necessários para reconhecimento de fala local e pacotes de idioma.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Clique no</sys:String>
-    <sys:String x:Key="W6">⚙️ ícone de engrenagem</sys:String>
-    <sys:String x:Key="W7">no Windows LiveCaptions para abrir o menu de configurações e selecione</sys:String>
-    <sys:String x:Key="W8">"Posição > Sobreposto na Tela"</sys:String>
-    <sys:String x:Key="W9">3. Clique no botão</sys:String>
-    <sys:String x:Key="W10">"Ocultar"</sys:String>
-    <sys:String x:Key="W11">localizado na página de configurações do LiveCaptions Translator para ocultar o Windows LiveCaptions.&#x0A;</sys:String>
-
-    <sys:String x:Key="W12">&#x0A;O programa já navegou automaticamente para a página de configurações e abriu o Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Após concluir a configuração, você pode voltar à página principal e aproveitar a tradução de áudio em tempo real.&#x0A;</sys:String>
-
-    <sys:String x:Key="W14">&#x0A;Para mais detalhes, visite nossa wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-
-    <sys:String x:Key="W16">&#x0A;&#x0A;Dica:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Para alterar o </sys:String>
-    <sys:String x:Key="W18">Idioma de Origem</sys:String>
-    <sys:String x:Key="W19">, por favor [Mostrar] o LiveCaptions na página de configurações e faça a alteração no Windows LiveCaptions.</sys:String>
-
-    <sys:String x:Key="W20">Compreendi e configurei completamente.</sys:String>
-
-    <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Começar</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Bem-vindo ao LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">O LiveCaptions Translator é baseado nas Legendas ao Vivo do Windows.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Antes da primeira execução, complete os seguintes passos:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Abra as Legendas ao Vivo do Windows e siga o guia para baixar os arquivos de reconhecimento de fala offline e os pacotes de idioma.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Clique</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ engrenagem</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">ícone para abrir as Configurações e selecionar</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Posição &gt; Sobreposto na tela"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Clique</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Ocultar"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">botão na página de configurações do LiveCaptions Translator para ocultar as Legendas ao Vivo do Windows.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;O aplicativo pulou automaticamente para a página de configurações e abriu as Legendas ao Vivo do Windows.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Após a configuração, você pode voltar à página principal e aproveitar a tradução de áudio em tempo real.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Para mais detalhes, consulte a Wiki:</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Dica:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Se você deseja alterar</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">idioma de origem</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, clique em [Mostrar] as Legendas ao Vivo primeiro e depois altere nas Legendas ao Vivo do Windows.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Entendi completamente e finalizei a configuração.</sys:String>
 
     <!-- Navigation menu -->
-    <sys:String x:Key="M10">Legenda</sys:String>
-    <sys:String x:Key="M11">Configurações</sys:String>
-    <sys:String x:Key="M12">Histórico</sys:String>
-    <sys:String x:Key="M13">Informações</sys:String>
+    <sys:String x:Key="Navigation_Captions">Legendas</sys:String>
+    <sys:String x:Key="Navigation_Settings">Configurações</sys:String>
+    <sys:String x:Key="Navigation_History">Histórico</sys:String>
+    <sys:String x:Key="Navigation_Info">Informações</sys:String>
 
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">Cartões de Log das Legendas</sys:String>
-    <sys:String x:Key="M21">Pausar Tradução (Somente Log)</sys:String>
-    <sys:String x:Key="M22">Janela de Sobreposição</sys:String>
-    <sys:String x:Key="M23">Sempre no Topo</sys:String>
+    <!-- MainWindow strings -->
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Cartões de log de legenda</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pausar tradução (apenas log)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Janela sobreposta</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Sempre no topo</sys:String>
 
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[ERRO] Falha ao Verificar Atualizações.</sys:String>
-    <sys:String x:Key="MC1">erro</sys:String>
-
-    <sys:String x:Key="MC2">Nova Versão Disponível</sys:String>
-    <sys:String x:Key="MC3">Foi detectada uma nova versão: {0}
+    <sys:String x:Key="MainWindow_Update_Error">[ERRO] Falha ao verificar atualizações.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">erro</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Nova versão encontrada</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Nova versão detectada: {0}
 Versão atual: {1}
-Por favor, visite o GitHub para baixar a versão mais recente.</sys:String>
-    <sys:String x:Key="MC4">Atualizar</sys:String>
-    <sys:String x:Key="MC5">Ignorar esta versão</sys:String>
+Por favor, vá ao GitHub para baixar a última versão.</sys:String>
 
-    <sys:String x:Key="MC6">[ERRO] Falha ao Abrir o Navegador.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[AVISO] O LiveCaptions foi fechado inesperadamente, reiniciando...</sys:String>
-    <sys:String x:Key="T1">[Pausado]</sys:String>
-    <sys:String x:Key="T2">Erro!</sys:String>
-    <sys:String x:Key="T3">Falha ao registrar histórico: {0}</sys:String>
+    <!-- Translator  -->
+    <sys:String x:Key="Translator_Status_Restarting">[AVISO] Legendas ao Vivo fechadas inesperadamente, reiniciando…</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Pausado]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Erro!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Falha ao salvar histórico: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Clique para Copiar</sys:String>
-    <sys:String x:Key="C1">Copiado</sys:String>
-    <sys:String x:Key="C2">Falha ao Copiar</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Clique para copiar</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Copiado</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Falha ao copiar</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/pt-br.xaml
+++ b/src/localization/pt-br.xaml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Legendas em Tempo Real</sys:String>
+    <sys:String x:Key="S1">Após a versão 24H2 do Windows 11, só é possível alterar o</sys:String>
+    <sys:String x:Key="S2">Idioma de Origem</sys:String>
+    <sys:String x:Key="S3">nas Legendas em Tempo Real.</sys:String>
+    <sys:String x:Key="S4">Observação:</sys:String>
+    <sys:String x:Key="S5">Por favor, clique</sys:String>
+    <sys:String x:Key="S6">"Ocultar"</sys:String>
+    <sys:String x:Key="S7">para ocultar as Legendas em Tempo Real, em vez de fechá-las diretamente.</sys:String>
+
+    <sys:String x:Key="S8">Mostrar</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Ocultar</sys:String>
+    <sys:String x:Key="S46">Mostrar</sys:String>
+
+    <sys:String x:Key="S9">Intervalo da API</sys:String>
+    <sys:String x:Key="S10">Determina a frequência das chamadas da API de tradução. Quanto menor, mais frequentes serão as chamadas.</sys:String>
+    <sys:String x:Key="S11">A API de tradução é chamada uma vez após a legenda mudar</sys:String>
+    <sys:String x:Key="S12">[Intervalo da API]</sys:String>
+    <sys:String x:Key="S13">vezes.</sys:String>
+
+    <sys:String x:Key="S14">API de Tradução</sys:String>
+    <sys:String x:Key="S15">Exceto Google e Google2, todas as outras APIs precisam ser configuradas antes de serem usadas.</sys:String>
+
+    <sys:String x:Key="S16">Idioma de Destino</sys:String>
+    <sys:String x:Key="S17">O idioma de destino que você esperava não está disponível!</sys:String>
+    <sys:String x:Key="S18">Você pode editar diretamente o conteúdo desta combobox para personalizar o idioma; recomenda-se seguir a</sys:String>
+    <sys:String x:Key="S19">etiqueta de idioma BCP 47.</sys:String>
+    <sys:String x:Key="S20">Algumas APIs (como DeepL) precisam de outra forma de definir o idioma de destino; consulte a documentação oficial para mais detalhes.</sys:String>
+    <sys:String x:Key="S21">Não é necessário considerar isso para idiomas incluídos, pois já construímos mapeamentos de etiquetas. Mas se o idioma esperado não estiver na lista, lembre-se disso.</sys:String>
+
+    <sys:String x:Key="S22">Configuração da API</sys:String>
+    <sys:String x:Key="S23">Abrir</sys:String>
+
+    <sys:String x:Key="S24">Mostrar Latência</sys:String>
+    <sys:String x:Key="S25">Desligado</sys:String>
+    <sys:String x:Key="S26">Ligado</sys:String>
+
+    <sys:String x:Key="S27">Contextos</sys:String>
+    <sys:String x:Key="S28">Contextos:</sys:String>
+    <sys:String x:Key="S29">Determina o número de frases de contexto quando</sys:String>
+    <sys:String x:Key="S30">Contexto Inteligente</sys:String>
+    <sys:String x:Key="S31">está ativado.</sys:String>
+    <sys:String x:Key="S32">Frases no Overlay:</sys:String>
+    <sys:String x:Key="S33">Determina o número de cartões exibidos quando</sys:String>
+    <sys:String x:Key="S34">Registro de Cartões</sys:String>
+    <sys:String x:Key="S35">está ativado, bem como o número máximo de frases exibidas na Janela de Overlay.</sys:String>
+    <sys:String x:Key="S36">Os contextos devem ser</sys:String>
+    <sys:String x:Key="S37">maiores ou iguais a</sys:String>
+    <sys:String x:Key="S38">Frases a Exibir</sys:String>
+    <sys:String x:Key="S39">. Se não for atendido, o programa ajustará automaticamente.</sys:String>
+
+    <sys:String x:Key="S40">Frases a Exibir</sys:String>
+
+    <sys:String x:Key="S41">Traduzir em contexto.</sys:String>
+    <sys:String x:Key="S42">Pode melhorar a precisão da tradução, mas consumirá mais tokens.</sys:String>
+
+    <sys:String x:Key="S43">Idioma da Interface</sys:String>
+    <sys:String x:Key="S44">Selecione o idioma usado pela interface do aplicativo.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Anterior</sys:String>
+    <sys:String x:Key="H1">Próxima Página</sys:String>
+    <sys:String x:Key="H2">Pesquisar</sys:String>
+    <sys:String x:Key="H3">Exportar</sys:String>
+    <sys:String x:Key="H4">Excluir Tudo</sys:String>
+    <sys:String x:Key="H5">Atualizar</sys:String>
+    <sys:String x:Key="H6">Hora</sys:String>
+    <sys:String x:Key="H7">Legenda</sys:String>
+    <sys:String x:Key="H8">Traduzido</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/página</sys:String>
+    <sys:String x:Key="H11">30/página</sys:String>
+    <sys:String x:Key="H12">50/página</sys:String>
+    <sys:String x:Key="H13">100/página</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">Deseja excluir todo o histórico?</sys:String>
+    <sys:String x:Key="H21">Esta ação não pode ser desfeita!</sys:String>
+    <sys:String x:Key="H22">Sim</sys:String>
+    <sys:String x:Key="H23">Não</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Todos os arquivos (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Salvo com Sucesso</sys:String>
+    <sys:String x:Key="H26">Arquivo salvo em: {0}</sys:String>
+    <sys:String x:Key="H27">Falha ao Salvar</sys:String>
+    <sys:String x:Key="H28">Falha ao salvar o arquivo: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Janela de Sobreposição</sys:String>
+    <sys:String x:Key="O1">Aumentar Tamanho da Fonte</sys:String>
+    <sys:String x:Key="O2">Diminuir Tamanho da Fonte</sys:String>
+    <sys:String x:Key="O3">Aumentar Contorno da Fonte</sys:String>
+    <sys:String x:Key="O4">Diminuir Contorno da Fonte</sys:String>
+    <sys:String x:Key="O5">Fonte Negrito</sys:String>
+    <sys:String x:Key="O6">Cor da Fonte</sys:String>
+    <sys:String x:Key="O7">Aumentar Opacidade do Fundo</sys:String>
+    <sys:String x:Key="O8">Diminuir Opacidade do Fundo</sys:String>
+    <sys:String x:Key="O9">Cor do Fundo</sys:String>
+    <sys:String x:Key="O10">Mostrar apenas legendas ou traduções</sys:String>
+    <sys:String x:Key="O11">Alterar posição legenda/tradução</sys:String>
+    <sys:String x:Key="O12">Ignorar Clique</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Agradecemos qualquer tipo de contribuição! Você pode enviar sugestões ou relatar bugs via GitHub, ou contribuir com código diretamente através de Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Se este programa for útil, considere nos dar uma estrela!</sys:String>
+    <sys:String x:Key="I2">Repositório:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Mantenedor:</sys:String>
+    <sys:String x:Key="I5">(Autor) e</sys:String>
+    <sys:String x:Key="I6">Versão:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Introdução</sys:String>
+    <sys:String x:Key="W1">Bem-vindo ao LiveCaptions Translator!</sys:String>
+
+    <sys:String x:Key="W2">O LiveCaptions Translator é baseado no Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Antes de executar pela primeira vez, configure-o seguindo os passos abaixo:&#x0A;</sys:String>
+
+    <sys:String x:Key="W4">&#x0A;1. Abra o Windows LiveCaptions e siga o guia para baixar os arquivos necessários para reconhecimento de fala local e pacotes de idioma.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Clique no</sys:String>
+    <sys:String x:Key="W6">⚙️ ícone de engrenagem</sys:String>
+    <sys:String x:Key="W7">no Windows LiveCaptions para abrir o menu de configurações e selecione</sys:String>
+    <sys:String x:Key="W8">"Posição > Sobreposto na Tela"</sys:String>
+    <sys:String x:Key="W9">3. Clique no botão</sys:String>
+    <sys:String x:Key="W10">"Ocultar"</sys:String>
+    <sys:String x:Key="W11">localizado na página de configurações do LiveCaptions Translator para ocultar o Windows LiveCaptions.&#x0A;</sys:String>
+
+    <sys:String x:Key="W12">&#x0A;O programa já navegou automaticamente para a página de configurações e abriu o Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Após concluir a configuração, você pode voltar à página principal e aproveitar a tradução de áudio em tempo real.&#x0A;</sys:String>
+
+    <sys:String x:Key="W14">&#x0A;Para mais detalhes, visite nossa wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+
+    <sys:String x:Key="W16">&#x0A;&#x0A;Dica:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Para alterar o </sys:String>
+    <sys:String x:Key="W18">Idioma de Origem</sys:String>
+    <sys:String x:Key="W19">, por favor [Mostrar] o LiveCaptions na página de configurações e faça a alteração no Windows LiveCaptions.</sys:String>
+
+    <sys:String x:Key="W20">Compreendi e configurei completamente.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">Legenda</sys:String>
+    <sys:String x:Key="M11">Configurações</sys:String>
+    <sys:String x:Key="M12">Histórico</sys:String>
+    <sys:String x:Key="M13">Informações</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">Cartões de Log das Legendas</sys:String>
+    <sys:String x:Key="M21">Pausar Tradução (Somente Log)</sys:String>
+    <sys:String x:Key="M22">Janela de Sobreposição</sys:String>
+    <sys:String x:Key="M23">Sempre no Topo</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[ERRO] Falha ao Verificar Atualizações.</sys:String>
+    <sys:String x:Key="MC1">erro</sys:String>
+
+    <sys:String x:Key="MC2">Nova Versão Disponível</sys:String>
+    <sys:String x:Key="MC3">Foi detectada uma nova versão: {0}
+Versão atual: {1}
+Por favor, visite o GitHub para baixar a versão mais recente.</sys:String>
+    <sys:String x:Key="MC4">Atualizar</sys:String>
+    <sys:String x:Key="MC5">Ignorar esta versão</sys:String>
+
+    <sys:String x:Key="MC6">[ERRO] Falha ao Abrir o Navegador.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[AVISO] O LiveCaptions foi fechado inesperadamente, reiniciando...</sys:String>
+    <sys:String x:Key="T1">[Pausado]</sys:String>
+    <sys:String x:Key="T2">Erro!</sys:String>
+    <sys:String x:Key="T3">Falha ao registrar histórico: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Clique para Copiar</sys:String>
+    <sys:String x:Key="C1">Copiado</sys:String>
+    <sys:String x:Key="C2">Falha ao Copiar</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/pt-pt.xaml
+++ b/src/localization/pt-pt.xaml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Legendas em Tempo Real</sys:String>
+    <sys:String x:Key="S1">Após a versão 24H2 do Windows 11, só é possível alterar o</sys:String>
+    <sys:String x:Key="S2">Idioma de Origem</sys:String>
+    <sys:String x:Key="S3">nas Legendas em Tempo Real.</sys:String>
+    <sys:String x:Key="S4">Nota:</sys:String>
+    <sys:String x:Key="S5">Por favor, clique</sys:String>
+    <sys:String x:Key="S6">"Ocultar"</sys:String>
+    <sys:String x:Key="S7">para ocultar as Legendas em Tempo Real em vez de fechá-las diretamente.</sys:String>
+
+    <sys:String x:Key="S8">Mostrar</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Ocultar</sys:String>
+    <sys:String x:Key="S46">Mostrar</sys:String>
+
+    <sys:String x:Key="S9">Intervalo da API</sys:String>
+    <sys:String x:Key="S10">Determina a frequência das chamadas da API de tradução. Quanto menor, mais frequentes serão as chamadas.</sys:String>
+    <sys:String x:Key="S11">A API de tradução é chamada uma vez após a legenda mudar</sys:String>
+    <sys:String x:Key="S12">[Intervalo da API]</sys:String>
+    <sys:String x:Key="S13">vezes.</sys:String>
+
+    <sys:String x:Key="S14">API de Tradução</sys:String>
+    <sys:String x:Key="S15">Exceto Google e Google2, todas as outras APIs requerem configuração antes de serem usadas.</sys:String>
+
+    <sys:String x:Key="S16">Idioma de Destino</sys:String>
+    <sys:String x:Key="S17">O idioma de destino esperado não está disponível!</sys:String>
+    <sys:String x:Key="S18">Pode editar diretamente o conteúdo desta combobox para personalizar o idioma, recomenda-se seguir a</sys:String>
+    <sys:String x:Key="S19">etiqueta de idioma BCP 47.</sys:String>
+    <sys:String x:Key="S20">Algumas APIs (como DeepL) precisam de outra forma de definir o idioma de destino, consulte a documentação oficial para mais detalhes.</sys:String>
+    <sys:String x:Key="S21">Não é necessário considerar isso para idiomas incluídos, pois já temos mapeamentos de etiquetas. Mas se o idioma esperado não estiver na lista, tenha isso em mente.</sys:String>
+
+    <sys:String x:Key="S22">Configuração da API</sys:String>
+    <sys:String x:Key="S23">Abrir</sys:String>
+
+    <sys:String x:Key="S24">Mostrar Latência</sys:String>
+    <sys:String x:Key="S25">Desligado</sys:String>
+    <sys:String x:Key="S26">Ligado</sys:String>
+
+    <sys:String x:Key="S27">Contextos</sys:String>
+    <sys:String x:Key="S28">Contextos:</sys:String>
+    <sys:String x:Key="S29">Determina o número de frases de contexto quando</sys:String>
+    <sys:String x:Key="S30">Contexto Inteligente</sys:String>
+    <sys:String x:Key="S31">está ativado.</sys:String>
+    <sys:String x:Key="S32">Frases no Overlay:</sys:String>
+    <sys:String x:Key="S33">Determina o número de cartões exibidos quando</sys:String>
+    <sys:String x:Key="S34">Registo de Cartões</sys:String>
+    <sys:String x:Key="S35">está ativado, assim como o número máximo de frases exibidas na Janela de Overlay.</sys:String>
+    <sys:String x:Key="S36">Os contextos devem ser</sys:String>
+    <sys:String x:Key="S37">maior ou igual a</sys:String>
+    <sys:String x:Key="S38">Frases a Exibir</sys:String>
+    <sys:String x:Key="S39">. Se não for cumprido, o programa ajustará automaticamente.</sys:String>
+
+    <sys:String x:Key="S40">Frases a Exibir</sys:String>
+
+    <sys:String x:Key="S41">Traduzir em contexto.</sys:String>
+    <sys:String x:Key="S42">Pode melhorar a precisão da tradução, mas consumirá mais tokens.</sys:String>
+
+    <sys:String x:Key="S43">Idioma da UI</sys:String>
+    <sys:String x:Key="S44">Selecione o idioma usado pela interface da aplicação.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Anterior</sys:String>
+    <sys:String x:Key="H1">Próxima Página</sys:String>
+    <sys:String x:Key="H2">Pesquisar</sys:String>
+    <sys:String x:Key="H3">Exportar</sys:String>
+    <sys:String x:Key="H4">Eliminar Tudo</sys:String>
+    <sys:String x:Key="H5">Atualizar</sys:String>
+    <sys:String x:Key="H6">Hora</sys:String>
+    <sys:String x:Key="H7">Legenda</sys:String>
+    <sys:String x:Key="H8">Traduzido</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/página</sys:String>
+    <sys:String x:Key="H11">30/página</sys:String>
+    <sys:String x:Key="H12">50/página</sys:String>
+    <sys:String x:Key="H13">100/página</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">Deseja eliminar todo o histórico?</sys:String>
+    <sys:String x:Key="H21">Esta operação não pode ser desfeita!</sys:String>
+    <sys:String x:Key="H22">Sim</sys:String>
+    <sys:String x:Key="H23">Não</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Todos os ficheiros (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Guardado com Sucesso</sys:String>
+    <sys:String x:Key="H26">Ficheiro guardado em: {0}</sys:String>
+    <sys:String x:Key="H27">Falha ao Guardar</sys:String>
+    <sys:String x:Key="H28">Falha ao guardar o ficheiro: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Janela de Overlay</sys:String>
+    <sys:String x:Key="O1">Aumentar Tamanho da Fonte</sys:String>
+    <sys:String x:Key="O2">Diminuir Tamanho da Fonte</sys:String>
+    <sys:String x:Key="O3">Aumentar Contorno da Fonte</sys:String>
+    <sys:String x:Key="O4">Diminuir Contorno da Fonte</sys:String>
+    <sys:String x:Key="O5">Fonte Negrito</sys:String>
+    <sys:String x:Key="O6">Cor da Fonte</sys:String>
+    <sys:String x:Key="O7">Aumentar Opacidade do Fundo</sys:String>
+    <sys:String x:Key="O8">Diminuir Opacidade do Fundo</sys:String>
+    <sys:String x:Key="O9">Cor do Fundo</sys:String>
+    <sys:String x:Key="O10">Mostrar apenas legendas ou traduções</sys:String>
+    <sys:String x:Key="O11">Alterar posição legenda/tradução</sys:String>
+    <sys:String x:Key="O12">Ignorar Clique</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Agradecemos qualquer forma de contribuição! Pode enviar sugestões ou reportar erros através do GitHub, ou contribuir com código diretamente enviando Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Se este programa for útil, considere dar-nos uma estrela!</sys:String>
+    <sys:String x:Key="I2">Repositório:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Mantenedor:</sys:String>
+    <sys:String x:Key="I5">(Autor) e</sys:String>
+    <sys:String x:Key="I6">Versão:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Começando</sys:String>
+    <sys:String x:Key="W1">Bem-vindo ao LiveCaptions Translator!</sys:String>
+
+    <sys:String x:Key="W2">O LiveCaptions Translator baseia-se no Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Antes de executar pela primeira vez, configure-o de acordo com os seguintes passos:&#x0A;</sys:String>
+
+    <sys:String x:Key="W4">&#x0A;1. Abra o Windows LiveCaptions e siga o guia para descarregar os ficheiros necessários para reconhecimento de fala local e pacotes de idioma.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Clique no</sys:String>
+    <sys:String x:Key="W6">⚙️ ícone de engrenagem</sys:String>
+    <sys:String x:Key="W7">no Windows LiveCaptions para abrir o menu de definições e selecione</sys:String>
+    <sys:String x:Key="W8">"Posição > Sobreposto no ecrã"</sys:String>
+    <sys:String x:Key="W9">3. Clique no botão</sys:String>
+    <sys:String x:Key="W10">"Ocultar"</sys:String>
+    <sys:String x:Key="W11">localizado na página de definições do LiveCaptions Translator para ocultar o Windows LiveCaptions.&#x0A;</sys:String>
+
+    <sys:String x:Key="W12">&#x0A;O programa já navegou automaticamente para a página de definições e abriu o Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Após concluir a configuração, pode voltar à página principal e usufruir da tradução de áudio em tempo real.&#x0A;</sys:String>
+
+    <sys:String x:Key="W14">&#x0A;Para mais detalhes, visite a nossa wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+
+    <sys:String x:Key="W16">&#x0A;&#x0A;Dica:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Para alterar o </sys:String>
+    <sys:String x:Key="W18">Idioma de Origem</sys:String>
+    <sys:String x:Key="W19">, por favor [Mostrar] o LiveCaptions na página de definições e faça a alteração no Windows LiveCaptions.</sys:String>
+
+    <sys:String x:Key="W20">Compreendi e configurei totalmente.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">Legenda</sys:String>
+    <sys:String x:Key="M11">Definições</sys:String>
+    <sys:String x:Key="M12">Histórico</sys:String>
+    <sys:String x:Key="M13">Informação</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">Cartões de Log das Legendas</sys:String>
+    <sys:String x:Key="M21">Pausar Tradução (Só Log)</sys:String>
+    <sys:String x:Key="M22">Janela de Overlay</sys:String>
+    <sys:String x:Key="M23">Sempre em Cima</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[ERRO] Falha ao Verificar Atualizações.</sys:String>
+    <sys:String x:Key="MC1">erro</sys:String>
+
+    <sys:String x:Key="MC2">Nova Versão Disponível</sys:String>
+    <sys:String x:Key="MC3">Foi detetada uma nova versão: {0}
+Versão atual: {1}
+Por favor visite o GitHub para descarregar a versão mais recente.</sys:String>
+    <sys:String x:Key="MC4">Atualizar</sys:String>
+    <sys:String x:Key="MC5">Ignorar esta versão</sys:String>
+
+    <sys:String x:Key="MC6">[ERRO] Falha ao Abrir o Navegador.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[AVISO] O LiveCaptions foi fechado inesperadamente, reiniciando...</sys:String>
+    <sys:String x:Key="T1">[Pausado]</sys:String>
+    <sys:String x:Key="T2">Erro!</sys:String>
+    <sys:String x:Key="T3">Falha ao registar histórico: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Clique para Copiar</sys:String>
+    <sys:String x:Key="C1">Copiado</sys:String>
+    <sys:String x:Key="C2">Falha ao Copiar</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/pt-pt.xaml
+++ b/src/localization/pt-pt.xaml
@@ -3,184 +3,165 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Legendas em Tempo Real</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Legendas em Tempo Real</sys:String>
     <sys:String x:Key="S1">Após a versão 24H2 do Windows 11, só é possível alterar o</sys:String>
-    <sys:String x:Key="S2">Idioma de Origem</sys:String>
-    <sys:String x:Key="S3">nas Legendas em Tempo Real.</sys:String>
-    <sys:String x:Key="S4">Nota:</sys:String>
-    <sys:String x:Key="S5">Por favor, clique</sys:String>
-    <sys:String x:Key="S6">"Ocultar"</sys:String>
-    <sys:String x:Key="S7">para ocultar as Legendas em Tempo Real em vez de fechá-las diretamente.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Idioma de Origem</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">nas Legendas em Tempo Real.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Nota:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Por favor, clique</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Ocultar"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">para ocultar as Legendas em Tempo Real em vez de fechá-las diretamente.</sys:String>
 
-    <sys:String x:Key="S8">Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Ocultar</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Ocultar</sys:String>
-    <sys:String x:Key="S46">Mostrar</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Intervalo da API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Determina a frequência das chamadas da API de tradução. Quanto menor, mais frequentes serão as chamadas.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">A API de tradução é chamada uma vez após a legenda mudar</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Intervalo da API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">vezes.</sys:String>
 
-    <sys:String x:Key="S9">Intervalo da API</sys:String>
-    <sys:String x:Key="S10">Determina a frequência das chamadas da API de tradução. Quanto menor, mais frequentes serão as chamadas.</sys:String>
-    <sys:String x:Key="S11">A API de tradução é chamada uma vez após a legenda mudar</sys:String>
-    <sys:String x:Key="S12">[Intervalo da API]</sys:String>
-    <sys:String x:Key="S13">vezes.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">API de Tradução</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Exceto Google e Google2, todas as outras APIs requerem configuração antes de serem usadas.</sys:String>
 
-    <sys:String x:Key="S14">API de Tradução</sys:String>
-    <sys:String x:Key="S15">Exceto Google e Google2, todas as outras APIs requerem configuração antes de serem usadas.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Idioma de Destino</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">O idioma de destino esperado não está disponível!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Pode editar diretamente o conteúdo desta combobox para personalizar o idioma, recomenda-se seguir a</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">etiqueta de idioma BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Algumas APIs (como DeepL) precisam de outra forma de definir o idioma de destino, consulte a documentação oficial para mais detalhes.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Não é necessário considerar isso para idiomas incluídos, pois já temos mapeamentos de etiquetas. Mas se o idioma esperado não estiver na lista, tenha isso em mente.</sys:String>
 
-    <sys:String x:Key="S16">Idioma de Destino</sys:String>
-    <sys:String x:Key="S17">O idioma de destino esperado não está disponível!</sys:String>
-    <sys:String x:Key="S18">Pode editar diretamente o conteúdo desta combobox para personalizar o idioma, recomenda-se seguir a</sys:String>
-    <sys:String x:Key="S19">etiqueta de idioma BCP 47.</sys:String>
-    <sys:String x:Key="S20">Algumas APIs (como DeepL) precisam de outra forma de definir o idioma de destino, consulte a documentação oficial para mais detalhes.</sys:String>
-    <sys:String x:Key="S21">Não é necessário considerar isso para idiomas incluídos, pois já temos mapeamentos de etiquetas. Mas se o idioma esperado não estiver na lista, tenha isso em mente.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Configuração da API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Abrir</sys:String>
 
-    <sys:String x:Key="S22">Configuração da API</sys:String>
-    <sys:String x:Key="S23">Abrir</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Mostrar Latência</sys:String>
+    <sys:String x:Key="Common_Off">Desligado</sys:String>
+    <sys:String x:Key="Common_On">Ligado</sys:String>
 
-    <sys:String x:Key="S24">Mostrar Latência</sys:String>
-    <sys:String x:Key="S25">Desligado</sys:String>
-    <sys:String x:Key="S26">Ligado</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Contextos</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Contextos:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Determina o número de frases de contexto quando</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Contexto Inteligente</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">está ativado.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Frases no Overlay:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Determina o número de cartões exibidos quando</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Registo de Cartões</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">está ativado, assim como o número máximo de frases exibidas na Janela de Overlay.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Os contextos devem ser</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">maior ou igual a</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Frases a Exibir</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Se não for cumprido, o programa ajustará automaticamente.</sys:String>
 
-    <sys:String x:Key="S27">Contextos</sys:String>
-    <sys:String x:Key="S28">Contextos:</sys:String>
-    <sys:String x:Key="S29">Determina o número de frases de contexto quando</sys:String>
-    <sys:String x:Key="S30">Contexto Inteligente</sys:String>
-    <sys:String x:Key="S31">está ativado.</sys:String>
-    <sys:String x:Key="S32">Frases no Overlay:</sys:String>
-    <sys:String x:Key="S33">Determina o número de cartões exibidos quando</sys:String>
-    <sys:String x:Key="S34">Registo de Cartões</sys:String>
-    <sys:String x:Key="S35">está ativado, assim como o número máximo de frases exibidas na Janela de Overlay.</sys:String>
-    <sys:String x:Key="S36">Os contextos devem ser</sys:String>
-    <sys:String x:Key="S37">maior ou igual a</sys:String>
-    <sys:String x:Key="S38">Frases a Exibir</sys:String>
-    <sys:String x:Key="S39">. Se não for cumprido, o programa ajustará automaticamente.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Frases a Exibir</sys:String>
 
-    <sys:String x:Key="S40">Frases a Exibir</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Traduzir em contexto.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Pode melhorar a precisão da tradução, mas consumirá mais tokens.</sys:String>
 
-    <sys:String x:Key="S41">Traduzir em contexto.</sys:String>
-    <sys:String x:Key="S42">Pode melhorar a precisão da tradução, mas consumirá mais tokens.</sys:String>
-
-    <sys:String x:Key="S43">Idioma da UI</sys:String>
-    <sys:String x:Key="S44">Selecione o idioma usado pela interface da aplicação.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Idioma da UI</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Selecione o idioma usado pela interface da aplicação.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">As alterações entram em vigor imediatamente e são guardadas automaticamente.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Anterior</sys:String>
-    <sys:String x:Key="H1">Próxima Página</sys:String>
-    <sys:String x:Key="H2">Pesquisar</sys:String>
-    <sys:String x:Key="H3">Exportar</sys:String>
-    <sys:String x:Key="H4">Eliminar Tudo</sys:String>
-    <sys:String x:Key="H5">Atualizar</sys:String>
-    <sys:String x:Key="H6">Hora</sys:String>
-    <sys:String x:Key="H7">Legenda</sys:String>
-    <sys:String x:Key="H8">Traduzido</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/página</sys:String>
-    <sys:String x:Key="H11">30/página</sys:String>
-    <sys:String x:Key="H12">50/página</sys:String>
-    <sys:String x:Key="H13">100/página</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Anterior</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Próxima Página</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Pesquisar</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Exportar</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Eliminar Tudo</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Atualizar</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Hora</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Legenda</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Traduzido</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/página</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/página</sys:String>
 
     <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">Deseja eliminar todo o histórico?</sys:String>
-    <sys:String x:Key="H21">Esta operação não pode ser desfeita!</sys:String>
-    <sys:String x:Key="H22">Sim</sys:String>
-    <sys:String x:Key="H23">Não</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Todos os ficheiros (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Guardado com Sucesso</sys:String>
-    <sys:String x:Key="H26">Ficheiro guardado em: {0}</sys:String>
-    <sys:String x:Key="H27">Falha ao Guardar</sys:String>
-    <sys:String x:Key="H28">Falha ao guardar o ficheiro: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Deseja eliminar todo o histórico?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Esta operação não pode ser desfeita!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Sim</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Não</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Todos os ficheiros (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Guardado com Sucesso</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Ficheiro guardado em: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Falha ao Guardar</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Falha ao guardar o ficheiro: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Janela de Overlay</sys:String>
-    <sys:String x:Key="O1">Aumentar Tamanho da Fonte</sys:String>
-    <sys:String x:Key="O2">Diminuir Tamanho da Fonte</sys:String>
-    <sys:String x:Key="O3">Aumentar Contorno da Fonte</sys:String>
-    <sys:String x:Key="O4">Diminuir Contorno da Fonte</sys:String>
-    <sys:String x:Key="O5">Fonte Negrito</sys:String>
-    <sys:String x:Key="O6">Cor da Fonte</sys:String>
-    <sys:String x:Key="O7">Aumentar Opacidade do Fundo</sys:String>
-    <sys:String x:Key="O8">Diminuir Opacidade do Fundo</sys:String>
-    <sys:String x:Key="O9">Cor do Fundo</sys:String>
-    <sys:String x:Key="O10">Mostrar apenas legendas ou traduções</sys:String>
-    <sys:String x:Key="O11">Alterar posição legenda/tradução</sys:String>
-    <sys:String x:Key="O12">Ignorar Clique</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Janela de Overlay</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Aumentar Tamanho da Fonte</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Diminuir Tamanho da Fonte</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Aumentar Contorno da Fonte</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Diminuir Contorno da Fonte</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Fonte Negrito</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Cor da Fonte</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Aumentar Opacidade do Fundo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Diminuir Opacidade do Fundo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Cor do Fundo</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Mostrar apenas legendas ou traduções</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Alterar posição legenda/tradução</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Ignorar Clique</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Agradecemos qualquer forma de contribuição! Pode enviar sugestões ou reportar erros através do GitHub, ou contribuir com código diretamente enviando Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Se este programa for útil, considere dar-nos uma estrela!</sys:String>
-    <sys:String x:Key="I2">Repositório:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Mantenedor:</sys:String>
-    <sys:String x:Key="I5">(Autor) e</sys:String>
-    <sys:String x:Key="I6">Versão:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Agradecemos qualquer forma de contribuição! Pode enviar sugestões ou reportar erros através do GitHub, ou contribuir com código diretamente enviando Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Se este programa for útil, considere dar-nos uma estrela!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repositório:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Mantenedor:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Autor) e</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Versão:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Começando</sys:String>
-    <sys:String x:Key="W1">Bem-vindo ao LiveCaptions Translator!</sys:String>
-
-    <sys:String x:Key="W2">O LiveCaptions Translator baseia-se no Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Antes de executar pela primeira vez, configure-o de acordo com os seguintes passos:&#x0A;</sys:String>
-
-    <sys:String x:Key="W4">&#x0A;1. Abra o Windows LiveCaptions e siga o guia para descarregar os ficheiros necessários para reconhecimento de fala local e pacotes de idioma.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Clique no</sys:String>
-    <sys:String x:Key="W6">⚙️ ícone de engrenagem</sys:String>
-    <sys:String x:Key="W7">no Windows LiveCaptions para abrir o menu de definições e selecione</sys:String>
-    <sys:String x:Key="W8">"Posição > Sobreposto no ecrã"</sys:String>
-    <sys:String x:Key="W9">3. Clique no botão</sys:String>
-    <sys:String x:Key="W10">"Ocultar"</sys:String>
-    <sys:String x:Key="W11">localizado na página de definições do LiveCaptions Translator para ocultar o Windows LiveCaptions.&#x0A;</sys:String>
-
-    <sys:String x:Key="W12">&#x0A;O programa já navegou automaticamente para a página de definições e abriu o Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Após concluir a configuração, pode voltar à página principal e usufruir da tradução de áudio em tempo real.&#x0A;</sys:String>
-
-    <sys:String x:Key="W14">&#x0A;Para mais detalhes, visite a nossa wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-
-    <sys:String x:Key="W16">&#x0A;&#x0A;Dica:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Para alterar o </sys:String>
-    <sys:String x:Key="W18">Idioma de Origem</sys:String>
-    <sys:String x:Key="W19">, por favor [Mostrar] o LiveCaptions na página de definições e faça a alteração no Windows LiveCaptions.</sys:String>
-
-    <sys:String x:Key="W20">Compreendi e configurei totalmente.</sys:String>
-
-    <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Começar</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Bem-vindo ao LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">O LiveCaptions Translator baseia-se no Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Antes de executar pela primeira vez, configure-o de acordo com os seguintes passos:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Abra o Windows LiveCaptions e siga o guia para descarregar os ficheiros necessários para reconhecimento de fala local e pacotes de idioma.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Clique no</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ ícone de engrenagem</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">no Windows LiveCaptions para abrir o menu de definições e selecione</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Posição &gt; Sobreposto no ecrã"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Clique no botão</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Ocultar"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">localizado na página de definições do LiveCaptions Translator para ocultar o Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;O programa já navegou automaticamente para a página de definições e abriu o Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Após concluir a configuração, pode voltar à página principal e usufruir da tradução de áudio em tempo real.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Para mais detalhes, visite a nossa wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Dica:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Para alterar o </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Idioma de Origem</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, por favor [Mostrar] o LiveCaptions na página de definições e faça a alteração no Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Compreendi e configurei totalmente.</sys:String>
 
     <!-- Navigation menu -->
-    <sys:String x:Key="M10">Legenda</sys:String>
-    <sys:String x:Key="M11">Definições</sys:String>
-    <sys:String x:Key="M12">Histórico</sys:String>
-    <sys:String x:Key="M13">Informação</sys:String>
+    <sys:String x:Key="Navigation_Captions">Legenda</sys:String>
+    <sys:String x:Key="Navigation_Settings">Definições</sys:String>
+    <sys:String x:Key="Navigation_History">Histórico</sys:String>
+    <sys:String x:Key="Navigation_Info">Informação</sys:String>
 
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">Cartões de Log das Legendas</sys:String>
-    <sys:String x:Key="M21">Pausar Tradução (Só Log)</sys:String>
-    <sys:String x:Key="M22">Janela de Overlay</sys:String>
-    <sys:String x:Key="M23">Sempre em Cima</sys:String>
+    <!-- MainWindow strings -->
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Cartões de Log das Legendas</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pausar Tradução (Só Log)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Janela de Overlay</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Sempre em Cima</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[ERRO] Falha ao Verificar Atualizações.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">erro</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Nova Versão Disponível</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Foi detetada uma nova versão: {0} Versão atual: {1} Por favor visite o GitHub para descarregar a versão mais recente.</sys:String>
 
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[ERRO] Falha ao Verificar Atualizações.</sys:String>
-    <sys:String x:Key="MC1">erro</sys:String>
-
-    <sys:String x:Key="MC2">Nova Versão Disponível</sys:String>
-    <sys:String x:Key="MC3">Foi detetada uma nova versão: {0}
-Versão atual: {1}
-Por favor visite o GitHub para descarregar a versão mais recente.</sys:String>
-    <sys:String x:Key="MC4">Atualizar</sys:String>
-    <sys:String x:Key="MC5">Ignorar esta versão</sys:String>
-
-    <sys:String x:Key="MC6">[ERRO] Falha ao Abrir o Navegador.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[AVISO] O LiveCaptions foi fechado inesperadamente, reiniciando...</sys:String>
-    <sys:String x:Key="T1">[Pausado]</sys:String>
-    <sys:String x:Key="T2">Erro!</sys:String>
-    <sys:String x:Key="T3">Falha ao registar histórico: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[AVISO] O LiveCaptions foi fechado inesperadamente, reiniciando...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Pausado]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Erro!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Falha ao registar histórico: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Clique para Copiar</sys:String>
-    <sys:String x:Key="C1">Copiado</sys:String>
-    <sys:String x:Key="C2">Falha ao Copiar</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Clique para Copiar</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Copiado</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Falha ao Copiar</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/ru-ru.xaml
+++ b/src/localization/ru-ru.xaml
@@ -3,169 +3,157 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Живые субтитры</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Живые субтитры</sys:String>
     <sys:String x:Key="S1">После версии Windows 11 24H2 можно изменить только</sys:String>
-    <sys:String x:Key="S2">Язык источника</sys:String>
-    <sys:String x:Key="S3">в Живых субтитрах.</sys:String>
-    <sys:String x:Key="S4">Примечание:</sys:String>
-    <sys:String x:Key="S5">Пожалуйста, нажмите</sys:String>
-    <sys:String x:Key="S6">"Скрыть"</sys:String>
-    <sys:String x:Key="S7">чтобы скрыть Живые субтитры, а не закрывать их напрямую.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Язык источника</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">в Живых субтитрах.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Примечание:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Пожалуйста, нажмите</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Скрыть"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">чтобы скрыть Живые субтитры, а не закрывать их напрямую.</sys:String>
 
-    <sys:String x:Key="S8">Показать</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Показать</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Скрыть</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Скрыть</sys:String>
-    <sys:String x:Key="S46">Показать</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Интервал API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Определяет частоту вызовов API перевода. Чем меньше значение, тем чаще вызовы.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">API перевода вызывается один раз после изменения субтитра</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Интервал API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">раз.</sys:String>
 
-    <sys:String x:Key="S9">Интервал API</sys:String>
-    <sys:String x:Key="S10">Определяет частоту вызовов API перевода. Чем меньше значение, тем чаще вызовы.</sys:String>
-    <sys:String x:Key="S11">API перевода вызывается один раз после изменения субтитра</sys:String>
-    <sys:String x:Key="S12">[Интервал API]</sys:String>
-    <sys:String x:Key="S13">раз.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">API перевода</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">За исключением Google и Google2, все остальные API требуют настройки перед использованием.</sys:String>
 
-    <sys:String x:Key="S14">API перевода</sys:String>
-    <sys:String x:Key="S15">За исключением Google и Google2, все остальные API требуют настройки перед использованием.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Целевой язык</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Ожидаемого целевого языка нет!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Вы можете напрямую редактировать содержимое этого комбобокса для настройки языка, рекомендуется использовать</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">языковой тег BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Некоторые API (например, DeepL) требуют другого способа задания целевого языка, см. их официальную документацию.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Не нужно учитывать это для встроенных целевых языков, так как мы уже создали соответствие тегов. Но если нужного языка нет в списке, имейте это в виду.</sys:String>
 
-    <sys:String x:Key="S16">Целевой язык</sys:String>
-    <sys:String x:Key="S17">Ожидаемого целевого языка нет!</sys:String>
-    <sys:String x:Key="S18">Вы можете напрямую редактировать содержимое этого комбобокса для настройки языка, рекомендуется использовать</sys:String>
-    <sys:String x:Key="S19">языковой тег BCP 47.</sys:String>
-    <sys:String x:Key="S20">Некоторые API (например, DeepL) требуют другого способа задания целевого языка, см. их официальную документацию.</sys:String>
-    <sys:String x:Key="S21">Не нужно учитывать это для встроенных целевых языков, так как мы уже создали соответствие тегов. Но если нужного языка нет в списке, имейте это в виду.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Настройки API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Открыть</sys:String>
 
-    <sys:String x:Key="S22">Настройки API</sys:String>
-    <sys:String x:Key="S23">Открыть</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Показать задержку</sys:String>
+    <sys:String x:Key="Common_Off">Выкл.</sys:String>
+    <sys:String x:Key="Common_On">Вкл.</sys:String>
 
-    <sys:String x:Key="S24">Показать задержку</sys:String>
-    <sys:String x:Key="S25">Выкл.</sys:String>
-    <sys:String x:Key="S26">Вкл.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Контексты</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Контексты:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Определяет количество контекстных предложений при включенном</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Контекстном переводе</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Отображаемые предложения:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Определяет количество отображаемых карточек при включенных</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Картах журнала</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">а также максимальное количество предложений, отображаемых в окне наложения.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Контексты должны быть</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">больше или равны</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Отображаемым предложениям</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Если нет, программа скорректирует их автоматически.</sys:String>
 
-    <sys:String x:Key="S27">Контексты</sys:String>
-    <sys:String x:Key="S28">Контексты:</sys:String>
-    <sys:String x:Key="S29">Определяет количество контекстных предложений при включенном</sys:String>
-    <sys:String x:Key="S30">Контекстном переводе</sys:String>
-    <sys:String x:Key="S31">.</sys:String>
-    <sys:String x:Key="S32">Отображаемые предложения:</sys:String>
-    <sys:String x:Key="S33">Определяет количество отображаемых карточек при включенных</sys:String>
-    <sys:String x:Key="S34">Картах журнала</sys:String>
-    <sys:String x:Key="S35">а также максимальное количество предложений, отображаемых в окне наложения.</sys:String>
-    <sys:String x:Key="S36">Контексты должны быть</sys:String>
-    <sys:String x:Key="S37">больше или равны</sys:String>
-    <sys:String x:Key="S38">Отображаемым предложениям</sys:String>
-    <sys:String x:Key="S39">. Если нет, программа скорректирует их автоматически.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Отображаемые предложения</sys:String>
 
-    <sys:String x:Key="S40">Отображаемые предложения</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Перевод в контексте.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Это может улучшить точность перевода, но потребляет больше токенов.</sys:String>
 
-    <sys:String x:Key="S41">Перевод в контексте.</sys:String>
-    <sys:String x:Key="S42">Это может улучшить точность перевода, но потребляет больше токенов.</sys:String>
-
-    <sys:String x:Key="S43">Язык интерфейса</sys:String>
-    <sys:String x:Key="S44">Выберите язык интерфейса приложения.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Язык интерфейса</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Выберите язык интерфейса приложения.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Изменения вступают в силу сразу и сохраняются автоматически.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Предыдущая</sys:String>
-    <sys:String x:Key="H1">Следующая страница</sys:String>
-    <sys:String x:Key="H2">Поиск</sys:String>
-    <sys:String x:Key="H3">Экспорт</sys:String>
-    <sys:String x:Key="H4">Удалить все</sys:String>
-    <sys:String x:Key="H5">Обновить</sys:String>
-    <sys:String x:Key="H6">Время</sys:String>
-    <sys:String x:Key="H7">Субтитры</sys:String>
-    <sys:String x:Key="H8">Переведено</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/страница</sys:String>
-    <sys:String x:Key="H11">30/страница</sys:String>
-    <sys:String x:Key="H12">50/страница</sys:String>
-    <sys:String x:Key="H13">100/страница</sys:String>
-    <sys:String x:Key="H20">Вы действительно хотите удалить всю историю?</sys:String>
-    <sys:String x:Key="H21">Это действие нельзя отменить!</sys:String>
-    <sys:String x:Key="H22">Да</sys:String>
-    <sys:String x:Key="H23">Нет</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Все файлы (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Сохранение прошло успешно</sys:String>
-    <sys:String x:Key="H26">Файл сохранён: {0}</sys:String>
-    <sys:String x:Key="H27">Ошибка сохранения</sys:String>
-    <sys:String x:Key="H28">Не удалось сохранить файл: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Предыдущая</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Следующая страница</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Поиск</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Экспорт</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Удалить все</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Обновить</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Время</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Субтитры</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Переведено</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/страница</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/страница</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/страница</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/страница</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Вы действительно хотите удалить всю историю?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Это действие нельзя отменить!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Да</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Нет</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Все файлы (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Сохранение прошло успешно</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Файл сохранён: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Ошибка сохранения</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Не удалось сохранить файл: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Окно наложения</sys:String>
-    <sys:String x:Key="O1">Увеличить размер шрифта</sys:String>
-    <sys:String x:Key="O2">Уменьшить размер шрифта</sys:String>
-    <sys:String x:Key="O3">Увеличить обводку шрифта</sys:String>
-    <sys:String x:Key="O4">Уменьшить обводку шрифта</sys:String>
-    <sys:String x:Key="O5">Жирный</sys:String>
-    <sys:String x:Key="O6">Цвет шрифта</sys:String>
-    <sys:String x:Key="O7">Увеличить прозрачность фона</sys:String>
-    <sys:String x:Key="O8">Уменьшить прозрачность фона</sys:String>
-    <sys:String x:Key="O9">Цвет фона</sys:String>
-    <sys:String x:Key="O10">Показывать только субтитры или переводы</sys:String>
-    <sys:String x:Key="O11">Сменить позицию субтитров/переводов</sys:String>
-    <sys:String x:Key="O12">Кликабельность сквозь окно</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Окно наложения</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Увеличить размер шрифта</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Уменьшить размер шрифта</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Увеличить обводку шрифта</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Уменьшить обводку шрифта</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Жирный</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Цвет шрифта</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Увеличить прозрачность фона</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Уменьшить прозрачность фона</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Цвет фона</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Показывать только субтитры или переводы</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Сменить позицию субтитров/переводов</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Кликабельность сквозь окно</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Мы приветствуем любые виды вклада! Вы можете оставлять предложения или сообщать об ошибках через GitHub issues или отправлять код через Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Если эта программа полезна для вас, пожалуйста, поставьте нам звезду!</sys:String>
-    <sys:String x:Key="I2">Репозиторий:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Поддержка:</sys:String>
-    <sys:String x:Key="I5">(Автор) и</sys:String>
-    <sys:String x:Key="I6">Версия:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Мы приветствуем любые виды вклада! Вы можете оставлять предложения или сообщать об ошибках через GitHub issues или отправлять код через Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Если эта программа полезна для вас, пожалуйста, поставьте нам звезду!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Репозиторий:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Поддержка:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Автор) и</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Версия:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Начало работы</sys:String>
-    <sys:String x:Key="W1">Добро пожаловать в LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator основан на Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Перед первым запуском необходимо настроить программу по следующим шагам:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Откройте Windows LiveCaptions и следуйте инструкции для загрузки необходимых файлов распознавания речи и языковых пакетов.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Нажмите</sys:String>
-    <sys:String x:Key="W6">⚙️ значок</sys:String>
-    <sys:String x:Key="W7">в Windows LiveCaptions для открытия настроек и выберите</sys:String>
-    <sys:String x:Key="W8">"Позиция &gt; На экране"</sys:String>
-    <sys:String x:Key="W9">3. Нажмите</sys:String>
-    <sys:String x:Key="W10">"Скрыть"</sys:String>
-    <sys:String x:Key="W11">кнопку на странице настроек LiveCaptions Translator, чтобы скрыть Windows LiveCaptions.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Программа автоматически перешла на страницу настроек и открыла Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">После завершения настройки вы можете вернуться на главную страницу и наслаждаться переводом в реальном времени.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;Более подробную информацию см. в нашей wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Совет:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Чтобы изменить </sys:String>
-    <sys:String x:Key="W18">Язык источника</sys:String>
-    <sys:String x:Key="W19">, нажмите [Показать] на странице настроек и сделайте это в Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">Я полностью понял и настроил программу.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Начать</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Добро пожаловать в LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator основан на Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Перед первым запуском необходимо настроить программу по следующим шагам:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Откройте Windows LiveCaptions и следуйте инструкции для загрузки необходимых файлов распознавания речи и языковых пакетов.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Нажмите</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ значок</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">в Windows LiveCaptions для открытия настроек и выберите</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Позиция &gt; На экране"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Нажмите</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Скрыть"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">кнопку на странице настроек LiveCaptions Translator, чтобы скрыть Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Программа автоматически перешла на страницу настроек и открыла Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">После завершения настройки вы можете вернуться на главную страницу и наслаждаться переводом в реальном времени.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Более подробную информацию см. в нашей wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Совет:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Чтобы изменить </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Язык источника</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, нажмите [Показать] на странице настроек и сделайте это в Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Я полностью понял и настроил программу.</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Субтитры</sys:String>
-    <sys:String x:Key="M11">Настройки</sys:String>
-    <sys:String x:Key="M12">История</sys:String>
-    <sys:String x:Key="M13">Информация</sys:String>
-    <sys:String x:Key="M20">Карты логов субтитров</sys:String>
-    <sys:String x:Key="M21">Пауза перевода (только лог)</sys:String>
-    <sys:String x:Key="M22">Окно наложения</sys:String>
-    <sys:String x:Key="M23">Всегда поверх</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Карты логов субтитров</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Пауза перевода (только лог)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Окно наложения</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Всегда поверх</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[ОШИБКА] Проверка обновлений не удалась.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">ошибка</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Доступна новая версия</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Обнаружена новая версия: {0} Текущая версия: {1} Пожалуйста, посетите GitHub, чтобы скачать последнюю версию.</sys:String>
 
-    <sys:String x:Key="MC0">[ОШИБКА] Проверка обновлений не удалась.</sys:String>
-    <sys:String x:Key="MC1">ошибка</sys:String>
-    <sys:String x:Key="MC2">Доступна новая версия</sys:String>
-    <sys:String x:Key="MC3">Обнаружена новая версия: {0}
-Текущая версия: {1}
-Пожалуйста, посетите GitHub, чтобы скачать последнюю версию.</sys:String>
-    <sys:String x:Key="MC4">Обновить</sys:String>
-    <sys:String x:Key="MC5">Игнорировать эту версию</sys:String>
-    <sys:String x:Key="MC6">[ОШИБКА] Не удалось открыть браузер.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[ПРЕДУПРЕЖДЕНИЕ] LiveCaptions был неожиданно закрыт, перезапуск...</sys:String>
-    <sys:String x:Key="T1">[Пауза]</sys:String>
-    <sys:String x:Key="T2">Ошибка!</sys:String>
-    <sys:String x:Key="T3">Не удалось записать историю: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[ПРЕДУПРЕЖДЕНИЕ] LiveCaptions был неожиданно закрыт, перезапуск...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Пауза]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Ошибка!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Не удалось записать историю: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Нажмите, чтобы скопировать</sys:String>
-    <sys:String x:Key="C1">Скопировано</sys:String>
-    <sys:String x:Key="C2">Не удалось скопировать</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Нажмите, чтобы скопировать</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Скопировано</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Не удалось скопировать</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/ru-ru.xaml
+++ b/src/localization/ru-ru.xaml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Живые субтитры</sys:String>
+    <sys:String x:Key="S1">После версии Windows 11 24H2 можно изменить только</sys:String>
+    <sys:String x:Key="S2">Язык источника</sys:String>
+    <sys:String x:Key="S3">в Живых субтитрах.</sys:String>
+    <sys:String x:Key="S4">Примечание:</sys:String>
+    <sys:String x:Key="S5">Пожалуйста, нажмите</sys:String>
+    <sys:String x:Key="S6">"Скрыть"</sys:String>
+    <sys:String x:Key="S7">чтобы скрыть Живые субтитры, а не закрывать их напрямую.</sys:String>
+
+    <sys:String x:Key="S8">Показать</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Скрыть</sys:String>
+    <sys:String x:Key="S46">Показать</sys:String>
+
+    <sys:String x:Key="S9">Интервал API</sys:String>
+    <sys:String x:Key="S10">Определяет частоту вызовов API перевода. Чем меньше значение, тем чаще вызовы.</sys:String>
+    <sys:String x:Key="S11">API перевода вызывается один раз после изменения субтитра</sys:String>
+    <sys:String x:Key="S12">[Интервал API]</sys:String>
+    <sys:String x:Key="S13">раз.</sys:String>
+
+    <sys:String x:Key="S14">API перевода</sys:String>
+    <sys:String x:Key="S15">За исключением Google и Google2, все остальные API требуют настройки перед использованием.</sys:String>
+
+    <sys:String x:Key="S16">Целевой язык</sys:String>
+    <sys:String x:Key="S17">Ожидаемого целевого языка нет!</sys:String>
+    <sys:String x:Key="S18">Вы можете напрямую редактировать содержимое этого комбобокса для настройки языка, рекомендуется использовать</sys:String>
+    <sys:String x:Key="S19">языковой тег BCP 47.</sys:String>
+    <sys:String x:Key="S20">Некоторые API (например, DeepL) требуют другого способа задания целевого языка, см. их официальную документацию.</sys:String>
+    <sys:String x:Key="S21">Не нужно учитывать это для встроенных целевых языков, так как мы уже создали соответствие тегов. Но если нужного языка нет в списке, имейте это в виду.</sys:String>
+
+    <sys:String x:Key="S22">Настройки API</sys:String>
+    <sys:String x:Key="S23">Открыть</sys:String>
+
+    <sys:String x:Key="S24">Показать задержку</sys:String>
+    <sys:String x:Key="S25">Выкл.</sys:String>
+    <sys:String x:Key="S26">Вкл.</sys:String>
+
+    <sys:String x:Key="S27">Контексты</sys:String>
+    <sys:String x:Key="S28">Контексты:</sys:String>
+    <sys:String x:Key="S29">Определяет количество контекстных предложений при включенном</sys:String>
+    <sys:String x:Key="S30">Контекстном переводе</sys:String>
+    <sys:String x:Key="S31">.</sys:String>
+    <sys:String x:Key="S32">Отображаемые предложения:</sys:String>
+    <sys:String x:Key="S33">Определяет количество отображаемых карточек при включенных</sys:String>
+    <sys:String x:Key="S34">Картах журнала</sys:String>
+    <sys:String x:Key="S35">а также максимальное количество предложений, отображаемых в окне наложения.</sys:String>
+    <sys:String x:Key="S36">Контексты должны быть</sys:String>
+    <sys:String x:Key="S37">больше или равны</sys:String>
+    <sys:String x:Key="S38">Отображаемым предложениям</sys:String>
+    <sys:String x:Key="S39">. Если нет, программа скорректирует их автоматически.</sys:String>
+
+    <sys:String x:Key="S40">Отображаемые предложения</sys:String>
+
+    <sys:String x:Key="S41">Перевод в контексте.</sys:String>
+    <sys:String x:Key="S42">Это может улучшить точность перевода, но потребляет больше токенов.</sys:String>
+
+    <sys:String x:Key="S43">Язык интерфейса</sys:String>
+    <sys:String x:Key="S44">Выберите язык интерфейса приложения.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Предыдущая</sys:String>
+    <sys:String x:Key="H1">Следующая страница</sys:String>
+    <sys:String x:Key="H2">Поиск</sys:String>
+    <sys:String x:Key="H3">Экспорт</sys:String>
+    <sys:String x:Key="H4">Удалить все</sys:String>
+    <sys:String x:Key="H5">Обновить</sys:String>
+    <sys:String x:Key="H6">Время</sys:String>
+    <sys:String x:Key="H7">Субтитры</sys:String>
+    <sys:String x:Key="H8">Переведено</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/страница</sys:String>
+    <sys:String x:Key="H11">30/страница</sys:String>
+    <sys:String x:Key="H12">50/страница</sys:String>
+    <sys:String x:Key="H13">100/страница</sys:String>
+    <sys:String x:Key="H20">Вы действительно хотите удалить всю историю?</sys:String>
+    <sys:String x:Key="H21">Это действие нельзя отменить!</sys:String>
+    <sys:String x:Key="H22">Да</sys:String>
+    <sys:String x:Key="H23">Нет</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Все файлы (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Сохранение прошло успешно</sys:String>
+    <sys:String x:Key="H26">Файл сохранён: {0}</sys:String>
+    <sys:String x:Key="H27">Ошибка сохранения</sys:String>
+    <sys:String x:Key="H28">Не удалось сохранить файл: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Окно наложения</sys:String>
+    <sys:String x:Key="O1">Увеличить размер шрифта</sys:String>
+    <sys:String x:Key="O2">Уменьшить размер шрифта</sys:String>
+    <sys:String x:Key="O3">Увеличить обводку шрифта</sys:String>
+    <sys:String x:Key="O4">Уменьшить обводку шрифта</sys:String>
+    <sys:String x:Key="O5">Жирный</sys:String>
+    <sys:String x:Key="O6">Цвет шрифта</sys:String>
+    <sys:String x:Key="O7">Увеличить прозрачность фона</sys:String>
+    <sys:String x:Key="O8">Уменьшить прозрачность фона</sys:String>
+    <sys:String x:Key="O9">Цвет фона</sys:String>
+    <sys:String x:Key="O10">Показывать только субтитры или переводы</sys:String>
+    <sys:String x:Key="O11">Сменить позицию субтитров/переводов</sys:String>
+    <sys:String x:Key="O12">Кликабельность сквозь окно</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Мы приветствуем любые виды вклада! Вы можете оставлять предложения или сообщать об ошибках через GitHub issues или отправлять код через Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Если эта программа полезна для вас, пожалуйста, поставьте нам звезду!</sys:String>
+    <sys:String x:Key="I2">Репозиторий:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Поддержка:</sys:String>
+    <sys:String x:Key="I5">(Автор) и</sys:String>
+    <sys:String x:Key="I6">Версия:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Начало работы</sys:String>
+    <sys:String x:Key="W1">Добро пожаловать в LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator основан на Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Перед первым запуском необходимо настроить программу по следующим шагам:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Откройте Windows LiveCaptions и следуйте инструкции для загрузки необходимых файлов распознавания речи и языковых пакетов.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Нажмите</sys:String>
+    <sys:String x:Key="W6">⚙️ значок</sys:String>
+    <sys:String x:Key="W7">в Windows LiveCaptions для открытия настроек и выберите</sys:String>
+    <sys:String x:Key="W8">"Позиция &gt; На экране"</sys:String>
+    <sys:String x:Key="W9">3. Нажмите</sys:String>
+    <sys:String x:Key="W10">"Скрыть"</sys:String>
+    <sys:String x:Key="W11">кнопку на странице настроек LiveCaptions Translator, чтобы скрыть Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Программа автоматически перешла на страницу настроек и открыла Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">После завершения настройки вы можете вернуться на главную страницу и наслаждаться переводом в реальном времени.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;Более подробную информацию см. в нашей wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Совет:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Чтобы изменить </sys:String>
+    <sys:String x:Key="W18">Язык источника</sys:String>
+    <sys:String x:Key="W19">, нажмите [Показать] на странице настроек и сделайте это в Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">Я полностью понял и настроил программу.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Субтитры</sys:String>
+    <sys:String x:Key="M11">Настройки</sys:String>
+    <sys:String x:Key="M12">История</sys:String>
+    <sys:String x:Key="M13">Информация</sys:String>
+    <sys:String x:Key="M20">Карты логов субтитров</sys:String>
+    <sys:String x:Key="M21">Пауза перевода (только лог)</sys:String>
+    <sys:String x:Key="M22">Окно наложения</sys:String>
+    <sys:String x:Key="M23">Всегда поверх</sys:String>
+
+    <sys:String x:Key="MC0">[ОШИБКА] Проверка обновлений не удалась.</sys:String>
+    <sys:String x:Key="MC1">ошибка</sys:String>
+    <sys:String x:Key="MC2">Доступна новая версия</sys:String>
+    <sys:String x:Key="MC3">Обнаружена новая версия: {0}
+Текущая версия: {1}
+Пожалуйста, посетите GitHub, чтобы скачать последнюю версию.</sys:String>
+    <sys:String x:Key="MC4">Обновить</sys:String>
+    <sys:String x:Key="MC5">Игнорировать эту версию</sys:String>
+    <sys:String x:Key="MC6">[ОШИБКА] Не удалось открыть браузер.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[ПРЕДУПРЕЖДЕНИЕ] LiveCaptions был неожиданно закрыт, перезапуск...</sys:String>
+    <sys:String x:Key="T1">[Пауза]</sys:String>
+    <sys:String x:Key="T2">Ошибка!</sys:String>
+    <sys:String x:Key="T3">Не удалось записать историю: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Нажмите, чтобы скопировать</sys:String>
+    <sys:String x:Key="C1">Скопировано</sys:String>
+    <sys:String x:Key="C2">Не удалось скопировать</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/sv-se.xaml
+++ b/src/localization/sv-se.xaml
@@ -3,169 +3,156 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">LiveCaptions</sys:String>
-    <sys:String x:Key="S1">Efter Windows 11 version 24H2 kan du endast ändra</sys:String>
-    <sys:String x:Key="S2">Källspråk</sys:String>
-    <sys:String x:Key="S3">i LiveCaptions.</sys:String>
-    <sys:String x:Key="S4">Observera:</sys:String>
-    <sys:String x:Key="S5">Klicka på</sys:String>
-    <sys:String x:Key="S6">"Dölj"</sys:String>
-    <sys:String x:Key="S7">för att dölja LiveCaptions istället för att stänga det direkt.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">LiveCaptions</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_AfterWin11">Efter Windows 11 version 24H2 kan du endast ändra</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Källspråk</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">i LiveCaptions.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Observera:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Klicka på</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Dölj"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">för att dölja LiveCaptions istället för att stänga det direkt.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Visa</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Dölj</sys:String>
 
-    <sys:String x:Key="S8">Visa</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API-intervall</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Bestämmer hur ofta översättnings-API:et anropas. Ju mindre värde, desto oftare anrop.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">Översättnings-API anropas en gång efter att texten ändrats</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API-intervall]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">gånger.</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Dölj</sys:String>
-    <sys:String x:Key="S46">Visa</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">Översättnings-API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Förutom Google och Google2 kräver alla andra API:er konfigurering innan de kan användas.</sys:String>
 
-    <sys:String x:Key="S9">API-intervall</sys:String>
-    <sys:String x:Key="S10">Bestämmer hur ofta översättnings-API:et anropas. Ju mindre värde, desto oftare anrop.</sys:String>
-    <sys:String x:Key="S11">Översättnings-API anropas en gång efter att texten ändrats</sys:String>
-    <sys:String x:Key="S12">[API-intervall]</sys:String>
-    <sys:String x:Key="S13">gånger.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Målspråk</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Det finns inget målspråk jag förväntade mig!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Du kan direkt redigera innehållet i denna kombinationsruta för att anpassa språket. Det rekommenderas att följa</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47-språktagg.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Vissa API:er (t.ex. DeepL) kräver ett annat sätt att definiera målspråk, se deras officiella dokumentation för detaljer.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Behöver inte tas hänsyn till för inbyggda målspråk, eftersom vi redan har gjort taggkarta. Men om ditt förväntade språk inte finns med, tänk på detta.</sys:String>
 
-    <sys:String x:Key="S14">Översättnings-API</sys:String>
-    <sys:String x:Key="S15">Förutom Google och Google2 kräver alla andra API:er konfigurering innan de kan användas.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API-inställningar</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Öppna</sys:String>
 
-    <sys:String x:Key="S16">Målspråk</sys:String>
-    <sys:String x:Key="S17">Det finns inget målspråk jag förväntade mig!</sys:String>
-    <sys:String x:Key="S18">Du kan direkt redigera innehållet i denna kombinationsruta för att anpassa språket. Det rekommenderas att följa</sys:String>
-    <sys:String x:Key="S19">BCP 47-språktagg.</sys:String>
-    <sys:String x:Key="S20">Vissa API:er (t.ex. DeepL) kräver ett annat sätt att definiera målspråk, se deras officiella dokumentation för detaljer.</sys:String>
-    <sys:String x:Key="S21">Behöver inte tas hänsyn till för inbyggda målspråk, eftersom vi redan har gjort taggkarta. Men om ditt förväntade språk inte finns med, tänk på detta.</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Visa latens</sys:String>
+    <sys:String x:Key="Common_Off">Av</sys:String>
+    <sys:String x:Key="Common_On">På</sys:String>
 
-    <sys:String x:Key="S22">API-inställningar</sys:String>
-    <sys:String x:Key="S23">Öppna</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Kontexter</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Kontexter:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Bestämmer antalet kontextsmeningar när</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Kontextmedveten</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">är aktiverad.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Överlagda meningar:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Bestämmer antalet visade kort när</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Loggkort</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">är aktiverade, samt maximalt antal meningar som visas i överläggsfönstret.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Kontexter måste vara</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">större än eller lika med</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Visade meningar</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Om inte justerar programmet automatiskt.</sys:String>
 
-    <sys:String x:Key="S24">Visa latens</sys:String>
-    <sys:String x:Key="S25">Av</sys:String>
-    <sys:String x:Key="S26">På</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Visade meningar</sys:String>
 
-    <sys:String x:Key="S27">Kontexter</sys:String>
-    <sys:String x:Key="S28">Kontexter:</sys:String>
-    <sys:String x:Key="S29">Bestämmer antalet kontextsmeningar när</sys:String>
-    <sys:String x:Key="S30">Kontextmedveten</sys:String>
-    <sys:String x:Key="S31">är aktiverad.</sys:String>
-    <sys:String x:Key="S32">Överlagda meningar:</sys:String>
-    <sys:String x:Key="S33">Bestämmer antalet visade kort när</sys:String>
-    <sys:String x:Key="S34">Loggkort</sys:String>
-    <sys:String x:Key="S35">är aktiverade, samt maximalt antal meningar som visas i överläggsfönstret.</sys:String>
-    <sys:String x:Key="S36">Kontexter måste vara</sys:String>
-    <sys:String x:Key="S37">större än eller lika med</sys:String>
-    <sys:String x:Key="S38">Visade meningar</sys:String>
-    <sys:String x:Key="S39">. Om inte justerar programmet automatiskt.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Översätt i kontext.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Det kan förbättra översättningsnoggrannheten men använder fler tokens.</sys:String>
 
-    <sys:String x:Key="S40">Visade meningar</sys:String>
-
-    <sys:String x:Key="S41">Översätt i kontext.</sys:String>
-    <sys:String x:Key="S42">Det kan förbättra översättningsnoggrannheten men använder fler tokens.</sys:String>
-
-    <sys:String x:Key="S43">UI-språk</sys:String>
-    <sys:String x:Key="S44">Välj språket som används av applikationens användargränssnitt.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI-språk</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Välj språket som används av applikationens användargränssnitt.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Ändringar träder i kraft omedelbart och sparas automatiskt.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Föregående</sys:String>
-    <sys:String x:Key="H1">Nästa sida</sys:String>
-    <sys:String x:Key="H2">Sök</sys:String>
-    <sys:String x:Key="H3">Exportera</sys:String>
-    <sys:String x:Key="H4">Radera allt</sys:String>
-    <sys:String x:Key="H5">Uppdatera</sys:String>
-    <sys:String x:Key="H6">Tid</sys:String>
-    <sys:String x:Key="H7">Text</sys:String>
-    <sys:String x:Key="H8">Översatt</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/sida</sys:String>
-    <sys:String x:Key="H11">30/sida</sys:String>
-    <sys:String x:Key="H12">50/sida</sys:String>
-    <sys:String x:Key="H13">100/sida</sys:String>
-    <sys:String x:Key="H20">Vill du radera hela historiken?</sys:String>
-    <sys:String x:Key="H21">Denna åtgärd kan inte ångras!</sys:String>
-    <sys:String x:Key="H22">Ja</sys:String>
-    <sys:String x:Key="H23">Nej</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Alla filer (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Sparat framgångsrikt</sys:String>
-    <sys:String x:Key="H26">Fil sparad till: {0}</sys:String>
-    <sys:String x:Key="H27">Misslyckades med att spara</sys:String>
-    <sys:String x:Key="H28">Kunde inte spara fil: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Föregående</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Nästa sida</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Sök</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Exportera</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Radera allt</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Uppdatera</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Tid</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Text</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Översatt</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/sida</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/sida</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/sida</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/sida</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Vill du radera hela historiken?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Denna åtgärd kan inte ångras!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Ja</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Nej</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Alla filer (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Sparat framgångsrikt</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Fil sparad till: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Misslyckades med att spara</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Kunde inte spara fil: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Överläggsfönster</sys:String>
-    <sys:String x:Key="O1">Öka teckenstorlek</sys:String>
-    <sys:String x:Key="O2">Minska teckenstorlek</sys:String>
-    <sys:String x:Key="O3">Öka teckensnittets kant</sys:String>
-    <sys:String x:Key="O4">Minska teckensnittets kant</sys:String>
-    <sys:String x:Key="O5">Fet stil</sys:String>
-    <sys:String x:Key="O6">Teckenfärg</sys:String>
-    <sys:String x:Key="O7">Öka bakgrundens opacitet</sys:String>
-    <sys:String x:Key="O8">Minska bakgrundens opacitet</sys:String>
-    <sys:String x:Key="O9">Bakgrundsfärg</sys:String>
-    <sys:String x:Key="O10">Visa endast undertexter eller översättningar</sys:String>
-    <sys:String x:Key="O11">Byt plats på undertext/översättning</sys:String>
-    <sys:String x:Key="O12">Klicka igenom</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Överläggsfönster</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Öka teckenstorlek</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Minska teckenstorlek</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Öka teckensnittets kant</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Minska teckensnittets kant</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Fet stil</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Teckenfärg</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Öka bakgrundens opacitet</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Minska bakgrundens opacitet</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Bakgrundsfärg</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Visa endast undertexter eller översättningar</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Byt plats på undertext/översättning</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Klicka igenom</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Vi välkomnar alla former av bidrag! Du kan lämna förslag eller rapportera buggar via GitHub-issues, eller bidra med kod direkt via Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Om detta program är användbart för dig, överväg att ge oss en stjärna!</sys:String>
-    <sys:String x:Key="I2">Repository:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Underhållare:</sys:String>
-    <sys:String x:Key="I5">(Författare) och</sys:String>
-    <sys:String x:Key="I6">Version:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Vi välkomnar alla former av bidrag! Du kan lämna förslag eller rapportera buggar via GitHub-issues, eller bidra med kod direkt via Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Om detta program är användbart för dig, överväg att ge oss en stjärna!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Repository:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Underhållare:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Författare) och</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Version:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Kom igång</sys:String>
-    <sys:String x:Key="W1">Välkommen till LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator är baserat på Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Innan du kör första gången, behöver du konfigurera enligt följande steg:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Öppna Windows LiveCaptions och följ guiden för att ladda ner nödvändiga filer för taligenkänning och språkpaket.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Klicka på</sys:String>
-    <sys:String x:Key="W6">⚙️-ikonen</sys:String>
-    <sys:String x:Key="W7">i Windows LiveCaptions för att öppna inställningsmenyn och välj</sys:String>
-    <sys:String x:Key="W8">"Position &gt; Överlagrad på skärmen"</sys:String>
-    <sys:String x:Key="W9">3. Klicka på</sys:String>
-    <sys:String x:Key="W10">"Dölj"</sys:String>
-    <sys:String x:Key="W11">knappen på inställningssidan för LiveCaptions Translator för att dölja Windows LiveCaptions.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Programmet har automatiskt navigerat till inställningssidan och öppnat Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Efter att konfigurationen är klar kan du gå tillbaka till huvudsidan och njuta av realtidsöversättning.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;För mer information, besök vår wiki: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Tips:&#x0A;</sys:String>
-    <sys:String x:Key="W17">För att ändra </sys:String>
-    <sys:String x:Key="W18">Källspråk</sys:String>
-    <sys:String x:Key="W19">, visa LiveCaptions på inställningssidan och gör ändringen i Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">Jag har full förståelse och har konfigurerat.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Kom igång</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Välkommen till LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator är baserat på Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Innan du kör första gången, behöver du konfigurera enligt följande steg:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Öppna Windows LiveCaptions och följ guiden för att ladda ner nödvändiga filer för taligenkänning och språkpaket.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Klicka på</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️-ikonen</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">i Windows LiveCaptions för att öppna inställningsmenyn och välj</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Position &gt; Överlagrad på skärmen"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Klicka på</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Dölj"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">knappen på inställningssidan för LiveCaptions Translator för att dölja Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Programmet har automatiskt navigerat till inställningssidan och öppnat Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Efter att konfigurationen är klar kan du gå tillbaka till huvudsidan och njuta av realtidsöversättning.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;För mer information, besök vår wiki: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Tips:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">För att ändra </sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Källspråk</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, visa LiveCaptions på inställningssidan och gör ändringen i Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Jag har full förståelse och har konfigurerat.</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Text</sys:String>
-    <sys:String x:Key="M11">Inställningar</sys:String>
-    <sys:String x:Key="M12">Historia</sys:String>
-    <sys:String x:Key="M13">Info</sys:String>
-    <sys:String x:Key="M20">Loggkort av undertexter</sys:String>
-    <sys:String x:Key="M21">Pausa översättning (endast logg)</sys:String>
-    <sys:String x:Key="M22">Överläggsfönster</sys:String>
-    <sys:String x:Key="M23">Alltid överst</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Loggkort av undertexter</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Pausa översättning (endast logg)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Överläggsfönster</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Alltid överst</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[FEL] Uppdateringskontroll misslyckades.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">fel</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Ny version tillgänglig</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">En ny version har upptäckts: {0} Nuvarande version: {1} Besök GitHub för att ladda ner den senaste releasen.</sys:String>
 
-    <sys:String x:Key="MC0">[FEL] Uppdateringskontroll misslyckades.</sys:String>
-    <sys:String x:Key="MC1">fel</sys:String>
-    <sys:String x:Key="MC2">Ny version tillgänglig</sys:String>
-    <sys:String x:Key="MC3">En ny version har upptäckts: {0}
-Nuvarande version: {1}
-Besök GitHub för att ladda ner den senaste releasen.</sys:String>
-    <sys:String x:Key="MC4">Uppdatera</sys:String>
-    <sys:String x:Key="MC5">Ignorera denna version</sys:String>
-    <sys:String x:Key="MC6">[FEL] Kunde inte öppna webbläsare.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[VARNING] LiveCaptions stängdes oväntat, startar om...</sys:String>
-    <sys:String x:Key="T1">[Pausad]</sys:String>
-    <sys:String x:Key="T2">Fel!</sys:String>
-    <sys:String x:Key="T3">Loggning av historik misslyckades: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[VARNING] LiveCaptions stängdes oväntat, startar om...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Pausad]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Fel!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Loggning av historik misslyckades: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Klicka för att kopiera</sys:String>
-    <sys:String x:Key="C1">Kopierad</sys:String>
-    <sys:String x:Key="C2">Kopiering misslyckades</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Klicka för att kopiera</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Kopierad</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Kopiering misslyckades</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/sv-se.xaml
+++ b/src/localization/sv-se.xaml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">LiveCaptions</sys:String>
+    <sys:String x:Key="S1">Efter Windows 11 version 24H2 kan du endast ändra</sys:String>
+    <sys:String x:Key="S2">Källspråk</sys:String>
+    <sys:String x:Key="S3">i LiveCaptions.</sys:String>
+    <sys:String x:Key="S4">Observera:</sys:String>
+    <sys:String x:Key="S5">Klicka på</sys:String>
+    <sys:String x:Key="S6">"Dölj"</sys:String>
+    <sys:String x:Key="S7">för att dölja LiveCaptions istället för att stänga det direkt.</sys:String>
+
+    <sys:String x:Key="S8">Visa</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Dölj</sys:String>
+    <sys:String x:Key="S46">Visa</sys:String>
+
+    <sys:String x:Key="S9">API-intervall</sys:String>
+    <sys:String x:Key="S10">Bestämmer hur ofta översättnings-API:et anropas. Ju mindre värde, desto oftare anrop.</sys:String>
+    <sys:String x:Key="S11">Översättnings-API anropas en gång efter att texten ändrats</sys:String>
+    <sys:String x:Key="S12">[API-intervall]</sys:String>
+    <sys:String x:Key="S13">gånger.</sys:String>
+
+    <sys:String x:Key="S14">Översättnings-API</sys:String>
+    <sys:String x:Key="S15">Förutom Google och Google2 kräver alla andra API:er konfigurering innan de kan användas.</sys:String>
+
+    <sys:String x:Key="S16">Målspråk</sys:String>
+    <sys:String x:Key="S17">Det finns inget målspråk jag förväntade mig!</sys:String>
+    <sys:String x:Key="S18">Du kan direkt redigera innehållet i denna kombinationsruta för att anpassa språket. Det rekommenderas att följa</sys:String>
+    <sys:String x:Key="S19">BCP 47-språktagg.</sys:String>
+    <sys:String x:Key="S20">Vissa API:er (t.ex. DeepL) kräver ett annat sätt att definiera målspråk, se deras officiella dokumentation för detaljer.</sys:String>
+    <sys:String x:Key="S21">Behöver inte tas hänsyn till för inbyggda målspråk, eftersom vi redan har gjort taggkarta. Men om ditt förväntade språk inte finns med, tänk på detta.</sys:String>
+
+    <sys:String x:Key="S22">API-inställningar</sys:String>
+    <sys:String x:Key="S23">Öppna</sys:String>
+
+    <sys:String x:Key="S24">Visa latens</sys:String>
+    <sys:String x:Key="S25">Av</sys:String>
+    <sys:String x:Key="S26">På</sys:String>
+
+    <sys:String x:Key="S27">Kontexter</sys:String>
+    <sys:String x:Key="S28">Kontexter:</sys:String>
+    <sys:String x:Key="S29">Bestämmer antalet kontextsmeningar när</sys:String>
+    <sys:String x:Key="S30">Kontextmedveten</sys:String>
+    <sys:String x:Key="S31">är aktiverad.</sys:String>
+    <sys:String x:Key="S32">Överlagda meningar:</sys:String>
+    <sys:String x:Key="S33">Bestämmer antalet visade kort när</sys:String>
+    <sys:String x:Key="S34">Loggkort</sys:String>
+    <sys:String x:Key="S35">är aktiverade, samt maximalt antal meningar som visas i överläggsfönstret.</sys:String>
+    <sys:String x:Key="S36">Kontexter måste vara</sys:String>
+    <sys:String x:Key="S37">större än eller lika med</sys:String>
+    <sys:String x:Key="S38">Visade meningar</sys:String>
+    <sys:String x:Key="S39">. Om inte justerar programmet automatiskt.</sys:String>
+
+    <sys:String x:Key="S40">Visade meningar</sys:String>
+
+    <sys:String x:Key="S41">Översätt i kontext.</sys:String>
+    <sys:String x:Key="S42">Det kan förbättra översättningsnoggrannheten men använder fler tokens.</sys:String>
+
+    <sys:String x:Key="S43">UI-språk</sys:String>
+    <sys:String x:Key="S44">Välj språket som används av applikationens användargränssnitt.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Föregående</sys:String>
+    <sys:String x:Key="H1">Nästa sida</sys:String>
+    <sys:String x:Key="H2">Sök</sys:String>
+    <sys:String x:Key="H3">Exportera</sys:String>
+    <sys:String x:Key="H4">Radera allt</sys:String>
+    <sys:String x:Key="H5">Uppdatera</sys:String>
+    <sys:String x:Key="H6">Tid</sys:String>
+    <sys:String x:Key="H7">Text</sys:String>
+    <sys:String x:Key="H8">Översatt</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/sida</sys:String>
+    <sys:String x:Key="H11">30/sida</sys:String>
+    <sys:String x:Key="H12">50/sida</sys:String>
+    <sys:String x:Key="H13">100/sida</sys:String>
+    <sys:String x:Key="H20">Vill du radera hela historiken?</sys:String>
+    <sys:String x:Key="H21">Denna åtgärd kan inte ångras!</sys:String>
+    <sys:String x:Key="H22">Ja</sys:String>
+    <sys:String x:Key="H23">Nej</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Alla filer (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Sparat framgångsrikt</sys:String>
+    <sys:String x:Key="H26">Fil sparad till: {0}</sys:String>
+    <sys:String x:Key="H27">Misslyckades med att spara</sys:String>
+    <sys:String x:Key="H28">Kunde inte spara fil: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Överläggsfönster</sys:String>
+    <sys:String x:Key="O1">Öka teckenstorlek</sys:String>
+    <sys:String x:Key="O2">Minska teckenstorlek</sys:String>
+    <sys:String x:Key="O3">Öka teckensnittets kant</sys:String>
+    <sys:String x:Key="O4">Minska teckensnittets kant</sys:String>
+    <sys:String x:Key="O5">Fet stil</sys:String>
+    <sys:String x:Key="O6">Teckenfärg</sys:String>
+    <sys:String x:Key="O7">Öka bakgrundens opacitet</sys:String>
+    <sys:String x:Key="O8">Minska bakgrundens opacitet</sys:String>
+    <sys:String x:Key="O9">Bakgrundsfärg</sys:String>
+    <sys:String x:Key="O10">Visa endast undertexter eller översättningar</sys:String>
+    <sys:String x:Key="O11">Byt plats på undertext/översättning</sys:String>
+    <sys:String x:Key="O12">Klicka igenom</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Vi välkomnar alla former av bidrag! Du kan lämna förslag eller rapportera buggar via GitHub-issues, eller bidra med kod direkt via Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Om detta program är användbart för dig, överväg att ge oss en stjärna!</sys:String>
+    <sys:String x:Key="I2">Repository:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Underhållare:</sys:String>
+    <sys:String x:Key="I5">(Författare) och</sys:String>
+    <sys:String x:Key="I6">Version:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Kom igång</sys:String>
+    <sys:String x:Key="W1">Välkommen till LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator är baserat på Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Innan du kör första gången, behöver du konfigurera enligt följande steg:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Öppna Windows LiveCaptions och följ guiden för att ladda ner nödvändiga filer för taligenkänning och språkpaket.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Klicka på</sys:String>
+    <sys:String x:Key="W6">⚙️-ikonen</sys:String>
+    <sys:String x:Key="W7">i Windows LiveCaptions för att öppna inställningsmenyn och välj</sys:String>
+    <sys:String x:Key="W8">"Position &gt; Överlagrad på skärmen"</sys:String>
+    <sys:String x:Key="W9">3. Klicka på</sys:String>
+    <sys:String x:Key="W10">"Dölj"</sys:String>
+    <sys:String x:Key="W11">knappen på inställningssidan för LiveCaptions Translator för att dölja Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Programmet har automatiskt navigerat till inställningssidan och öppnat Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Efter att konfigurationen är klar kan du gå tillbaka till huvudsidan och njuta av realtidsöversättning.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;För mer information, besök vår wiki: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Tips:&#x0A;</sys:String>
+    <sys:String x:Key="W17">För att ändra </sys:String>
+    <sys:String x:Key="W18">Källspråk</sys:String>
+    <sys:String x:Key="W19">, visa LiveCaptions på inställningssidan och gör ändringen i Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">Jag har full förståelse och har konfigurerat.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Text</sys:String>
+    <sys:String x:Key="M11">Inställningar</sys:String>
+    <sys:String x:Key="M12">Historia</sys:String>
+    <sys:String x:Key="M13">Info</sys:String>
+    <sys:String x:Key="M20">Loggkort av undertexter</sys:String>
+    <sys:String x:Key="M21">Pausa översättning (endast logg)</sys:String>
+    <sys:String x:Key="M22">Överläggsfönster</sys:String>
+    <sys:String x:Key="M23">Alltid överst</sys:String>
+
+    <sys:String x:Key="MC0">[FEL] Uppdateringskontroll misslyckades.</sys:String>
+    <sys:String x:Key="MC1">fel</sys:String>
+    <sys:String x:Key="MC2">Ny version tillgänglig</sys:String>
+    <sys:String x:Key="MC3">En ny version har upptäckts: {0}
+Nuvarande version: {1}
+Besök GitHub för att ladda ner den senaste releasen.</sys:String>
+    <sys:String x:Key="MC4">Uppdatera</sys:String>
+    <sys:String x:Key="MC5">Ignorera denna version</sys:String>
+    <sys:String x:Key="MC6">[FEL] Kunde inte öppna webbläsare.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[VARNING] LiveCaptions stängdes oväntat, startar om...</sys:String>
+    <sys:String x:Key="T1">[Pausad]</sys:String>
+    <sys:String x:Key="T2">Fel!</sys:String>
+    <sys:String x:Key="T3">Loggning av historik misslyckades: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Klicka för att kopiera</sys:String>
+    <sys:String x:Key="C1">Kopierad</sys:String>
+    <sys:String x:Key="C2">Kopiering misslyckades</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/tr-tr.xaml
+++ b/src/localization/tr-tr.xaml
@@ -3,184 +3,162 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Canlı Altyazılar</sys:String>
-    <sys:String x:Key="S1">Windows 11 sürüm 24H2'den sonra, yalnızca</sys:String>
-    <sys:String x:Key="S2">Kaynak Dili</sys:String>
-    <sys:String x:Key="S3">Canlı Altyazılar'da değiştirilebilir.</sys:String>
-    <sys:String x:Key="S4">Not:</sys:String>
-    <sys:String x:Key="S5">Lütfen tıklayın</sys:String>
-    <sys:String x:Key="S6">"Gizle"</sys:String>
-    <sys:String x:Key="S7">Canlı Altyazıları doğrudan kapatmak yerine gizlemek için.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Canlı Altyazılar</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_Text1">Windows 11 sürüm 24H2'den sonra, yalnızca</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Kaynak Dili</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">Canlı Altyazılar'da değiştirilebilir.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Not:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Lütfen tıklayın</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Gizle"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">Canlı Altyazıları doğrudan kapatmak yerine gizlemek için.</sys:String>
 
-    <sys:String x:Key="S8">Göster</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Göster</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Gizle</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Gizle</sys:String>
-    <sys:String x:Key="S46">Göster</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API Aralığı</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Çeviri API çağrılarının sıklığını belirler. Daha küçük değer, daha sık çağrı demektir.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">Altyazı değiştikten sonra çeviri API'si</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API Aralığı]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">kere çağrılır.</sys:String>
 
-    <sys:String x:Key="S9">API Aralığı</sys:String>
-    <sys:String x:Key="S10">Çeviri API çağrılarının sıklığını belirler. Daha küçük değer, daha sık çağrı demektir.</sys:String>
-    <sys:String x:Key="S11">Altyazı değiştikten sonra çeviri API'si</sys:String>
-    <sys:String x:Key="S12">[API Aralığı]</sys:String>
-    <sys:String x:Key="S13">kere çağrılır.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">Çeviri API'si</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Google ve Google2 dışındaki tüm API'ler kullanılmadan önce yapılandırılmalıdır.</sys:String>
 
-    <sys:String x:Key="S14">Çeviri API'si</sys:String>
-    <sys:String x:Key="S15">Google ve Google2 dışındaki tüm API'ler kullanılmadan önce yapılandırılmalıdır.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Hedef Dil</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Beklediğim hedef dil yok!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Bu açılır kutunun içeriğini doğrudan düzenleyebilir ve dili özelleştirebilirsiniz; BCP 47 dil etiketini takip etmeniz önerilir.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47 dil etiketi.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Bazı API'ler (ör. DeepL) hedef dili farklı bir şekilde tanımlar, daha fazla bilgi için resmi belgelerine bakın.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Dahili hedef diller için bunu düşünmenize gerek yok, çünkü etiket eşlemeleri zaten mevcut. Ancak beklediğiniz dil listede yoksa bunu unutmayın.</sys:String>
 
-    <sys:String x:Key="S16">Hedef Dil</sys:String>
-    <sys:String x:Key="S17">Beklediğim hedef dil yok!</sys:String>
-    <sys:String x:Key="S18">Bu açılır kutunun içeriğini doğrudan düzenleyebilir ve dili özelleştirebilirsiniz; BCP 47 dil etiketini takip etmeniz önerilir.</sys:String>
-    <sys:String x:Key="S19">BCP 47 dil etiketi.</sys:String>
-    <sys:String x:Key="S20">Bazı API'ler (ör. DeepL) hedef dili farklı bir şekilde tanımlar, daha fazla bilgi için resmi belgelerine bakın.</sys:String>
-    <sys:String x:Key="S21">Dahili hedef diller için bunu düşünmenize gerek yok, çünkü etiket eşlemeleri zaten mevcut. Ancak beklediğiniz dil listede yoksa bunu unutmayın.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API Ayarları</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Aç</sys:String>
 
-    <sys:String x:Key="S22">API Ayarları</sys:String>
-    <sys:String x:Key="S23">Aç</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Gecikmeyi Göster</sys:String>
+    <sys:String x:Key="Common_Off">Kapalı</sys:String>
+    <sys:String x:Key="Common_On">Açık</sys:String>
 
-    <sys:String x:Key="S24">Gecikmeyi Göster</sys:String>
-    <sys:String x:Key="S25">Kapalı</sys:String>
-    <sys:String x:Key="S26">Açık</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Bağlamlar</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Bağlamlar:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Bağlam Bilinçli çeviri etkin olduğunda bağlam cümlelerinin sayısını belirler.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Bağlam Bilinçli</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">etkinleştirildiğinde.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Kaplama Cümleler:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Log Kartları etkin olduğunda gösterilen kart sayısını ve Kaplama Penceresinde gösterilen maksimum cümle sayısını belirler.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Log Kartları</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">etkinleştirildiğinde, ayrıca Kaplama Penceresinde gösterilen maksimum cümle sayısı.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Bağlam sayısı</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">en az</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Gösterilecek Cümleler</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">olmalıdır. Karşılanmazsa, program otomatik olarak ayarlayacaktır.</sys:String>
 
-    <sys:String x:Key="S27">Bağlamlar</sys:String>
-    <sys:String x:Key="S28">Bağlamlar:</sys:String>
-    <sys:String x:Key="S29">Bağlam Bilinçli çeviri etkin olduğunda bağlam cümlelerinin sayısını belirler.</sys:String>
-    <sys:String x:Key="S30">Bağlam Bilinçli</sys:String>
-    <sys:String x:Key="S31">etkinleştirildiğinde.</sys:String>
-    <sys:String x:Key="S32">Kaplama Cümleler:</sys:String>
-    <sys:String x:Key="S33">Log Kartları etkin olduğunda gösterilen kart sayısını ve Kaplama Penceresinde gösterilen maksimum cümle sayısını belirler.</sys:String>
-    <sys:String x:Key="S34">Log Kartları</sys:String>
-    <sys:String x:Key="S35">etkinleştirildiğinde, ayrıca Kaplama Penceresinde gösterilen maksimum cümle sayısı.</sys:String>
-    <sys:String x:Key="S36">Bağlam sayısı</sys:String>
-    <sys:String x:Key="S37">en az</sys:String>
-    <sys:String x:Key="S38">Gösterilecek Cümleler</sys:String>
-    <sys:String x:Key="S39">olmalıdır. Karşılanmazsa, program otomatik olarak ayarlayacaktır.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Gösterilecek Cümleler</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Bağlam içinde çevir.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Çeviri doğruluğunu artırabilir, ancak daha fazla token tüketir.</sys:String>
 
-    <sys:String x:Key="S40">Gösterilecek Cümleler</sys:String>
-
-    <sys:String x:Key="S41">Bağlam içinde çevir.</sys:String>
-    <sys:String x:Key="S42">Çeviri doğruluğunu artırabilir, ancak daha fazla token tüketir.</sys:String>
-
-    <sys:String x:Key="S43">UI Dili</sys:String>
-    <sys:String x:Key="S44">Uygulamanın kullanıcı arayüzü dili seçin.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">UI Dili</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Uygulamanın kullanıcı arayüzü dili seçin.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Değişiklikler anında geçerli olur ve otomatik kaydedilir.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Önceki</sys:String>
-    <sys:String x:Key="H1">Sonraki Sayfa</sys:String>
-    <sys:String x:Key="H2">Ara</sys:String>
-    <sys:String x:Key="H3">Dışa Aktar</sys:String>
-    <sys:String x:Key="H4">Tümünü Sil</sys:String>
-    <sys:String x:Key="H5">Yenile</sys:String>
-    <sys:String x:Key="H6">Zaman</sys:String>
-    <sys:String x:Key="H7">Altyazı</sys:String>
-    <sys:String x:Key="H8">Çevirisi</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/sayfa</sys:String>
-    <sys:String x:Key="H11">30/sayfa</sys:String>
-    <sys:String x:Key="H12">50/sayfa</sys:String>
-    <sys:String x:Key="H13">100/sayfa</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Önceki Sayfa</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Sonraki Sayfa</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Ara</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Dışa Aktar</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Tümünü Sil</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Yenile</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Zaman</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Altyazı</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Çevirisi</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/sayfa</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/sayfa</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/sayfa</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/sayfa</sys:String>
 
-    <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">Tüm geçmişi silmek istiyor musunuz?</sys:String>
-    <sys:String x:Key="H21">Bu işlem geri alınamaz!</sys:String>
-    <sys:String x:Key="H22">Evet</sys:String>
-    <sys:String x:Key="H23">Hayır</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Tüm dosyalar (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Başarıyla Kaydedildi</sys:String>
-    <sys:String x:Key="H26">Dosya kaydedildi: {0}</sys:String>
-    <sys:String x:Key="H27">Kaydetme Başarısız</sys:String>
-    <sys:String x:Key="H28">Dosya kaydedilemedi: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Tüm geçmişi silmek istiyor musunuz?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Bu işlem geri alınamaz!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Evet</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Hayır</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Tüm dosyalar (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Başarıyla Kaydedildi</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Dosya kaydedildi: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Kaydetme Başarısız</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Dosya kaydedilemedi: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Kaplama Penceresi</sys:String>
-    <sys:String x:Key="O1">Yazı Tipi Boyutunu Artır</sys:String>
-    <sys:String x:Key="O2">Yazı Tipi Boyutunu Azalt</sys:String>
-    <sys:String x:Key="O3">Yazı Tipi Çizgisi Artır</sys:String>
-    <sys:String x:Key="O4">Yazı Tipi Çizgisi Azalt</sys:String>
-    <sys:String x:Key="O5">Kalın Yazı Tipi</sys:String>
-    <sys:String x:Key="O6">Yazı Rengi</sys:String>
-    <sys:String x:Key="O7">Arka Plan Opaklığı Artır</sys:String>
-    <sys:String x:Key="O8">Arka Plan Opaklığı Azalt</sys:String>
-    <sys:String x:Key="O9">Arka Plan Rengi</sys:String>
-    <sys:String x:Key="O10">Sadece altyazı veya çeviriyi göster</sys:String>
-    <sys:String x:Key="O11">Altyazı/çeviri konumunu değiştir</sys:String>
-    <sys:String x:Key="O12">Tıklamayı Geç</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Kaplama Penceresi</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Yazı Tipi Boyutunu Artır</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Yazı Tipi Boyutunu Azalt</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Yazı Tipi Çizgisi Artır</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Yazı Tipi Çizgisi Azalt</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Kalın Yazı Tipi</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Yazı Rengi</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Arka Plan Opaklığı Artır</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Arka Plan Opaklığı Azalt</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Arka Plan Rengi</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Sadece altyazı veya çeviriyi göster</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Altyazı/çeviri konumunu değiştir</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Tıklamayı Geç</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Her türlü katkıya açığız! Öneri veya hata bildirimi için GitHub issues kullanabilir veya Pull Request göndererek doğrudan kod katkısında bulunabilirsiniz.</sys:String>
-    <sys:String x:Key="I1">Bu program size yardımcı olduysa, lütfen bize bir yıldız verin!</sys:String>
-    <sys:String x:Key="I2">Depo:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Bakımcı:</sys:String>
-    <sys:String x:Key="I5">(Yazar) ve</sys:String>
-    <sys:String x:Key="I6">Sürüm:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Her türlü katkıya açığız! Öneri veya hata bildirimi için GitHub issues kullanabilir veya Pull Request göndererek doğrudan kod katkısında bulunabilirsiniz.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Bu program size yardımcı olduysa, lütfen bize bir yıldız verin!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Depo:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Bakımcı:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Yazar) ve</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Sürüm:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Başlarken</sys:String>
-    <sys:String x:Key="W1">LiveCaptions Translator'a Hoşgeldiniz!</sys:String>
-
-    <sys:String x:Key="W2">LiveCaptions Translator, Windows LiveCaptions tabanlıdır.</sys:String>
-    <sys:String x:Key="W3">&#x0A;İlk çalıştırmadan önce, aşağıdaki adımlara göre yapılandırmanız gerekir:&#x0A;</sys:String>
-
-    <sys:String x:Key="W4">&#x0A;1. Windows LiveCaptions'ı açın ve cihaz üzeri konuşma tanıma ve dil paketlerini indirme kılavuzunu takip edin.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Windows LiveCaptions'ta ayarlar menüsünü açmak için</sys:String>
-    <sys:String x:Key="W6">⚙️ dişli</sys:String>
-    <sys:String x:Key="W7">simgesine tıklayın ve şunu seçin</sys:String>
-    <sys:String x:Key="W8">"Konum > Ekranda Üstüste"</sys:String>
-    <sys:String x:Key="W9">3. CanlıAltyazılar Translator ayar sayfasında bulunan</sys:String>
-    <sys:String x:Key="W10">"Gizle"</sys:String>
-    <sys:String x:Key="W11">butonuna tıklayarak Windows LiveCaptions'ı gizleyin.&#x0A;</sys:String>
-
-    <sys:String x:Key="W12">&#x0A;Program otomatik olarak ayar sayfasına yönlendirildi ve Windows LiveCaptions açıldı.</sys:String>
-    <sys:String x:Key="W13">Yapılandırmayı tamamladıktan sonra, ana sayfaya geri dönebilir ve gerçek zamanlı ses çevirisinin tadını çıkarabilirsiniz.&#x0A;</sys:String>
-
-    <sys:String x:Key="W14">&#x0A;Detaylar için wiki sayfamızı ziyaret edin: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-
-    <sys:String x:Key="W16">&#x0A;&#x0A;İpucu:&#x0A;</sys:String>
-    <sys:String x:Key="W17"> </sys:String>
-    <sys:String x:Key="W18">Kaynak Dili</sys:String>
-    <sys:String x:Key="W19"> değiştirmek için ayar sayfasında LiveCaptions'ı [Göster] yapın ve bunu Windows LiveCaptions içinde yapın.</sys:String>
-
-    <sys:String x:Key="W20">Tamamen anladım ve yapılandırdım.</sys:String>
-
-    <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Başlayın</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">LiveCaptions Translator'a Hoşgeldiniz!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator, Windows LiveCaptions tabanlıdır.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;İlk çalıştırmadan önce, aşağıdaki adımlara göre yapılandırmanız gerekir:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Windows LiveCaptions'ı açın ve cihaz üzeri konuşma tanıma ve dil paketlerini indirme kılavuzunu takip edin.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Windows LiveCaptions'ta ayarlar menüsünü açmak için</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ dişli</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">simgesine tıklayın ve şunu seçin</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Konum &gt; Ekranda Üstüste"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. CanlıAltyazılar Translator ayar sayfasında bulunan</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Gizle"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">butonuna tıklayarak Windows LiveCaptions'ı gizleyin.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Program otomatik olarak ayar sayfasına yönlendirildi ve Windows LiveCaptions açıldı.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Yapılandırmayı tamamladıktan sonra, ana sayfaya geri dönebilir ve gerçek zamanlı ses çevirisinin tadını çıkarabilirsiniz.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Detaylar için wiki sayfamızı ziyaret edin: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;İpucu:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Kaynak Dili</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage"> değiştirmek için ayar sayfasında LiveCaptions'ı [Göster] yapın ve bunu Windows LiveCaptions içinde yapın.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Tamamen anladım ve yapılandırdım.</sys:String>
 
     <!-- Navigation menu -->
-    <sys:String x:Key="M10">Altyazı</sys:String>
-    <sys:String x:Key="M11">Ayarlar</sys:String>
-    <sys:String x:Key="M12">Geçmiş</sys:String>
-    <sys:String x:Key="M13">Bilgi</sys:String>
+    <sys:String x:Key="Navigation_Captions">Altyazı</sys:String>
+    <sys:String x:Key="Navigation_Settings">Ayarlar</sys:String>
+    <sys:String x:Key="Navigation_History">Geçmiş</sys:String>
+    <sys:String x:Key="Navigation_Info">Bilgi</sys:String>
 
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">Altyazı Log Kartları</sys:String>
-    <sys:String x:Key="M21">Çeviriyi Duraklat (Sadece Log)</sys:String>
-    <sys:String x:Key="M22">Kaplama Penceresi</sys:String>
-    <sys:String x:Key="M23">Her Zaman Üstte</sys:String>
+    <!-- MainWindow strings -->
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Altyazı Log Kartları</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Çeviriyi Duraklat (Sadece Log)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Kaplama Penceresi</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Her Zaman Üstte</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[HATA] Güncelleme Kontrolü Başarısız.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">hata</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Yeni Sürüm Mevcut</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Yeni bir sürüm tespit edildi: {0} Mevcut sürüm: {1} Lütfen en son sürümü indirmek için GitHub'u ziyaret edin.</sys:String>
 
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[HATA] Güncelleme Kontrolü Başarısız.</sys:String>
-    <sys:String x:Key="MC1">hata</sys:String>
-
-    <sys:String x:Key="MC2">Yeni Sürüm Mevcut</sys:String>
-    <sys:String x:Key="MC3">Yeni bir sürüm tespit edildi: {0}
-Mevcut sürüm: {1}
-Lütfen en son sürümü indirmek için GitHub'u ziyaret edin.</sys:String>
-    <sys:String x:Key="MC4">Güncelle</sys:String>
-    <sys:String x:Key="MC5">Bu sürümü yoksay</sys:String>
-
-    <sys:String x:Key="MC6">[HATA] Tarayıcı Açma Başarısız.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[UYARI] LiveCaptions beklenmedik şekilde kapandı, yeniden başlatılıyor...</sys:String>
-    <sys:String x:Key="T1">[Duraklatıldı]</sys:String>
-    <sys:String x:Key="T2">Hata!</sys:String>
-    <sys:String x:Key="T3">Geçmiş kaydı başarısız: {0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[UYARI] LiveCaptions beklenmedik şekilde kapandı, yeniden başlatılıyor...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Duraklatıldı]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Hata!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Geçmiş kaydı başarısız: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Kopyalamak için tıklayın</sys:String>
-    <sys:String x:Key="C1">Kopyalandı</sys:String>
-    <sys:String x:Key="C2">Kopyalama Başarısız</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Kopyalamak için tıklayın</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Kopyalandı</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Kopyalama Başarısız</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/tr-tr.xaml
+++ b/src/localization/tr-tr.xaml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Canlı Altyazılar</sys:String>
+    <sys:String x:Key="S1">Windows 11 sürüm 24H2'den sonra, yalnızca</sys:String>
+    <sys:String x:Key="S2">Kaynak Dili</sys:String>
+    <sys:String x:Key="S3">Canlı Altyazılar'da değiştirilebilir.</sys:String>
+    <sys:String x:Key="S4">Not:</sys:String>
+    <sys:String x:Key="S5">Lütfen tıklayın</sys:String>
+    <sys:String x:Key="S6">"Gizle"</sys:String>
+    <sys:String x:Key="S7">Canlı Altyazıları doğrudan kapatmak yerine gizlemek için.</sys:String>
+
+    <sys:String x:Key="S8">Göster</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Gizle</sys:String>
+    <sys:String x:Key="S46">Göster</sys:String>
+
+    <sys:String x:Key="S9">API Aralığı</sys:String>
+    <sys:String x:Key="S10">Çeviri API çağrılarının sıklığını belirler. Daha küçük değer, daha sık çağrı demektir.</sys:String>
+    <sys:String x:Key="S11">Altyazı değiştikten sonra çeviri API'si</sys:String>
+    <sys:String x:Key="S12">[API Aralığı]</sys:String>
+    <sys:String x:Key="S13">kere çağrılır.</sys:String>
+
+    <sys:String x:Key="S14">Çeviri API'si</sys:String>
+    <sys:String x:Key="S15">Google ve Google2 dışındaki tüm API'ler kullanılmadan önce yapılandırılmalıdır.</sys:String>
+
+    <sys:String x:Key="S16">Hedef Dil</sys:String>
+    <sys:String x:Key="S17">Beklediğim hedef dil yok!</sys:String>
+    <sys:String x:Key="S18">Bu açılır kutunun içeriğini doğrudan düzenleyebilir ve dili özelleştirebilirsiniz; BCP 47 dil etiketini takip etmeniz önerilir.</sys:String>
+    <sys:String x:Key="S19">BCP 47 dil etiketi.</sys:String>
+    <sys:String x:Key="S20">Bazı API'ler (ör. DeepL) hedef dili farklı bir şekilde tanımlar, daha fazla bilgi için resmi belgelerine bakın.</sys:String>
+    <sys:String x:Key="S21">Dahili hedef diller için bunu düşünmenize gerek yok, çünkü etiket eşlemeleri zaten mevcut. Ancak beklediğiniz dil listede yoksa bunu unutmayın.</sys:String>
+
+    <sys:String x:Key="S22">API Ayarları</sys:String>
+    <sys:String x:Key="S23">Aç</sys:String>
+
+    <sys:String x:Key="S24">Gecikmeyi Göster</sys:String>
+    <sys:String x:Key="S25">Kapalı</sys:String>
+    <sys:String x:Key="S26">Açık</sys:String>
+
+    <sys:String x:Key="S27">Bağlamlar</sys:String>
+    <sys:String x:Key="S28">Bağlamlar:</sys:String>
+    <sys:String x:Key="S29">Bağlam Bilinçli çeviri etkin olduğunda bağlam cümlelerinin sayısını belirler.</sys:String>
+    <sys:String x:Key="S30">Bağlam Bilinçli</sys:String>
+    <sys:String x:Key="S31">etkinleştirildiğinde.</sys:String>
+    <sys:String x:Key="S32">Kaplama Cümleler:</sys:String>
+    <sys:String x:Key="S33">Log Kartları etkin olduğunda gösterilen kart sayısını ve Kaplama Penceresinde gösterilen maksimum cümle sayısını belirler.</sys:String>
+    <sys:String x:Key="S34">Log Kartları</sys:String>
+    <sys:String x:Key="S35">etkinleştirildiğinde, ayrıca Kaplama Penceresinde gösterilen maksimum cümle sayısı.</sys:String>
+    <sys:String x:Key="S36">Bağlam sayısı</sys:String>
+    <sys:String x:Key="S37">en az</sys:String>
+    <sys:String x:Key="S38">Gösterilecek Cümleler</sys:String>
+    <sys:String x:Key="S39">olmalıdır. Karşılanmazsa, program otomatik olarak ayarlayacaktır.</sys:String>
+
+    <sys:String x:Key="S40">Gösterilecek Cümleler</sys:String>
+
+    <sys:String x:Key="S41">Bağlam içinde çevir.</sys:String>
+    <sys:String x:Key="S42">Çeviri doğruluğunu artırabilir, ancak daha fazla token tüketir.</sys:String>
+
+    <sys:String x:Key="S43">UI Dili</sys:String>
+    <sys:String x:Key="S44">Uygulamanın kullanıcı arayüzü dili seçin.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Önceki</sys:String>
+    <sys:String x:Key="H1">Sonraki Sayfa</sys:String>
+    <sys:String x:Key="H2">Ara</sys:String>
+    <sys:String x:Key="H3">Dışa Aktar</sys:String>
+    <sys:String x:Key="H4">Tümünü Sil</sys:String>
+    <sys:String x:Key="H5">Yenile</sys:String>
+    <sys:String x:Key="H6">Zaman</sys:String>
+    <sys:String x:Key="H7">Altyazı</sys:String>
+    <sys:String x:Key="H8">Çevirisi</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/sayfa</sys:String>
+    <sys:String x:Key="H11">30/sayfa</sys:String>
+    <sys:String x:Key="H12">50/sayfa</sys:String>
+    <sys:String x:Key="H13">100/sayfa</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">Tüm geçmişi silmek istiyor musunuz?</sys:String>
+    <sys:String x:Key="H21">Bu işlem geri alınamaz!</sys:String>
+    <sys:String x:Key="H22">Evet</sys:String>
+    <sys:String x:Key="H23">Hayır</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Tüm dosyalar (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Başarıyla Kaydedildi</sys:String>
+    <sys:String x:Key="H26">Dosya kaydedildi: {0}</sys:String>
+    <sys:String x:Key="H27">Kaydetme Başarısız</sys:String>
+    <sys:String x:Key="H28">Dosya kaydedilemedi: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Kaplama Penceresi</sys:String>
+    <sys:String x:Key="O1">Yazı Tipi Boyutunu Artır</sys:String>
+    <sys:String x:Key="O2">Yazı Tipi Boyutunu Azalt</sys:String>
+    <sys:String x:Key="O3">Yazı Tipi Çizgisi Artır</sys:String>
+    <sys:String x:Key="O4">Yazı Tipi Çizgisi Azalt</sys:String>
+    <sys:String x:Key="O5">Kalın Yazı Tipi</sys:String>
+    <sys:String x:Key="O6">Yazı Rengi</sys:String>
+    <sys:String x:Key="O7">Arka Plan Opaklığı Artır</sys:String>
+    <sys:String x:Key="O8">Arka Plan Opaklığı Azalt</sys:String>
+    <sys:String x:Key="O9">Arka Plan Rengi</sys:String>
+    <sys:String x:Key="O10">Sadece altyazı veya çeviriyi göster</sys:String>
+    <sys:String x:Key="O11">Altyazı/çeviri konumunu değiştir</sys:String>
+    <sys:String x:Key="O12">Tıklamayı Geç</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Her türlü katkıya açığız! Öneri veya hata bildirimi için GitHub issues kullanabilir veya Pull Request göndererek doğrudan kod katkısında bulunabilirsiniz.</sys:String>
+    <sys:String x:Key="I1">Bu program size yardımcı olduysa, lütfen bize bir yıldız verin!</sys:String>
+    <sys:String x:Key="I2">Depo:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Bakımcı:</sys:String>
+    <sys:String x:Key="I5">(Yazar) ve</sys:String>
+    <sys:String x:Key="I6">Sürüm:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Başlarken</sys:String>
+    <sys:String x:Key="W1">LiveCaptions Translator'a Hoşgeldiniz!</sys:String>
+
+    <sys:String x:Key="W2">LiveCaptions Translator, Windows LiveCaptions tabanlıdır.</sys:String>
+    <sys:String x:Key="W3">&#x0A;İlk çalıştırmadan önce, aşağıdaki adımlara göre yapılandırmanız gerekir:&#x0A;</sys:String>
+
+    <sys:String x:Key="W4">&#x0A;1. Windows LiveCaptions'ı açın ve cihaz üzeri konuşma tanıma ve dil paketlerini indirme kılavuzunu takip edin.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Windows LiveCaptions'ta ayarlar menüsünü açmak için</sys:String>
+    <sys:String x:Key="W6">⚙️ dişli</sys:String>
+    <sys:String x:Key="W7">simgesine tıklayın ve şunu seçin</sys:String>
+    <sys:String x:Key="W8">"Konum > Ekranda Üstüste"</sys:String>
+    <sys:String x:Key="W9">3. CanlıAltyazılar Translator ayar sayfasında bulunan</sys:String>
+    <sys:String x:Key="W10">"Gizle"</sys:String>
+    <sys:String x:Key="W11">butonuna tıklayarak Windows LiveCaptions'ı gizleyin.&#x0A;</sys:String>
+
+    <sys:String x:Key="W12">&#x0A;Program otomatik olarak ayar sayfasına yönlendirildi ve Windows LiveCaptions açıldı.</sys:String>
+    <sys:String x:Key="W13">Yapılandırmayı tamamladıktan sonra, ana sayfaya geri dönebilir ve gerçek zamanlı ses çevirisinin tadını çıkarabilirsiniz.&#x0A;</sys:String>
+
+    <sys:String x:Key="W14">&#x0A;Detaylar için wiki sayfamızı ziyaret edin: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+
+    <sys:String x:Key="W16">&#x0A;&#x0A;İpucu:&#x0A;</sys:String>
+    <sys:String x:Key="W17"> </sys:String>
+    <sys:String x:Key="W18">Kaynak Dili</sys:String>
+    <sys:String x:Key="W19"> değiştirmek için ayar sayfasında LiveCaptions'ı [Göster] yapın ve bunu Windows LiveCaptions içinde yapın.</sys:String>
+
+    <sys:String x:Key="W20">Tamamen anladım ve yapılandırdım.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">Altyazı</sys:String>
+    <sys:String x:Key="M11">Ayarlar</sys:String>
+    <sys:String x:Key="M12">Geçmiş</sys:String>
+    <sys:String x:Key="M13">Bilgi</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">Altyazı Log Kartları</sys:String>
+    <sys:String x:Key="M21">Çeviriyi Duraklat (Sadece Log)</sys:String>
+    <sys:String x:Key="M22">Kaplama Penceresi</sys:String>
+    <sys:String x:Key="M23">Her Zaman Üstte</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[HATA] Güncelleme Kontrolü Başarısız.</sys:String>
+    <sys:String x:Key="MC1">hata</sys:String>
+
+    <sys:String x:Key="MC2">Yeni Sürüm Mevcut</sys:String>
+    <sys:String x:Key="MC3">Yeni bir sürüm tespit edildi: {0}
+Mevcut sürüm: {1}
+Lütfen en son sürümü indirmek için GitHub'u ziyaret edin.</sys:String>
+    <sys:String x:Key="MC4">Güncelle</sys:String>
+    <sys:String x:Key="MC5">Bu sürümü yoksay</sys:String>
+
+    <sys:String x:Key="MC6">[HATA] Tarayıcı Açma Başarısız.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[UYARI] LiveCaptions beklenmedik şekilde kapandı, yeniden başlatılıyor...</sys:String>
+    <sys:String x:Key="T1">[Duraklatıldı]</sys:String>
+    <sys:String x:Key="T2">Hata!</sys:String>
+    <sys:String x:Key="T3">Geçmiş kaydı başarısız: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Kopyalamak için tıklayın</sys:String>
+    <sys:String x:Key="C1">Kopyalandı</sys:String>
+    <sys:String x:Key="C2">Kopyalama Başarısız</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/vi-vn.xaml
+++ b/src/localization/vi-vn.xaml
@@ -3,169 +3,157 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">Phụ đề trực tiếp</sys:String>
-    <sys:String x:Key="S1">Sau phiên bản Windows 11 24H2, bạn chỉ có thể thay đổi</sys:String>
-    <sys:String x:Key="S2">Ngôn ngữ nguồn</sys:String>
-    <sys:String x:Key="S3">trong Phụ đề trực tiếp.</sys:String>
-    <sys:String x:Key="S4">Lưu ý:</sys:String>
-    <sys:String x:Key="S5">Vui lòng nhấp</sys:String>
-    <sys:String x:Key="S6">"Ẩn"</sys:String>
-    <sys:String x:Key="S7">để ẩn Phụ đề trực tiếp thay vì đóng trực tiếp.</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">Phụ đề trực tiếp</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_Notice">Sau phiên bản Windows 11 24H2, bạn chỉ có thể thay đổi</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">Ngôn ngữ nguồn</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">trong Phụ đề trực tiếp.</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">Lưu ý:</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">Vui lòng nhấp</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"Ẩn"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">để ẩn Phụ đề trực tiếp thay vì đóng trực tiếp.</sys:String>
 
-    <sys:String x:Key="S8">Hiển thị</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">Hiển thị</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">Ẩn</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">Ẩn</sys:String>
-    <sys:String x:Key="S46">Hiển thị</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">Khoảng thời gian API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">Xác định tần suất gọi API dịch. Giá trị nhỏ hơn sẽ gọi API thường xuyên hơn.</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">API dịch sẽ được gọi một lần sau khi phụ đề thay đổi</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[Khoảng thời gian API]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">lần.</sys:String>
 
-    <sys:String x:Key="S9">Khoảng thời gian API</sys:String>
-    <sys:String x:Key="S10">Xác định tần suất gọi API dịch. Giá trị nhỏ hơn sẽ gọi API thường xuyên hơn.</sys:String>
-    <sys:String x:Key="S11">API dịch sẽ được gọi một lần sau khi phụ đề thay đổi</sys:String>
-    <sys:String x:Key="S12">[Khoảng thời gian API]</sys:String>
-    <sys:String x:Key="S13">lần.</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">API dịch</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">Ngoại trừ Google và Google2, tất cả các API khác cần được cấu hình trước khi sử dụng.</sys:String>
 
-    <sys:String x:Key="S14">API dịch</sys:String>
-    <sys:String x:Key="S15">Ngoại trừ Google và Google2, tất cả các API khác cần được cấu hình trước khi sử dụng.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">Ngôn ngữ đích</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">Không có ngôn ngữ đích mà tôi mong đợi!</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">Bạn có thể trực tiếp chỉnh sửa nội dung của hộp kết hợp này để tùy chỉnh ngôn ngữ, khuyến nghị theo</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">thẻ ngôn ngữ BCP 47.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">Một số API (như DeepL) yêu cầu cách khác để định nghĩa ngôn ngữ đích, xem tài liệu chính thức để biết chi tiết.</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">Không cần quan tâm đến điều này đối với các ngôn ngữ đích đã tích hợp, vì chúng tôi đã tạo sẵn bản đồ thẻ. Nhưng nếu ngôn ngữ mong muốn không có trong danh sách, hãy lưu ý.</sys:String>
 
-    <sys:String x:Key="S16">Ngôn ngữ đích</sys:String>
-    <sys:String x:Key="S17">Không có ngôn ngữ đích mà tôi mong đợi!</sys:String>
-    <sys:String x:Key="S18">Bạn có thể trực tiếp chỉnh sửa nội dung của hộp kết hợp này để tùy chỉnh ngôn ngữ, khuyến nghị theo</sys:String>
-    <sys:String x:Key="S19">thẻ ngôn ngữ BCP 47.</sys:String>
-    <sys:String x:Key="S20">Một số API (như DeepL) yêu cầu cách khác để định nghĩa ngôn ngữ đích, xem tài liệu chính thức để biết chi tiết.</sys:String>
-    <sys:String x:Key="S21">Không cần quan tâm đến điều này đối với các ngôn ngữ đích đã tích hợp, vì chúng tôi đã tạo sẵn bản đồ thẻ. Nhưng nếu ngôn ngữ mong muốn không có trong danh sách, hãy lưu ý.</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">Cài đặt API</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">Mở</sys:String>
 
-    <sys:String x:Key="S22">Cài đặt API</sys:String>
-    <sys:String x:Key="S23">Mở</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">Hiển thị độ trễ</sys:String>
+    <sys:String x:Key="Common_Off">Tắt</sys:String>
+    <sys:String x:Key="Common_On">Bật</sys:String>
 
-    <sys:String x:Key="S24">Hiển thị độ trễ</sys:String>
-    <sys:String x:Key="S25">Tắt</sys:String>
-    <sys:String x:Key="S26">Bật</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">Ngữ cảnh</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">Ngữ cảnh:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">Xác định số câu ngữ cảnh khi</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">Nhận thức ngữ cảnh</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">được bật.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">Câu hiển thị:</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">Xác định số thẻ hiển thị khi</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">Thẻ nhật ký</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">được bật, cũng như số câu tối đa hiển thị trong cửa sổ lớp phủ.</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">Ngữ cảnh phải</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">lớn hơn hoặc bằng</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">Câu hiển thị</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">. Nếu không, chương trình sẽ tự động điều chỉnh.</sys:String>
 
-    <sys:String x:Key="S27">Ngữ cảnh</sys:String>
-    <sys:String x:Key="S28">Ngữ cảnh:</sys:String>
-    <sys:String x:Key="S29">Xác định số câu ngữ cảnh khi</sys:String>
-    <sys:String x:Key="S30">Nhận thức ngữ cảnh</sys:String>
-    <sys:String x:Key="S31">được bật.</sys:String>
-    <sys:String x:Key="S32">Câu hiển thị:</sys:String>
-    <sys:String x:Key="S33">Xác định số thẻ hiển thị khi</sys:String>
-    <sys:String x:Key="S34">Thẻ nhật ký</sys:String>
-    <sys:String x:Key="S35">được bật, cũng như số câu tối đa hiển thị trong cửa sổ lớp phủ.</sys:String>
-    <sys:String x:Key="S36">Ngữ cảnh phải</sys:String>
-    <sys:String x:Key="S37">lớn hơn hoặc bằng</sys:String>
-    <sys:String x:Key="S38">Câu hiển thị</sys:String>
-    <sys:String x:Key="S39">. Nếu không, chương trình sẽ tự động điều chỉnh.</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">Câu hiển thị</sys:String>
 
-    <sys:String x:Key="S40">Câu hiển thị</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">Dịch trong ngữ cảnh.</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">Điều này có thể cải thiện độ chính xác của bản dịch, nhưng sẽ tốn nhiều token hơn.</sys:String>
 
-    <sys:String x:Key="S41">Dịch trong ngữ cảnh.</sys:String>
-    <sys:String x:Key="S42">Điều này có thể cải thiện độ chính xác của bản dịch, nhưng sẽ tốn nhiều token hơn.</sys:String>
-
-    <sys:String x:Key="S43">Ngôn ngữ giao diện</sys:String>
-    <sys:String x:Key="S44">Chọn ngôn ngữ sử dụng cho giao diện ứng dụng.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">Ngôn ngữ giao diện</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">Chọn ngôn ngữ sử dụng cho giao diện ứng dụng.</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">Thay đổi có hiệu lực ngay lập tức và được lưu tự động.</sys:String>
 
     <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">Trước</sys:String>
-    <sys:String x:Key="H1">Trang tiếp theo</sys:String>
-    <sys:String x:Key="H2">Tìm kiếm</sys:String>
-    <sys:String x:Key="H3">Xuất</sys:String>
-    <sys:String x:Key="H4">Xóa tất cả</sys:String>
-    <sys:String x:Key="H5">Làm mới</sys:String>
-    <sys:String x:Key="H6">Thời gian</sys:String>
-    <sys:String x:Key="H7">Phụ đề</sys:String>
-    <sys:String x:Key="H8">Đã dịch</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/trang</sys:String>
-    <sys:String x:Key="H11">30/trang</sys:String>
-    <sys:String x:Key="H12">50/trang</sys:String>
-    <sys:String x:Key="H13">100/trang</sys:String>
-    <sys:String x:Key="H20">Bạn có muốn xóa toàn bộ lịch sử không?</sys:String>
-    <sys:String x:Key="H21">Hành động này không thể hoàn tác!</sys:String>
-    <sys:String x:Key="H22">Có</sys:String>
-    <sys:String x:Key="H23">Không</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Tất cả tệp (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">Lưu thành công</sys:String>
-    <sys:String x:Key="H26">Tệp đã lưu tại: {0}</sys:String>
-    <sys:String x:Key="H27">Lưu thất bại</sys:String>
-    <sys:String x:Key="H28">Không lưu được tệp: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Previous">Trước</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">Trang tiếp theo</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">Tìm kiếm</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">Xuất</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">Xóa tất cả</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">Làm mới</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">Thời gian</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">Phụ đề</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">Đã dịch</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/trang</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/trang</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/trang</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/trang</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">Bạn có muốn xóa toàn bộ lịch sử không?</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">Hành động này không thể hoàn tác!</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">Có</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">Không</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|Tất cả tệp (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">Lưu thành công</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">Tệp đã lưu tại: {0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">Lưu thất bại</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">Không lưu được tệp: {0}</sys:String>
 
     <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">Cửa sổ lớp phủ</sys:String>
-    <sys:String x:Key="O1">Tăng cỡ chữ</sys:String>
-    <sys:String x:Key="O2">Giảm cỡ chữ</sys:String>
-    <sys:String x:Key="O3">Tăng viền chữ</sys:String>
-    <sys:String x:Key="O4">Giảm viền chữ</sys:String>
-    <sys:String x:Key="O5">Đậm</sys:String>
-    <sys:String x:Key="O6">Màu chữ</sys:String>
-    <sys:String x:Key="O7">Tăng độ mờ nền</sys:String>
-    <sys:String x:Key="O8">Giảm độ mờ nền</sys:String>
-    <sys:String x:Key="O9">Màu nền</sys:String>
-    <sys:String x:Key="O10">Chỉ hiển thị phụ đề hoặc bản dịch</sys:String>
-    <sys:String x:Key="O11">Chuyển vị trí phụ đề/bản dịch</sys:String>
-    <sys:String x:Key="O12">Nhấp xuyên qua</sys:String>
+    <sys:String x:Key="OverlayWindow_Title">Cửa sổ lớp phủ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">Tăng cỡ chữ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">Giảm cỡ chữ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">Tăng viền chữ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">Giảm viền chữ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">Đậm</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">Màu chữ</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">Tăng độ mờ nền</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">Giảm độ mờ nền</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">Màu nền</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">Chỉ hiển thị phụ đề hoặc bản dịch</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">Chuyển vị trí phụ đề/bản dịch</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">Nhấp xuyên qua</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">Chúng tôi hoan nghênh mọi hình thức đóng góp! Bạn có thể gửi đề xuất hoặc báo lỗi qua GitHub issues, hoặc đóng góp mã trực tiếp bằng Pull Requests.</sys:String>
-    <sys:String x:Key="I1">Nếu chương trình này hữu ích với bạn, hãy cân nhắc cho chúng tôi một ngôi sao!</sys:String>
-    <sys:String x:Key="I2">Kho lưu trữ:</sys:String>
-    <sys:String x:Key="I3">Wiki:</sys:String>
-    <sys:String x:Key="I4">Người duy trì:</sys:String>
-    <sys:String x:Key="I5">(Tác giả) và</sys:String>
-    <sys:String x:Key="I6">Phiên bản:</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">Chúng tôi hoan nghênh mọi hình thức đóng góp! Bạn có thể gửi đề xuất hoặc báo lỗi qua GitHub issues, hoặc đóng góp mã trực tiếp bằng Pull Requests.</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">Nếu chương trình này hữu ích với bạn, hãy cân nhắc cho chúng tôi một ngôi sao!</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">Kho lưu trữ:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki:</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">Người duy trì:</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(Tác giả) và</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">Phiên bản:</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">Bắt đầu</sys:String>
-    <sys:String x:Key="W1">Chào mừng đến với LiveCaptions Translator!</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator dựa trên Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W3">&#x0A;Trước khi chạy lần đầu, bạn cần cấu hình theo các bước sau:&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. Mở Windows LiveCaptions và làm theo hướng dẫn để tải các tệp cần thiết cho nhận dạng giọng nói và gói ngôn ngữ.</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. Nhấp vào</sys:String>
-    <sys:String x:Key="W6">biểu tượng ⚙️</sys:String>
-    <sys:String x:Key="W7">trong Windows LiveCaptions để mở menu cài đặt và chọn</sys:String>
-    <sys:String x:Key="W8">"Vị trí &gt; Chồng lên màn hình"</sys:String>
-    <sys:String x:Key="W9">3. Nhấp vào</sys:String>
-    <sys:String x:Key="W10">"Ẩn"</sys:String>
-    <sys:String x:Key="W11">nút trên trang cài đặt của LiveCaptions Translator để ẩn Windows LiveCaptions.&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;Chương trình đã tự động điều hướng đến trang cài đặt và mở Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W13">Sau khi cấu hình xong, bạn có thể trở lại trang chính và thưởng thức dịch âm thanh thời gian thực.&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;Chi tiết hơn, hãy truy cập wiki của chúng tôi: </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;Mẹo:&#x0A;</sys:String>
-    <sys:String x:Key="W17">Để thay đổi </sys:String>
-    <sys:String x:Key="W18">Ngôn ngữ nguồn</sys:String>
-    <sys:String x:Key="W19">, hãy [Hiển thị] LiveCaptions trên trang cài đặt và thực hiện trong Windows LiveCaptions.</sys:String>
-    <sys:String x:Key="W20">Tôi đã hiểu đầy đủ và đã cấu hình.</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">Bắt đầu</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">Chào mừng đến với LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator dựa trên Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;Trước khi chạy lần đầu, bạn cần cấu hình theo các bước sau:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. Mở Windows LiveCaptions và làm theo hướng dẫn để tải các tệp cần thiết cho nhận dạng giọng nói và gói ngôn ngữ.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. Nhấp vào</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">biểu tượng ⚙️</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">trong Windows LiveCaptions để mở menu cài đặt và chọn</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"Vị trí &gt; Chồng lên màn hình"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. Nhấp vào</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"Ẩn"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">nút trên trang cài đặt của LiveCaptions Translator để ẩn Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;Chương trình đã tự động điều hướng đến trang cài đặt và mở Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">Sau khi cấu hình xong, bạn có thể trở lại trang chính và thưởng thức dịch âm thanh thời gian thực.&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;Chi tiết hơn, hãy truy cập wiki của chúng tôi: </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;Mẹo:&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">Để thay đổi</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">Ngôn ngữ nguồn</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">, hãy [Hiển thị] LiveCaptions trên trang cài đặt và thực hiện trong Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">Tôi đã hiểu đầy đủ và đã cấu hình.</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">Phụ đề</sys:String>
-    <sys:String x:Key="M11">Cài đặt</sys:String>
-    <sys:String x:Key="M12">Lịch sử</sys:String>
-    <sys:String x:Key="M13">Thông tin</sys:String>
-    <sys:String x:Key="M20">Thẻ nhật ký của phụ đề</sys:String>
-    <sys:String x:Key="M21">Tạm dừng dịch (chỉ nhật ký)</sys:String>
-    <sys:String x:Key="M22">Cửa sổ lớp phủ</sys:String>
-    <sys:String x:Key="M23">Luôn ở trên cùng</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">Thẻ nhật ký của phụ đề</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">Tạm dừng dịch (chỉ nhật ký)</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">Cửa sổ lớp phủ</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">Luôn ở trên cùng</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[LỖI] Kiểm tra cập nhật thất bại.</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">lỗi</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">Có phiên bản mới</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">Phát hiện phiên bản mới: {0} Phiên bản hiện tại: {1} Vui lòng truy cập GitHub để tải phiên bản mới nhất.</sys:String>
 
-    <sys:String x:Key="MC0">[LỖI] Kiểm tra cập nhật thất bại.</sys:String>
-    <sys:String x:Key="MC1">lỗi</sys:String>
-    <sys:String x:Key="MC2">Có phiên bản mới</sys:String>
-    <sys:String x:Key="MC3">Phát hiện phiên bản mới: {0}
-Phiên bản hiện tại: {1}
-Vui lòng truy cập GitHub để tải phiên bản mới nhất.</sys:String>
-    <sys:String x:Key="MC4">Cập nhật</sys:String>
-    <sys:String x:Key="MC5">Bỏ qua phiên bản này</sys:String>
-    <sys:String x:Key="MC6">[LỖI] Mở trình duyệt thất bại.</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[CẢNH BÁO] LiveCaptions đã đóng bất ngờ, đang khởi động lại...</sys:String>
-    <sys:String x:Key="T1">[Tạm dừng]</sys:String>
-    <sys:String x:Key="T2">Lỗi!</sys:String>
-    <sys:String x:Key="T3">Ghi lịch sử thất bại: {0}</sys:String>
+    <!-- Translator strings -->
+    <sys:String x:Key="Translator_Status_Restarting">[CẢNH BÁO] LiveCaptions đã đóng bất ngờ, đang khởi động lại...</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[Tạm dừng]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">Lỗi!</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">Ghi lịch sử thất bại: {0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">Nhấp để sao chép</sys:String>
-    <sys:String x:Key="C1">Đã sao chép</sys:String>
-    <sys:String x:Key="C2">Sao chép thất bại</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">Nhấp để sao chép</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">Đã sao chép</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">Sao chép thất bại</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/vi-vn.xaml
+++ b/src/localization/vi-vn.xaml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">Phụ đề trực tiếp</sys:String>
+    <sys:String x:Key="S1">Sau phiên bản Windows 11 24H2, bạn chỉ có thể thay đổi</sys:String>
+    <sys:String x:Key="S2">Ngôn ngữ nguồn</sys:String>
+    <sys:String x:Key="S3">trong Phụ đề trực tiếp.</sys:String>
+    <sys:String x:Key="S4">Lưu ý:</sys:String>
+    <sys:String x:Key="S5">Vui lòng nhấp</sys:String>
+    <sys:String x:Key="S6">"Ẩn"</sys:String>
+    <sys:String x:Key="S7">để ẩn Phụ đề trực tiếp thay vì đóng trực tiếp.</sys:String>
+
+    <sys:String x:Key="S8">Hiển thị</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">Ẩn</sys:String>
+    <sys:String x:Key="S46">Hiển thị</sys:String>
+
+    <sys:String x:Key="S9">Khoảng thời gian API</sys:String>
+    <sys:String x:Key="S10">Xác định tần suất gọi API dịch. Giá trị nhỏ hơn sẽ gọi API thường xuyên hơn.</sys:String>
+    <sys:String x:Key="S11">API dịch sẽ được gọi một lần sau khi phụ đề thay đổi</sys:String>
+    <sys:String x:Key="S12">[Khoảng thời gian API]</sys:String>
+    <sys:String x:Key="S13">lần.</sys:String>
+
+    <sys:String x:Key="S14">API dịch</sys:String>
+    <sys:String x:Key="S15">Ngoại trừ Google và Google2, tất cả các API khác cần được cấu hình trước khi sử dụng.</sys:String>
+
+    <sys:String x:Key="S16">Ngôn ngữ đích</sys:String>
+    <sys:String x:Key="S17">Không có ngôn ngữ đích mà tôi mong đợi!</sys:String>
+    <sys:String x:Key="S18">Bạn có thể trực tiếp chỉnh sửa nội dung của hộp kết hợp này để tùy chỉnh ngôn ngữ, khuyến nghị theo</sys:String>
+    <sys:String x:Key="S19">thẻ ngôn ngữ BCP 47.</sys:String>
+    <sys:String x:Key="S20">Một số API (như DeepL) yêu cầu cách khác để định nghĩa ngôn ngữ đích, xem tài liệu chính thức để biết chi tiết.</sys:String>
+    <sys:String x:Key="S21">Không cần quan tâm đến điều này đối với các ngôn ngữ đích đã tích hợp, vì chúng tôi đã tạo sẵn bản đồ thẻ. Nhưng nếu ngôn ngữ mong muốn không có trong danh sách, hãy lưu ý.</sys:String>
+
+    <sys:String x:Key="S22">Cài đặt API</sys:String>
+    <sys:String x:Key="S23">Mở</sys:String>
+
+    <sys:String x:Key="S24">Hiển thị độ trễ</sys:String>
+    <sys:String x:Key="S25">Tắt</sys:String>
+    <sys:String x:Key="S26">Bật</sys:String>
+
+    <sys:String x:Key="S27">Ngữ cảnh</sys:String>
+    <sys:String x:Key="S28">Ngữ cảnh:</sys:String>
+    <sys:String x:Key="S29">Xác định số câu ngữ cảnh khi</sys:String>
+    <sys:String x:Key="S30">Nhận thức ngữ cảnh</sys:String>
+    <sys:String x:Key="S31">được bật.</sys:String>
+    <sys:String x:Key="S32">Câu hiển thị:</sys:String>
+    <sys:String x:Key="S33">Xác định số thẻ hiển thị khi</sys:String>
+    <sys:String x:Key="S34">Thẻ nhật ký</sys:String>
+    <sys:String x:Key="S35">được bật, cũng như số câu tối đa hiển thị trong cửa sổ lớp phủ.</sys:String>
+    <sys:String x:Key="S36">Ngữ cảnh phải</sys:String>
+    <sys:String x:Key="S37">lớn hơn hoặc bằng</sys:String>
+    <sys:String x:Key="S38">Câu hiển thị</sys:String>
+    <sys:String x:Key="S39">. Nếu không, chương trình sẽ tự động điều chỉnh.</sys:String>
+
+    <sys:String x:Key="S40">Câu hiển thị</sys:String>
+
+    <sys:String x:Key="S41">Dịch trong ngữ cảnh.</sys:String>
+    <sys:String x:Key="S42">Điều này có thể cải thiện độ chính xác của bản dịch, nhưng sẽ tốn nhiều token hơn.</sys:String>
+
+    <sys:String x:Key="S43">Ngôn ngữ giao diện</sys:String>
+    <sys:String x:Key="S44">Chọn ngôn ngữ sử dụng cho giao diện ứng dụng.</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">Trước</sys:String>
+    <sys:String x:Key="H1">Trang tiếp theo</sys:String>
+    <sys:String x:Key="H2">Tìm kiếm</sys:String>
+    <sys:String x:Key="H3">Xuất</sys:String>
+    <sys:String x:Key="H4">Xóa tất cả</sys:String>
+    <sys:String x:Key="H5">Làm mới</sys:String>
+    <sys:String x:Key="H6">Thời gian</sys:String>
+    <sys:String x:Key="H7">Phụ đề</sys:String>
+    <sys:String x:Key="H8">Đã dịch</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/trang</sys:String>
+    <sys:String x:Key="H11">30/trang</sys:String>
+    <sys:String x:Key="H12">50/trang</sys:String>
+    <sys:String x:Key="H13">100/trang</sys:String>
+    <sys:String x:Key="H20">Bạn có muốn xóa toàn bộ lịch sử không?</sys:String>
+    <sys:String x:Key="H21">Hành động này không thể hoàn tác!</sys:String>
+    <sys:String x:Key="H22">Có</sys:String>
+    <sys:String x:Key="H23">Không</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|Tất cả tệp (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">Lưu thành công</sys:String>
+    <sys:String x:Key="H26">Tệp đã lưu tại: {0}</sys:String>
+    <sys:String x:Key="H27">Lưu thất bại</sys:String>
+    <sys:String x:Key="H28">Không lưu được tệp: {0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">Cửa sổ lớp phủ</sys:String>
+    <sys:String x:Key="O1">Tăng cỡ chữ</sys:String>
+    <sys:String x:Key="O2">Giảm cỡ chữ</sys:String>
+    <sys:String x:Key="O3">Tăng viền chữ</sys:String>
+    <sys:String x:Key="O4">Giảm viền chữ</sys:String>
+    <sys:String x:Key="O5">Đậm</sys:String>
+    <sys:String x:Key="O6">Màu chữ</sys:String>
+    <sys:String x:Key="O7">Tăng độ mờ nền</sys:String>
+    <sys:String x:Key="O8">Giảm độ mờ nền</sys:String>
+    <sys:String x:Key="O9">Màu nền</sys:String>
+    <sys:String x:Key="O10">Chỉ hiển thị phụ đề hoặc bản dịch</sys:String>
+    <sys:String x:Key="O11">Chuyển vị trí phụ đề/bản dịch</sys:String>
+    <sys:String x:Key="O12">Nhấp xuyên qua</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">Chúng tôi hoan nghênh mọi hình thức đóng góp! Bạn có thể gửi đề xuất hoặc báo lỗi qua GitHub issues, hoặc đóng góp mã trực tiếp bằng Pull Requests.</sys:String>
+    <sys:String x:Key="I1">Nếu chương trình này hữu ích với bạn, hãy cân nhắc cho chúng tôi một ngôi sao!</sys:String>
+    <sys:String x:Key="I2">Kho lưu trữ:</sys:String>
+    <sys:String x:Key="I3">Wiki:</sys:String>
+    <sys:String x:Key="I4">Người duy trì:</sys:String>
+    <sys:String x:Key="I5">(Tác giả) và</sys:String>
+    <sys:String x:Key="I6">Phiên bản:</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">Bắt đầu</sys:String>
+    <sys:String x:Key="W1">Chào mừng đến với LiveCaptions Translator!</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator dựa trên Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W3">&#x0A;Trước khi chạy lần đầu, bạn cần cấu hình theo các bước sau:&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. Mở Windows LiveCaptions và làm theo hướng dẫn để tải các tệp cần thiết cho nhận dạng giọng nói và gói ngôn ngữ.</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. Nhấp vào</sys:String>
+    <sys:String x:Key="W6">biểu tượng ⚙️</sys:String>
+    <sys:String x:Key="W7">trong Windows LiveCaptions để mở menu cài đặt và chọn</sys:String>
+    <sys:String x:Key="W8">"Vị trí &gt; Chồng lên màn hình"</sys:String>
+    <sys:String x:Key="W9">3. Nhấp vào</sys:String>
+    <sys:String x:Key="W10">"Ẩn"</sys:String>
+    <sys:String x:Key="W11">nút trên trang cài đặt của LiveCaptions Translator để ẩn Windows LiveCaptions.&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;Chương trình đã tự động điều hướng đến trang cài đặt và mở Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W13">Sau khi cấu hình xong, bạn có thể trở lại trang chính và thưởng thức dịch âm thanh thời gian thực.&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;Chi tiết hơn, hãy truy cập wiki của chúng tôi: </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;Mẹo:&#x0A;</sys:String>
+    <sys:String x:Key="W17">Để thay đổi </sys:String>
+    <sys:String x:Key="W18">Ngôn ngữ nguồn</sys:String>
+    <sys:String x:Key="W19">, hãy [Hiển thị] LiveCaptions trên trang cài đặt và thực hiện trong Windows LiveCaptions.</sys:String>
+    <sys:String x:Key="W20">Tôi đã hiểu đầy đủ và đã cấu hình.</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">Phụ đề</sys:String>
+    <sys:String x:Key="M11">Cài đặt</sys:String>
+    <sys:String x:Key="M12">Lịch sử</sys:String>
+    <sys:String x:Key="M13">Thông tin</sys:String>
+    <sys:String x:Key="M20">Thẻ nhật ký của phụ đề</sys:String>
+    <sys:String x:Key="M21">Tạm dừng dịch (chỉ nhật ký)</sys:String>
+    <sys:String x:Key="M22">Cửa sổ lớp phủ</sys:String>
+    <sys:String x:Key="M23">Luôn ở trên cùng</sys:String>
+
+    <sys:String x:Key="MC0">[LỖI] Kiểm tra cập nhật thất bại.</sys:String>
+    <sys:String x:Key="MC1">lỗi</sys:String>
+    <sys:String x:Key="MC2">Có phiên bản mới</sys:String>
+    <sys:String x:Key="MC3">Phát hiện phiên bản mới: {0}
+Phiên bản hiện tại: {1}
+Vui lòng truy cập GitHub để tải phiên bản mới nhất.</sys:String>
+    <sys:String x:Key="MC4">Cập nhật</sys:String>
+    <sys:String x:Key="MC5">Bỏ qua phiên bản này</sys:String>
+    <sys:String x:Key="MC6">[LỖI] Mở trình duyệt thất bại.</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[CẢNH BÁO] LiveCaptions đã đóng bất ngờ, đang khởi động lại...</sys:String>
+    <sys:String x:Key="T1">[Tạm dừng]</sys:String>
+    <sys:String x:Key="T2">Lỗi!</sys:String>
+    <sys:String x:Key="T3">Ghi lịch sử thất bại: {0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">Nhấp để sao chép</sys:String>
+    <sys:String x:Key="C1">Đã sao chép</sys:String>
+    <sys:String x:Key="C2">Sao chép thất bại</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/zh-cn.xaml
+++ b/src/localization/zh-cn.xaml
@@ -1,186 +1,174 @@
-<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">实时字幕</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">实时字幕</sys:String>
     <sys:String x:Key="S1">在 Windows 11 24H2 之后，你只能在实时字幕中更改</sys:String>
-    <sys:String x:Key="S2">源语言</sys:String>
-    <sys:String x:Key="S3">。</sys:String>
-    <sys:String x:Key="S4">注意：</sys:String>
-    <sys:String x:Key="S5">请点击</sys:String>
-    <sys:String x:Key="S6">"隐藏"</sys:String>
-    <sys:String x:Key="S7">来隐藏实时字幕，而不是直接关闭它。</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">源语言</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">。</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">注意：</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">请点击</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"隐藏"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">来隐藏实时字幕，而不是直接关闭它。</sys:String>
 
-    <sys:String x:Key="S8">显示</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">显示</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">隐藏</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">隐藏</sys:String>
-    <sys:String x:Key="S46">显示</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API 间隔</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">决定翻译 API 调用频率。数值越小，调用越频繁。</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">字幕变化达到</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API 间隔]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">次后调用一次翻译 API。</sys:String>
 
-    <sys:String x:Key="S9">API 间隔</sys:String>
-    <sys:String x:Key="S10">决定翻译 API 调用频率。数值越小，调用越频繁。</sys:String>
-    <sys:String x:Key="S11">字幕变化达到</sys:String>
-    <sys:String x:Key="S12">[API 间隔]</sys:String>
-    <sys:String x:Key="S13">次后调用一次翻译 API。</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">翻译 API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">除 Google 和 Google2 外，其它 API 均需要配置后才能使用。</sys:String>
 
-    <sys:String x:Key="S14">翻译 API</sys:String>
-    <sys:String x:Key="S15">除 Google 和 Google2 外，其它 API 均需要配置后才能使用。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">目标语言</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">没有我想要的目标语言？</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">你可以直接编辑此下拉框内容来自定义语言，建议遵循</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47 语言标签。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">部分 API（如 DeepL）需要用另一种方式定义目标语言，详情请查看其官方文档。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">内置目标语言无需考虑此问题（已做标签映射）；若你需要的语言不在列表中，请留意这一点。</sys:String>
 
-    <sys:String x:Key="S16">目标语言</sys:String>
-    <sys:String x:Key="S17">没有我想要的目标语言？</sys:String>
-    <sys:String x:Key="S18">你可以直接编辑此下拉框内容来自定义语言，建议遵循</sys:String>
-    <sys:String x:Key="S19">BCP 47 语言标签。</sys:String>
-    <sys:String x:Key="S20">部分 API（如 DeepL）需要用另一种方式定义目标语言，详情请查看其官方文档。</sys:String>
-    <sys:String x:Key="S21">内置目标语言无需考虑此问题（已做标签映射）；若你需要的语言不在列表中，请留意这一点。</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API 设置</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">打开</sys:String>
 
-    <sys:String x:Key="S22">API 设置</sys:String>
-    <sys:String x:Key="S23">打开</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">显示延迟</sys:String>
+    <sys:String x:Key="Common_Off">关</sys:String>
+    <sys:String x:Key="Common_On">开</sys:String>
 
-    <sys:String x:Key="S24">显示延迟</sys:String>
-    <sys:String x:Key="S25">关</sys:String>
-    <sys:String x:Key="S26">开</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">上下文</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">上下文：</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">决定在启用</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">上下文感知</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">时的上下文句子数量。</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">叠加句子：</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">决定在启用</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">日志卡片</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">时显示的卡片数量，以及叠加窗口中显示的最大句子数。</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">上下文必须</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">大于或等于</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">显示句子</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">。否则程序会自动调整。</sys:String>
 
-    <sys:String x:Key="S27">上下文</sys:String>
-    <sys:String x:Key="S28">上下文：</sys:String>
-    <sys:String x:Key="S29">决定在启用</sys:String>
-    <sys:String x:Key="S30">上下文感知</sys:String>
-    <sys:String x:Key="S31">时的上下文句子数量。</sys:String>
-    <sys:String x:Key="S32">叠加句子：</sys:String>
-    <sys:String x:Key="S33">决定在启用</sys:String>
-    <sys:String x:Key="S34">日志卡片</sys:String>
-    <sys:String x:Key="S35">时显示的卡片数量，以及叠加窗口中显示的最大句子数。</sys:String>
-    <sys:String x:Key="S36">上下文必须</sys:String>
-    <sys:String x:Key="S37">大于或等于</sys:String>
-    <sys:String x:Key="S38">显示句子</sys:String>
-    <sys:String x:Key="S39">。否则程序会自动调整。</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">显示句子</sys:String>
 
-    <sys:String x:Key="S40">显示句子</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">在上下文中翻译。</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">可提升翻译准确性，但会消耗更多 tokens。</sys:String>
 
-    <sys:String x:Key="S41">在上下文中翻译。</sys:String>
-    <sys:String x:Key="S42">可提升翻译准确性，但会消耗更多 tokens。</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">界面语言</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">选择应用程序界面所使用的语言。</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">更改会立即生效，并自动保存。</sys:String>
 
-    <sys:String x:Key="S43">界面语言</sys:String>
-    <sys:String x:Key="S44">选择应用程序界面所使用的语言。</sys:String>
+    <!-- HistoryPage strings (semantic keys) -->
+    <sys:String x:Key="HistoryPage_Pagination_Previous">上一页</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">下一页</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">搜索</sys:String>
 
-    <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">上一页</sys:String>
-    <sys:String x:Key="H1">下一页</sys:String>
-    <sys:String x:Key="H2">搜索</sys:String>
-    <sys:String x:Key="H3">导出</sys:String>
-    <sys:String x:Key="H4">删除全部</sys:String>
-    <sys:String x:Key="H5">刷新</sys:String>
-    <sys:String x:Key="H6">时间</sys:String>
-    <sys:String x:Key="H7">字幕</sys:String>
-    <sys:String x:Key="H8">翻译</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/页</sys:String>
-    <sys:String x:Key="H11">30/页</sys:String>
-    <sys:String x:Key="H12">50/页</sys:String>
-    <sys:String x:Key="H13">100/页</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">导出</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">删除全部</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">刷新</sys:String>
+
+    <sys:String x:Key="HistoryPage_Column_Time">时间</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">字幕</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">翻译</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+
+    <sys:String x:Key="HistoryPage_PageSize_20">20/页</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/页</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/页</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/页</sys:String>
 
     <!-- HistoryPage (code-behind) strings -->
-    <sys:String x:Key="H20">确定要删除所有历史记录吗？</sys:String>
-    <sys:String x:Key="H21">此操作不可撤销！</sys:String>
-    <sys:String x:Key="H22">是</sys:String>
-    <sys:String x:Key="H23">否</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|所有文件 (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">保存成功</sys:String>
-    <sys:String x:Key="H26">文件已保存到：{0}</sys:String>
-    <sys:String x:Key="H27">保存失败</sys:String>
-    <sys:String x:Key="H28">文件保存失败：{0}</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">确定要删除所有历史记录吗？</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">此操作不可撤销！</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">是</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">否</sys:String>
 
-    <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">悬浮窗口</sys:String>
-    <sys:String x:Key="O1">增大字体</sys:String>
-    <sys:String x:Key="O2">减小字体</sys:String>
-    <sys:String x:Key="O3">增大描边</sys:String>
-    <sys:String x:Key="O4">减小描边</sys:String>
-    <sys:String x:Key="O5">字体加粗</sys:String>
-    <sys:String x:Key="O6">字体颜色</sys:String>
-    <sys:String x:Key="O7">增大背景透明度</sys:String>
-    <sys:String x:Key="O8">减小背景透明度</sys:String>
-    <sys:String x:Key="O9">背景颜色</sys:String>
-    <sys:String x:Key="O10">仅显示原文或译文</sys:String>
-    <sys:String x:Key="O11">切换原文/译文位置</sys:String>
-    <sys:String x:Key="O12">点击穿透</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|所有文件 (*.*)|*.*</sys:String>
+
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">保存成功</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">文件已保存到：{0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">保存失败</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">文件保存失败：{0}</sys:String>
+
+    <!-- OverlayWindow strings (semantic tooltips) -->
+    <sys:String x:Key="OverlayWindow_Title">悬浮窗口</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">增大字体</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">减小字体</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">增大描边</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">减小描边</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">字体加粗</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">字体颜色</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">增大背景透明度</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">减小背景透明度</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">背景颜色</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">仅显示原文或译文</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">切换原文/译文位置</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">点击穿透</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">欢迎任何形式的贡献！你可以通过 GitHub issues 提出建议或反馈 bug，也可以通过提交 Pull Request 直接贡献代码。</sys:String>
-    <sys:String x:Key="I1">如果这个程序对你有帮助，欢迎给项目点个 Star！</sys:String>
-    <sys:String x:Key="I2">仓库：</sys:String>
-    <sys:String x:Key="I3">Wiki：</sys:String>
-    <sys:String x:Key="I4">维护者：</sys:String>
-    <sys:String x:Key="I5">（作者）以及</sys:String>
-    <sys:String x:Key="I6">版本：</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">欢迎任何形式的贡献！你可以通过 GitHub issues 提出建议或反馈 bug，也可以通过提交 Pull Request 直接贡献代码。</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">如果这个程序对你有帮助，欢迎给项目点个 Star！</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">仓库：</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki：</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">维护者：</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">（作者）以及</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">版本：</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">开始使用</sys:String>
-    <sys:String x:Key="W1">欢迎使用 LiveCaptions Translator！</sys:String>
-
-    <sys:String x:Key="W2">LiveCaptions Translator 基于 Windows 实时字幕（Live Captions）。</sys:String>
-    <sys:String x:Key="W3">&#x0A;首次运行前，你需要按以下步骤完成配置：&#x0A;</sys:String>
-
-    <sys:String x:Key="W4">&#x0A;1. 打开Windows实时字幕，并按照引导下载离线语音识别所需文件和语言包。</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. 点击Windows实时字幕中的</sys:String>
-    <sys:String x:Key="W6">⚙️ 齿轮</sys:String>
-    <sys:String x:Key="W7">图标打开设置菜单，并选择</sys:String>
-    <sys:String x:Key="W8">“位置 &gt; 覆盖在屏幕上”</sys:String>
-    <sys:String x:Key="W9">3. 在 LiveCaptions Translator 的设置页面点击</sys:String>
-    <sys:String x:Key="W10">“隐藏”</sys:String>
-    <sys:String x:Key="W11">按钮来隐藏Windows实时字幕。&#x0A;</sys:String>
-
-    <sys:String x:Key="W12">&#x0A;程序已自动跳转到设置页并打开Windows实时字幕。</sys:String>
-    <sys:String x:Key="W13">配置完成后，你可以切换回主页，享受实时音频翻译。&#x0A;</sys:String>
-
-    <sys:String x:Key="W14">&#x0A;更多详细说明请查看 Wiki： </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-
-    <sys:String x:Key="W16">&#x0A;&#x0A;提示：&#x0A;</sys:String>
-    <sys:String x:Key="W17">如需更改</sys:String>
-    <sys:String x:Key="W18">源语言</sys:String>
-    <sys:String x:Key="W19">，请先在设置页点击 [显示] 实时字幕，然后在 Windows 实时字幕内进行更改。</sys:String>
-
-    <sys:String x:Key="W20">我已完全理解并完成配置。</sys:String>
-
-    <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">开始使用</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">欢迎使用 LiveCaptions Translator！</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator 基于 Windows 实时字幕（Live Captions）。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;首次运行前，你需要按以下步骤完成配置：&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. 打开Windows实时字幕，并按照引导下载离线语音识别所需文件和语言包。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. 点击</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ 齿轮</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">图标打开设置菜单，并选择</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">“位置 &gt; 覆盖在屏幕上”</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. 点击</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"隐藏"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">按钮来隐藏Windows实时字幕。&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;程序已自动跳转到设置页并打开Windows实时字幕。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">配置完成后，你可以切换回主页，享受实时音频翻译。&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;更多详细说明请查看 Wiki： </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;提示：&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">如需更改</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">源语言</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">，请先在设置页点击 [显示] 实时字幕，然后在 Windows 实时字幕内进行更改。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">我已完全理解并完成配置。</sys:String>
 
     <!-- Navigation menu -->
-    <sys:String x:Key="M10">字幕</sys:String>
-    <sys:String x:Key="M11">设置</sys:String>
-    <sys:String x:Key="M12">历史</sys:String>
-    <sys:String x:Key="M13">信息</sys:String>
+    <sys:String x:Key="Navigation_Captions">字幕</sys:String>
+    <sys:String x:Key="Navigation_Settings">设置</sys:String>
+    <sys:String x:Key="Navigation_History">历史</sys:String>
+    <sys:String x:Key="Navigation_Info">信息</sys:String>
 
-    <!-- Title bar buttons tooltips -->
-    <sys:String x:Key="M20">字幕日志卡片</sys:String>
-    <sys:String x:Key="M21">暂停翻译（仅记录）</sys:String>
-    <sys:String x:Key="M22">叠加窗口</sys:String>
-    <sys:String x:Key="M23">置顶</sys:String>
+    <!-- MainWindow strings -->
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">字幕日志卡片</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">暂停翻译（仅记录）</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">叠加窗口</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">置顶</sys:String>
 
-    <!-- MainWindow (code-behind) strings -->
-    <sys:String x:Key="MC0">[错误] 检查更新失败。</sys:String>
-    <sys:String x:Key="MC1">error</sys:String>
-
-    <sys:String x:Key="MC2">发现新版本</sys:String>
-    <sys:String x:Key="MC3">检测到新版本：{0}
+    <sys:String x:Key="MainWindow_Update_Error">[错误] 检查更新失败。</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">error</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">发现新版本</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">检测到新版本：{0}
 当前版本：{1}
 请前往 GitHub 下载最新 Release。</sys:String>
-    <sys:String x:Key="MC4">更新</sys:String>
-    <sys:String x:Key="MC5">忽略此版本</sys:String>
 
-    <sys:String x:Key="MC6">[错误] 打开浏览器失败。</sys:String>
-
-    <!-- Translator（运行时状态） -->
-    <sys:String x:Key="T0">[警告] 实时字幕意外关闭，正在重启……</sys:String>
-    <sys:String x:Key="T1">[已暂停]</sys:String>
-    <sys:String x:Key="T2">错误！</sys:String>
-    <sys:String x:Key="T3">写入历史记录失败：{0}</sys:String>
+    <!-- Translator  -->
+    <sys:String x:Key="Translator_Status_Restarting">[警告] 实时字幕意外关闭，正在重启……</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[已暂停]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">错误！</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">写入历史记录失败：{0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">点击复制</sys:String>
-    <sys:String x:Key="C1">已复制</sys:String>
-    <sys:String x:Key="C2">复制失败</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">点击复制</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">已复制</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">复制失败</sys:String>
 
 </ResourceDictionary>

--- a/src/localization/zh-cn.xaml
+++ b/src/localization/zh-cn.xaml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">实时字幕</sys:String>
+    <sys:String x:Key="S1">在 Windows 11 24H2 之后，你只能在实时字幕中更改</sys:String>
+    <sys:String x:Key="S2">源语言</sys:String>
+    <sys:String x:Key="S3">。</sys:String>
+    <sys:String x:Key="S4">注意：</sys:String>
+    <sys:String x:Key="S5">请点击</sys:String>
+    <sys:String x:Key="S6">"隐藏"</sys:String>
+    <sys:String x:Key="S7">来隐藏实时字幕，而不是直接关闭它。</sys:String>
+
+    <sys:String x:Key="S8">显示</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">隐藏</sys:String>
+    <sys:String x:Key="S46">显示</sys:String>
+
+    <sys:String x:Key="S9">API 间隔</sys:String>
+    <sys:String x:Key="S10">决定翻译 API 调用频率。数值越小，调用越频繁。</sys:String>
+    <sys:String x:Key="S11">字幕变化达到</sys:String>
+    <sys:String x:Key="S12">[API 间隔]</sys:String>
+    <sys:String x:Key="S13">次后调用一次翻译 API。</sys:String>
+
+    <sys:String x:Key="S14">翻译 API</sys:String>
+    <sys:String x:Key="S15">除 Google 和 Google2 外，其它 API 均需要配置后才能使用。</sys:String>
+
+    <sys:String x:Key="S16">目标语言</sys:String>
+    <sys:String x:Key="S17">没有我想要的目标语言？</sys:String>
+    <sys:String x:Key="S18">你可以直接编辑此下拉框内容来自定义语言，建议遵循</sys:String>
+    <sys:String x:Key="S19">BCP 47 语言标签。</sys:String>
+    <sys:String x:Key="S20">部分 API（如 DeepL）需要用另一种方式定义目标语言，详情请查看其官方文档。</sys:String>
+    <sys:String x:Key="S21">内置目标语言无需考虑此问题（已做标签映射）；若你需要的语言不在列表中，请留意这一点。</sys:String>
+
+    <sys:String x:Key="S22">API 设置</sys:String>
+    <sys:String x:Key="S23">打开</sys:String>
+
+    <sys:String x:Key="S24">显示延迟</sys:String>
+    <sys:String x:Key="S25">关</sys:String>
+    <sys:String x:Key="S26">开</sys:String>
+
+    <sys:String x:Key="S27">上下文</sys:String>
+    <sys:String x:Key="S28">上下文：</sys:String>
+    <sys:String x:Key="S29">决定在启用</sys:String>
+    <sys:String x:Key="S30">上下文感知</sys:String>
+    <sys:String x:Key="S31">时的上下文句子数量。</sys:String>
+    <sys:String x:Key="S32">叠加句子：</sys:String>
+    <sys:String x:Key="S33">决定在启用</sys:String>
+    <sys:String x:Key="S34">日志卡片</sys:String>
+    <sys:String x:Key="S35">时显示的卡片数量，以及叠加窗口中显示的最大句子数。</sys:String>
+    <sys:String x:Key="S36">上下文必须</sys:String>
+    <sys:String x:Key="S37">大于或等于</sys:String>
+    <sys:String x:Key="S38">显示句子</sys:String>
+    <sys:String x:Key="S39">。否则程序会自动调整。</sys:String>
+
+    <sys:String x:Key="S40">显示句子</sys:String>
+
+    <sys:String x:Key="S41">在上下文中翻译。</sys:String>
+    <sys:String x:Key="S42">可提升翻译准确性，但会消耗更多 tokens。</sys:String>
+
+    <sys:String x:Key="S43">界面语言</sys:String>
+    <sys:String x:Key="S44">选择应用程序界面所使用的语言。</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">上一页</sys:String>
+    <sys:String x:Key="H1">下一页</sys:String>
+    <sys:String x:Key="H2">搜索</sys:String>
+    <sys:String x:Key="H3">导出</sys:String>
+    <sys:String x:Key="H4">删除全部</sys:String>
+    <sys:String x:Key="H5">刷新</sys:String>
+    <sys:String x:Key="H6">时间</sys:String>
+    <sys:String x:Key="H7">字幕</sys:String>
+    <sys:String x:Key="H8">翻译</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/页</sys:String>
+    <sys:String x:Key="H11">30/页</sys:String>
+    <sys:String x:Key="H12">50/页</sys:String>
+    <sys:String x:Key="H13">100/页</sys:String>
+
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="H20">确定要删除所有历史记录吗？</sys:String>
+    <sys:String x:Key="H21">此操作不可撤销！</sys:String>
+    <sys:String x:Key="H22">是</sys:String>
+    <sys:String x:Key="H23">否</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|所有文件 (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">保存成功</sys:String>
+    <sys:String x:Key="H26">文件已保存到：{0}</sys:String>
+    <sys:String x:Key="H27">保存失败</sys:String>
+    <sys:String x:Key="H28">文件保存失败：{0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">悬浮窗口</sys:String>
+    <sys:String x:Key="O1">增大字体</sys:String>
+    <sys:String x:Key="O2">减小字体</sys:String>
+    <sys:String x:Key="O3">增大描边</sys:String>
+    <sys:String x:Key="O4">减小描边</sys:String>
+    <sys:String x:Key="O5">字体加粗</sys:String>
+    <sys:String x:Key="O6">字体颜色</sys:String>
+    <sys:String x:Key="O7">增大背景透明度</sys:String>
+    <sys:String x:Key="O8">减小背景透明度</sys:String>
+    <sys:String x:Key="O9">背景颜色</sys:String>
+    <sys:String x:Key="O10">仅显示原文或译文</sys:String>
+    <sys:String x:Key="O11">切换原文/译文位置</sys:String>
+    <sys:String x:Key="O12">点击穿透</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">欢迎任何形式的贡献！你可以通过 GitHub issues 提出建议或反馈 bug，也可以通过提交 Pull Request 直接贡献代码。</sys:String>
+    <sys:String x:Key="I1">如果这个程序对你有帮助，欢迎给项目点个 Star！</sys:String>
+    <sys:String x:Key="I2">仓库：</sys:String>
+    <sys:String x:Key="I3">Wiki：</sys:String>
+    <sys:String x:Key="I4">维护者：</sys:String>
+    <sys:String x:Key="I5">（作者）以及</sys:String>
+    <sys:String x:Key="I6">版本：</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">开始使用</sys:String>
+    <sys:String x:Key="W1">欢迎使用 LiveCaptions Translator！</sys:String>
+
+    <sys:String x:Key="W2">LiveCaptions Translator 基于 Windows 实时字幕（Live Captions）。</sys:String>
+    <sys:String x:Key="W3">&#x0A;首次运行前，你需要按以下步骤完成配置：&#x0A;</sys:String>
+
+    <sys:String x:Key="W4">&#x0A;1. 打开Windows实时字幕，并按照引导下载离线语音识别所需文件和语言包。</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. 点击Windows实时字幕中的</sys:String>
+    <sys:String x:Key="W6">⚙️ 齿轮</sys:String>
+    <sys:String x:Key="W7">图标打开设置菜单，并选择</sys:String>
+    <sys:String x:Key="W8">“位置 &gt; 覆盖在屏幕上”</sys:String>
+    <sys:String x:Key="W9">3. 在 LiveCaptions Translator 的设置页面点击</sys:String>
+    <sys:String x:Key="W10">“隐藏”</sys:String>
+    <sys:String x:Key="W11">按钮来隐藏Windows实时字幕。&#x0A;</sys:String>
+
+    <sys:String x:Key="W12">&#x0A;程序已自动跳转到设置页并打开Windows实时字幕。</sys:String>
+    <sys:String x:Key="W13">配置完成后，你可以切换回主页，享受实时音频翻译。&#x0A;</sys:String>
+
+    <sys:String x:Key="W14">&#x0A;更多详细说明请查看 Wiki： </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+
+    <sys:String x:Key="W16">&#x0A;&#x0A;提示：&#x0A;</sys:String>
+    <sys:String x:Key="W17">如需更改</sys:String>
+    <sys:String x:Key="W18">源语言</sys:String>
+    <sys:String x:Key="W19">，请先在设置页点击 [显示] 实时字幕，然后在 Windows 实时字幕内进行更改。</sys:String>
+
+    <sys:String x:Key="W20">我已完全理解并完成配置。</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="M10">字幕</sys:String>
+    <sys:String x:Key="M11">设置</sys:String>
+    <sys:String x:Key="M12">历史</sys:String>
+    <sys:String x:Key="M13">信息</sys:String>
+
+    <!-- Title bar buttons tooltips -->
+    <sys:String x:Key="M20">字幕日志卡片</sys:String>
+    <sys:String x:Key="M21">暂停翻译（仅记录）</sys:String>
+    <sys:String x:Key="M22">叠加窗口</sys:String>
+    <sys:String x:Key="M23">置顶</sys:String>
+
+    <!-- MainWindow (code-behind) strings -->
+    <sys:String x:Key="MC0">[错误] 检查更新失败。</sys:String>
+    <sys:String x:Key="MC1">error</sys:String>
+
+    <sys:String x:Key="MC2">发现新版本</sys:String>
+    <sys:String x:Key="MC3">检测到新版本：{0}
+当前版本：{1}
+请前往 GitHub 下载最新 Release。</sys:String>
+    <sys:String x:Key="MC4">更新</sys:String>
+    <sys:String x:Key="MC5">忽略此版本</sys:String>
+
+    <sys:String x:Key="MC6">[错误] 打开浏览器失败。</sys:String>
+
+    <!-- Translator（运行时状态） -->
+    <sys:String x:Key="T0">[警告] 实时字幕意外关闭，正在重启……</sys:String>
+    <sys:String x:Key="T1">[已暂停]</sys:String>
+    <sys:String x:Key="T2">错误！</sys:String>
+    <sys:String x:Key="T3">写入历史记录失败：{0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">点击复制</sys:String>
+    <sys:String x:Key="C1">已复制</sys:String>
+    <sys:String x:Key="C2">复制失败</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/zh-tw.xaml
+++ b/src/localization/zh-tw.xaml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- SettingPage strings (compact numeric keys) -->
+    <sys:String x:Key="S0">即時字幕</sys:String>
+    <sys:String x:Key="S1">在 Windows 11 24H2 版本之後，您只能更改</sys:String>
+    <sys:String x:Key="S2">來源語言</sys:String>
+    <sys:String x:Key="S3">在即時字幕中。</sys:String>
+    <sys:String x:Key="S4">注意：</sys:String>
+    <sys:String x:Key="S5">請點擊</sys:String>
+    <sys:String x:Key="S6">"隱藏"</sys:String>
+    <sys:String x:Key="S7">來隱藏即時字幕，而非直接關閉。</sys:String>
+
+    <sys:String x:Key="S8">顯示</sys:String>
+
+    <!-- LiveCaptions toggle button text -->
+    <sys:String x:Key="S45">隱藏</sys:String>
+    <sys:String x:Key="S46">顯示</sys:String>
+
+    <sys:String x:Key="S9">API 間隔</sys:String>
+    <sys:String x:Key="S10">決定翻譯 API 呼叫的頻率。數值越小，呼叫越頻繁。</sys:String>
+    <sys:String x:Key="S11">字幕變更後，API 將呼叫一次</sys:String>
+    <sys:String x:Key="S12">[API 間隔]</sys:String>
+    <sys:String x:Key="S13">次。</sys:String>
+
+    <sys:String x:Key="S14">翻譯 API</sys:String>
+    <sys:String x:Key="S15">除了 Google 和 Google2，其他 API 需先配置才能使用。</sys:String>
+
+    <sys:String x:Key="S16">目標語言</sys:String>
+    <sys:String x:Key="S17">沒有找到我想要的目標語言！</sys:String>
+    <sys:String x:Key="S18">您可以直接編輯此下拉框內容自訂語言，建議遵循</sys:String>
+    <sys:String x:Key="S19">BCP 47 語言標籤。</sys:String>
+    <sys:String x:Key="S20">部分 API（例如 DeepL）需使用不同方式定義目標語言，詳情請參考官方文件。</sys:String>
+    <sys:String x:Key="S21">已包含的目標語言無需考慮，我們已內建標籤對應。但若預期語言不在列表中，請留意此點。</sys:String>
+
+    <sys:String x:Key="S22">API 設定</sys:String>
+    <sys:String x:Key="S23">開啟</sys:String>
+
+    <sys:String x:Key="S24">顯示延遲</sys:String>
+    <sys:String x:Key="S25">關閉</sys:String>
+    <sys:String x:Key="S26">開啟</sys:String>
+
+    <sys:String x:Key="S27">語境</sys:String>
+    <sys:String x:Key="S28">語境：</sys:String>
+    <sys:String x:Key="S29">啟用</sys:String>
+    <sys:String x:Key="S30">語境感知</sys:String>
+    <sys:String x:Key="S31">時，決定上下文句子數量。</sys:String>
+    <sys:String x:Key="S32">覆蓋句：</sys:String>
+    <sys:String x:Key="S33">啟用</sys:String>
+    <sys:String x:Key="S34">日誌卡片</sys:String>
+    <sys:String x:Key="S35">時，決定顯示卡片數量及覆蓋視窗的最大句數。</sys:String>
+    <sys:String x:Key="S36">語境必須</sys:String>
+    <sys:String x:Key="S37">大於或等於</sys:String>
+    <sys:String x:Key="S38">顯示句數</sys:String>
+    <sys:String x:Key="S39">。若不符合，程式將自動調整。</sys:String>
+
+    <sys:String x:Key="S40">顯示句數</sys:String>
+
+    <sys:String x:Key="S41">在語境中翻譯。</sys:String>
+    <sys:String x:Key="S42">可提高翻譯準確度，但會消耗更多代幣。</sys:String>
+
+    <sys:String x:Key="S43">介面語言</sys:String>
+    <sys:String x:Key="S44">選擇應用程式介面使用的語言。</sys:String>
+
+    <!-- HistoryPage strings -->
+    <sys:String x:Key="H0">上一頁</sys:String>
+    <sys:String x:Key="H1">下一頁</sys:String>
+    <sys:String x:Key="H2">搜尋</sys:String>
+    <sys:String x:Key="H3">匯出</sys:String>
+    <sys:String x:Key="H4">全部刪除</sys:String>
+    <sys:String x:Key="H5">重新整理</sys:String>
+    <sys:String x:Key="H6">時間</sys:String>
+    <sys:String x:Key="H7">字幕</sys:String>
+    <sys:String x:Key="H8">翻譯結果</sys:String>
+    <sys:String x:Key="H9">API</sys:String>
+    <sys:String x:Key="H10">20/頁</sys:String>
+    <sys:String x:Key="H11">30/頁</sys:String>
+    <sys:String x:Key="H12">50/頁</sys:String>
+    <sys:String x:Key="H13">100/頁</sys:String>
+    <sys:String x:Key="H20">您確定要刪除所有歷史記錄嗎？</sys:String>
+    <sys:String x:Key="H21">此操作無法復原！</sys:String>
+    <sys:String x:Key="H22">是</sys:String>
+    <sys:String x:Key="H23">否</sys:String>
+    <sys:String x:Key="H24">CSV (*.csv)|*.csv|所有檔案 (*.*)|*.*</sys:String>
+    <sys:String x:Key="H25">儲存成功</sys:String>
+    <sys:String x:Key="H26">檔案已儲存至：{0}</sys:String>
+    <sys:String x:Key="H27">儲存失敗</sys:String>
+    <sys:String x:Key="H28">檔案儲存失敗：{0}</sys:String>
+
+    <!-- OverlayWindow strings -->
+    <sys:String x:Key="O0">覆蓋視窗</sys:String>
+    <sys:String x:Key="O1">增加字型大小</sys:String>
+    <sys:String x:Key="O2">減小字型大小</sys:String>
+    <sys:String x:Key="O3">增加字型描邊</sys:String>
+    <sys:String x:Key="O4">減小字型描邊</sys:String>
+    <sys:String x:Key="O5">加粗</sys:String>
+    <sys:String x:Key="O6">字型顏色</sys:String>
+    <sys:String x:Key="O7">增加背景透明度</sys:String>
+    <sys:String x:Key="O8">減少背景透明度</sys:String>
+    <sys:String x:Key="O9">背景顏色</sys:String>
+    <sys:String x:Key="O10">僅顯示字幕或翻譯</sys:String>
+    <sys:String x:Key="O11">切換字幕/翻譯位置</sys:String>
+    <sys:String x:Key="O12">點擊穿透</sys:String>
+
+    <!-- InfoPage strings -->
+    <sys:String x:Key="I0">我們歡迎任何形式的貢獻！您可以透過 GitHub issues 提建議或回報錯誤，或直接透過 Pull Requests 提交程式碼。</sys:String>
+    <sys:String x:Key="I1">如果本程式對您有幫助，請考慮給我們一顆星！</sys:String>
+    <sys:String x:Key="I2">倉庫：</sys:String>
+    <sys:String x:Key="I3">Wiki：</sys:String>
+    <sys:String x:Key="I4">維護者：</sys:String>
+    <sys:String x:Key="I5">(作者) 與</sys:String>
+    <sys:String x:Key="I6">版本：</sys:String>
+
+    <!-- WelcomeWindow strings -->
+    <sys:String x:Key="W0">開始使用</sys:String>
+    <sys:String x:Key="W1">歡迎使用 LiveCaptions Translator！</sys:String>
+    <sys:String x:Key="W2">LiveCaptions Translator 基於 Windows LiveCaptions。</sys:String>
+    <sys:String x:Key="W3">&#x0A;在首次運行前，請依照以下步驟配置：&#x0A;</sys:String>
+    <sys:String x:Key="W4">&#x0A;1. 開啟 Windows LiveCaptions 並依導引下載語音辨識與語言套件所需檔案。</sys:String>
+    <sys:String x:Key="W5">&#x0A;2. 點擊</sys:String>
+    <sys:String x:Key="W6">⚙️ 圖示</sys:String>
+    <sys:String x:Key="W7">在 Windows LiveCaptions 中打開設定選單，並選擇</sys:String>
+    <sys:String x:Key="W8">"位置 &gt; 疊加在螢幕上"</sys:String>
+    <sys:String x:Key="W9">3. 點擊</sys:String>
+    <sys:String x:Key="W10">"隱藏"</sys:String>
+    <sys:String x:Key="W11">按鈕以隱藏 Windows LiveCaptions。&#x0A;</sys:String>
+    <sys:String x:Key="W12">&#x0A;程式已自動導向至設定頁並開啟 Windows LiveCaptions。</sys:String>
+    <sys:String x:Key="W13">完成設定後，可返回主頁並享受即時音訊翻譯。&#x0A;</sys:String>
+    <sys:String x:Key="W14">&#x0A;更多詳情請參考我們的 Wiki： </sys:String>
+    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="W16">&#x0A;&#x0A;小提示：&#x0A;</sys:String>
+    <sys:String x:Key="W17">若要更改 </sys:String>
+    <sys:String x:Key="W18">來源語言</sys:String>
+    <sys:String x:Key="W19">，請在設定頁 [顯示] LiveCaptions，並於 Windows LiveCaptions 中操作。</sys:String>
+    <sys:String x:Key="W20">我已完全理解並完成配置。</sys:String>
+
+    <!-- MainWindow strings -->
+    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="M10">字幕</sys:String>
+    <sys:String x:Key="M11">設定</sys:String>
+    <sys:String x:Key="M12">歷史</sys:String>
+    <sys:String x:Key="M13">資訊</sys:String>
+    <sys:String x:Key="M20">字幕日誌卡片</sys:String>
+    <sys:String x:Key="M21">暫停翻譯（僅日誌）</sys:String>
+    <sys:String x:Key="M22">覆蓋視窗</sys:String>
+    <sys:String x:Key="M23">永遠置頂</sys:String>
+
+    <sys:String x:Key="MC0">[錯誤] 檢查更新失敗。</sys:String>
+    <sys:String x:Key="MC1">錯誤</sys:String>
+    <sys:String x:Key="MC2">有新版本可用</sys:String>
+    <sys:String x:Key="MC3">檢測到新版本：{0}
+當前版本：{1}
+請前往 GitHub 下載最新版本。</sys:String>
+    <sys:String x:Key="MC4">更新</sys:String>
+    <sys:String x:Key="MC5">忽略此版本</sys:String>
+    <sys:String x:Key="MC6">[錯誤] 打開瀏覽器失敗。</sys:String>
+
+    <!-- Translator (runtime status) strings -->
+    <sys:String x:Key="T0">[警告] LiveCaptions 意外關閉，正在重新啟動...</sys:String>
+    <sys:String x:Key="T1">[暫停]</sys:String>
+    <sys:String x:Key="T2">錯誤！</sys:String>
+    <sys:String x:Key="T3">記錄歷史失敗：{0}</sys:String>
+
+    <!-- CaptionPage strings -->
+    <sys:String x:Key="C0">點擊複製</sys:String>
+    <sys:String x:Key="C1">已複製</sys:String>
+    <sys:String x:Key="C2">複製失敗</sys:String>
+
+</ResourceDictionary>

--- a/src/localization/zh-tw.xaml
+++ b/src/localization/zh-tw.xaml
@@ -1,171 +1,156 @@
-<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <!-- SettingPage strings (compact numeric keys) -->
-    <sys:String x:Key="S0">即時字幕</sys:String>
-    <sys:String x:Key="S1">在 Windows 11 24H2 版本之後，您只能更改</sys:String>
-    <sys:String x:Key="S2">來源語言</sys:String>
-    <sys:String x:Key="S3">在即時字幕中。</sys:String>
-    <sys:String x:Key="S4">注意：</sys:String>
-    <sys:String x:Key="S5">請點擊</sys:String>
-    <sys:String x:Key="S6">"隱藏"</sys:String>
-    <sys:String x:Key="S7">來隱藏即時字幕，而非直接關閉。</sys:String>
+    <!-- SettingPage strings -->
+    <sys:String x:Key="SettingPage_LiveCaptionsName">即時字幕</sys:String>
+    <sys:String x:Key="S1">在 Windows 11 24H2 之後，您只能更改</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_SourceLanguage">來源語言</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_InLiveCaptions">於即時字幕中。</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_NoteLabel">注意：</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_PleaseClick">請點擊</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideQuoted">"隱藏"</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsInfo_HideInsteadOfClose">以隱藏即時字幕，而非關閉它。</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Show">顯示</sys:String>
+    <sys:String x:Key="SettingPage_LiveCaptionsToggle_Hide">隱藏</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Label">API 間隔</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Desc">決定翻譯 API 的呼叫頻率。數值越小呼叫越頻繁。</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Line1">字幕更改後呼叫一次翻譯 API</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_IntervalName">[API 間隔]</sys:String>
+    <sys:String x:Key="SettingPage_ApiInterval_Tooltip_Suffix">次。</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Label">翻譯 API</sys:String>
+    <sys:String x:Key="SettingPage_TranslateApi_Tooltip">除 Google 與 Google2 外，其他 API 使用前需先配置。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Label">目標語言</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Title">沒有我想要的目標語言？</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Line1">您可以編輯此下拉框文字來自訂語言。建議遵循</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Bcp47">BCP 47 語言標籤。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note1">某些 API（如 DeepL）需要不同方式指定目標語言，請查閱其文件。</sys:String>
+    <sys:String x:Key="SettingPage_TargetLanguage_Tooltip_Note2">內建目標語言已對應好。如果您的語言不在列表中，請留意這點。</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Label">API 設定</sys:String>
+    <sys:String x:Key="SettingPage_ApiSetting_Open">開啟</sys:String>
+    <sys:String x:Key="SettingPage_ShowLatency_Label">顯示延遲</sys:String>
+    <sys:String x:Key="Common_Off">關閉</sys:String>
+    <sys:String x:Key="Common_On">開啟</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Label">上下文</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Title">上下文：</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line1">決定啟用</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_ContextAware">上下文感知</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line2">時的上下文句子數量。</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_OverlaySentences">疊加句子：</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line3">決定啟用</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_LogCards">日誌卡片</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line4">時顯示的卡片數量，以及疊加視窗中最大顯示句數。</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line5">上下文必須</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line6">大於或等於</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_DisplaySentences">顯示句數</sys:String>
+    <sys:String x:Key="SettingPage_Contexts_Tooltip_Line7">。否則應用程式將自動調整。</sys:String>
+    <sys:String x:Key="SettingPage_DisplaySentences_Label">顯示句數</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line1">使用上下文進行翻譯。</sys:String>
+    <sys:String x:Key="SettingPage_ContextAware_Tooltip_Line2">可能提高準確性，但會消耗更多 token。</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Label">介面語言</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip">選擇應用程式 UI 使用的語言。</sys:String>
+    <sys:String x:Key="SettingPage_UiLanguage_Tooltip_ImmediateSave">更改會立即生效並自動保存。</sys:String>
 
-    <sys:String x:Key="S8">顯示</sys:String>
+    <!-- HistoryPage strings (semantic keys) -->
+    <sys:String x:Key="HistoryPage_Pagination_Previous">上一頁</sys:String>
+    <sys:String x:Key="HistoryPage_Pagination_Next">下一頁</sys:String>
+    <sys:String x:Key="HistoryPage_Search_Placeholder">搜尋</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Export">匯出</sys:String>
+    <sys:String x:Key="HistoryPage_Action_DeleteAll">全部刪除</sys:String>
+    <sys:String x:Key="HistoryPage_Action_Refresh">重新整理</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Time">時間</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Caption">字幕</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Translation">翻譯</sys:String>
+    <sys:String x:Key="HistoryPage_Column_Api">API</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_20">20/頁</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_30">30/頁</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_50">50/頁</sys:String>
+    <sys:String x:Key="HistoryPage_PageSize_100">100/頁</sys:String>
 
-    <!-- LiveCaptions toggle button text -->
-    <sys:String x:Key="S45">隱藏</sys:String>
-    <sys:String x:Key="S46">顯示</sys:String>
+    <!-- HistoryPage (code-behind) strings -->
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Title">確定要刪除所有歷史記錄嗎？</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Content">此操作無法復原！</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Primary">是</sys:String>
+    <sys:String x:Key="HistoryPage_Dialog_DeleteAll_Close">否</sys:String>
+    <sys:String x:Key="HistoryPage_Export_Filter">CSV (*.csv)|*.csv|所有檔案 (*.*)|*.*</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessTitle">保存成功</sys:String>
+    <sys:String x:Key="HistoryPage_Save_SuccessMessage">檔案已保存至：{0}</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedTitle">保存失敗</sys:String>
+    <sys:String x:Key="HistoryPage_Save_FailedMessage">檔案保存失敗：{0}</sys:String>
 
-    <sys:String x:Key="S9">API 間隔</sys:String>
-    <sys:String x:Key="S10">決定翻譯 API 呼叫的頻率。數值越小，呼叫越頻繁。</sys:String>
-    <sys:String x:Key="S11">字幕變更後，API 將呼叫一次</sys:String>
-    <sys:String x:Key="S12">[API 間隔]</sys:String>
-    <sys:String x:Key="S13">次。</sys:String>
-
-    <sys:String x:Key="S14">翻譯 API</sys:String>
-    <sys:String x:Key="S15">除了 Google 和 Google2，其他 API 需先配置才能使用。</sys:String>
-
-    <sys:String x:Key="S16">目標語言</sys:String>
-    <sys:String x:Key="S17">沒有找到我想要的目標語言！</sys:String>
-    <sys:String x:Key="S18">您可以直接編輯此下拉框內容自訂語言，建議遵循</sys:String>
-    <sys:String x:Key="S19">BCP 47 語言標籤。</sys:String>
-    <sys:String x:Key="S20">部分 API（例如 DeepL）需使用不同方式定義目標語言，詳情請參考官方文件。</sys:String>
-    <sys:String x:Key="S21">已包含的目標語言無需考慮，我們已內建標籤對應。但若預期語言不在列表中，請留意此點。</sys:String>
-
-    <sys:String x:Key="S22">API 設定</sys:String>
-    <sys:String x:Key="S23">開啟</sys:String>
-
-    <sys:String x:Key="S24">顯示延遲</sys:String>
-    <sys:String x:Key="S25">關閉</sys:String>
-    <sys:String x:Key="S26">開啟</sys:String>
-
-    <sys:String x:Key="S27">語境</sys:String>
-    <sys:String x:Key="S28">語境：</sys:String>
-    <sys:String x:Key="S29">啟用</sys:String>
-    <sys:String x:Key="S30">語境感知</sys:String>
-    <sys:String x:Key="S31">時，決定上下文句子數量。</sys:String>
-    <sys:String x:Key="S32">覆蓋句：</sys:String>
-    <sys:String x:Key="S33">啟用</sys:String>
-    <sys:String x:Key="S34">日誌卡片</sys:String>
-    <sys:String x:Key="S35">時，決定顯示卡片數量及覆蓋視窗的最大句數。</sys:String>
-    <sys:String x:Key="S36">語境必須</sys:String>
-    <sys:String x:Key="S37">大於或等於</sys:String>
-    <sys:String x:Key="S38">顯示句數</sys:String>
-    <sys:String x:Key="S39">。若不符合，程式將自動調整。</sys:String>
-
-    <sys:String x:Key="S40">顯示句數</sys:String>
-
-    <sys:String x:Key="S41">在語境中翻譯。</sys:String>
-    <sys:String x:Key="S42">可提高翻譯準確度，但會消耗更多代幣。</sys:String>
-
-    <sys:String x:Key="S43">介面語言</sys:String>
-    <sys:String x:Key="S44">選擇應用程式介面使用的語言。</sys:String>
-
-    <!-- HistoryPage strings -->
-    <sys:String x:Key="H0">上一頁</sys:String>
-    <sys:String x:Key="H1">下一頁</sys:String>
-    <sys:String x:Key="H2">搜尋</sys:String>
-    <sys:String x:Key="H3">匯出</sys:String>
-    <sys:String x:Key="H4">全部刪除</sys:String>
-    <sys:String x:Key="H5">重新整理</sys:String>
-    <sys:String x:Key="H6">時間</sys:String>
-    <sys:String x:Key="H7">字幕</sys:String>
-    <sys:String x:Key="H8">翻譯結果</sys:String>
-    <sys:String x:Key="H9">API</sys:String>
-    <sys:String x:Key="H10">20/頁</sys:String>
-    <sys:String x:Key="H11">30/頁</sys:String>
-    <sys:String x:Key="H12">50/頁</sys:String>
-    <sys:String x:Key="H13">100/頁</sys:String>
-    <sys:String x:Key="H20">您確定要刪除所有歷史記錄嗎？</sys:String>
-    <sys:String x:Key="H21">此操作無法復原！</sys:String>
-    <sys:String x:Key="H22">是</sys:String>
-    <sys:String x:Key="H23">否</sys:String>
-    <sys:String x:Key="H24">CSV (*.csv)|*.csv|所有檔案 (*.*)|*.*</sys:String>
-    <sys:String x:Key="H25">儲存成功</sys:String>
-    <sys:String x:Key="H26">檔案已儲存至：{0}</sys:String>
-    <sys:String x:Key="H27">儲存失敗</sys:String>
-    <sys:String x:Key="H28">檔案儲存失敗：{0}</sys:String>
-
-    <!-- OverlayWindow strings -->
-    <sys:String x:Key="O0">覆蓋視窗</sys:String>
-    <sys:String x:Key="O1">增加字型大小</sys:String>
-    <sys:String x:Key="O2">減小字型大小</sys:String>
-    <sys:String x:Key="O3">增加字型描邊</sys:String>
-    <sys:String x:Key="O4">減小字型描邊</sys:String>
-    <sys:String x:Key="O5">加粗</sys:String>
-    <sys:String x:Key="O6">字型顏色</sys:String>
-    <sys:String x:Key="O7">增加背景透明度</sys:String>
-    <sys:String x:Key="O8">減少背景透明度</sys:String>
-    <sys:String x:Key="O9">背景顏色</sys:String>
-    <sys:String x:Key="O10">僅顯示字幕或翻譯</sys:String>
-    <sys:String x:Key="O11">切換字幕/翻譯位置</sys:String>
-    <sys:String x:Key="O12">點擊穿透</sys:String>
+    <!-- OverlayWindow strings (semantic tooltips) -->
+    <sys:String x:Key="OverlayWindow_Title">疊加視窗</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseFontSize">增大字型</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseFontSize">減小字型</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseStroke">增強描邊</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseStroke">減弱描邊</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_Bold">粗體</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_FontColor">字體顏色</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_IncreaseBackgroundOpacity">增大背景不透明度</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_DecreaseBackgroundOpacity">減小背景不透明度</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_BackgroundColor">背景顏色</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_OnlyMode">只顯示字幕或翻譯</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_SwitchPosition">切換字幕/翻譯位置</sys:String>
+    <sys:String x:Key="OverlayWindow_Button_ClickThrough">穿透點擊</sys:String>
 
     <!-- InfoPage strings -->
-    <sys:String x:Key="I0">我們歡迎任何形式的貢獻！您可以透過 GitHub issues 提建議或回報錯誤，或直接透過 Pull Requests 提交程式碼。</sys:String>
-    <sys:String x:Key="I1">如果本程式對您有幫助，請考慮給我們一顆星！</sys:String>
-    <sys:String x:Key="I2">倉庫：</sys:String>
-    <sys:String x:Key="I3">Wiki：</sys:String>
-    <sys:String x:Key="I4">維護者：</sys:String>
-    <sys:String x:Key="I5">(作者) 與</sys:String>
-    <sys:String x:Key="I6">版本：</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_Message">歡迎各種貢獻！您可以透過 GitHub 問題建議功能或提交 Pull Request 直接貢獻程式碼。</sys:String>
+    <sys:String x:Key="InfoPage_Contrib_StarHint">如果這個程式對您有幫助，請考慮給專案一顆 Star！</sys:String>
+    <sys:String x:Key="InfoPage_Label_Repo">程式庫：</sys:String>
+    <sys:String x:Key="InfoPage_Label_Wiki">Wiki：</sys:String>
+    <sys:String x:Key="InfoPage_Label_Maintainer">維護者：</sys:String>
+    <sys:String x:Key="InfoPage_Label_And">(作者)及</sys:String>
+    <sys:String x:Key="InfoPage_Label_Version">版本：</sys:String>
 
     <!-- WelcomeWindow strings -->
-    <sys:String x:Key="W0">開始使用</sys:String>
-    <sys:String x:Key="W1">歡迎使用 LiveCaptions Translator！</sys:String>
-    <sys:String x:Key="W2">LiveCaptions Translator 基於 Windows LiveCaptions。</sys:String>
-    <sys:String x:Key="W3">&#x0A;在首次運行前，請依照以下步驟配置：&#x0A;</sys:String>
-    <sys:String x:Key="W4">&#x0A;1. 開啟 Windows LiveCaptions 並依導引下載語音辨識與語言套件所需檔案。</sys:String>
-    <sys:String x:Key="W5">&#x0A;2. 點擊</sys:String>
-    <sys:String x:Key="W6">⚙️ 圖示</sys:String>
-    <sys:String x:Key="W7">在 Windows LiveCaptions 中打開設定選單，並選擇</sys:String>
-    <sys:String x:Key="W8">"位置 &gt; 疊加在螢幕上"</sys:String>
-    <sys:String x:Key="W9">3. 點擊</sys:String>
-    <sys:String x:Key="W10">"隱藏"</sys:String>
-    <sys:String x:Key="W11">按鈕以隱藏 Windows LiveCaptions。&#x0A;</sys:String>
-    <sys:String x:Key="W12">&#x0A;程式已自動導向至設定頁並開啟 Windows LiveCaptions。</sys:String>
-    <sys:String x:Key="W13">完成設定後，可返回主頁並享受即時音訊翻譯。&#x0A;</sys:String>
-    <sys:String x:Key="W14">&#x0A;更多詳情請參考我們的 Wiki： </sys:String>
-    <sys:String x:Key="W15">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
-    <sys:String x:Key="W16">&#x0A;&#x0A;小提示：&#x0A;</sys:String>
-    <sys:String x:Key="W17">若要更改 </sys:String>
-    <sys:String x:Key="W18">來源語言</sys:String>
-    <sys:String x:Key="W19">，請在設定頁 [顯示] LiveCaptions，並於 Windows LiveCaptions 中操作。</sys:String>
-    <sys:String x:Key="W20">我已完全理解並完成配置。</sys:String>
+    <sys:String x:Key="WelcomeWindow_GetStarted">開始使用</sys:String>
+    <sys:String x:Key="WelcomeWindow_Title">歡迎使用 LiveCaptions Translator！</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_Base">LiveCaptions Translator 基於 Windows 即時字幕。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Intro_StepsLead">&#x0A;首次使用前，請完成以下設定步驟：&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step1">&#x0A;1. 開啟 Windows 即時字幕，並按照指示下載離線語音辨識檔與語言包。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Click">&#x0A;2. 點擊</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Gear">⚙️ 齒輪</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Instruction">圖示以開啟設定並選擇</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step2_Position">"位置 &gt; 疊加於螢幕"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Click">3. 點擊</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_HideQuoted">"隱藏"</sys:String>
+    <sys:String x:Key="WelcomeWindow_Step3_Instruction">按鈕於 LiveCaptions Translator 設定頁面中以隱藏 Windows 即時字幕。&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_AutoOpen">&#x0A;程式已自動跳轉到設定頁並開啟 Windows 即時字幕。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Enjoy">完成設定後，即可回到主頁享受即時語音翻譯。&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiLead">&#x0A;更多細節請參考 Wiki： </sys:String>
+    <sys:String x:Key="WelcomeWindow_WikiUrl">https://github.com/SakiRinn/LiveCaptions-Translator/wiki</sys:String>
+    <sys:String x:Key="WelcomeWindow_TipLead">&#x0A;&#x0A;提示：&#x0A;</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_IfYouWantToChange">如果您想更改</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_SourceLanguage">來源語言</sys:String>
+    <sys:String x:Key="WelcomeWindow_Tip_Instruction">，請先點擊 [顯示] 即時字幕，然後在 Windows 即時字幕中更改。</sys:String>
+    <sys:String x:Key="WelcomeWindow_Button_Confirm">我已完全理解並完成設定。</sys:String>
+
+    <!-- Navigation menu -->
+    <sys:String x:Key="Navigation_Captions">字幕</sys:String>
+    <sys:String x:Key="Navigation_Settings">設定</sys:String>
+    <sys:String x:Key="Navigation_History">歷史</sys:String>
+    <sys:String x:Key="Navigation_Info">資訊</sys:String>
 
     <!-- MainWindow strings -->
-    <sys:String x:Key="M0">LiveCaptions Translator</sys:String>
-    <sys:String x:Key="M10">字幕</sys:String>
-    <sys:String x:Key="M11">設定</sys:String>
-    <sys:String x:Key="M12">歷史</sys:String>
-    <sys:String x:Key="M13">資訊</sys:String>
-    <sys:String x:Key="M20">字幕日誌卡片</sys:String>
-    <sys:String x:Key="M21">暫停翻譯（僅日誌）</sys:String>
-    <sys:String x:Key="M22">覆蓋視窗</sys:String>
-    <sys:String x:Key="M23">永遠置頂</sys:String>
+    <sys:String x:Key="MainWindow_Title">LiveCaptions Translator</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_CaptionLog">字幕日誌卡片</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_LogOnly">暫停翻譯（僅日誌）</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Overlay">疊加視窗</sys:String>
+    <sys:String x:Key="MainWindow_Tooltip_Topmost">總在最前</sys:String>
+    <sys:String x:Key="MainWindow_Update_Error">[錯誤] 更新檢查失敗。</sys:String>
+    <sys:String x:Key="MainWindow_Update_ErrorLabel">錯誤</sys:String>
+    <sys:String x:Key="MainWindow_Update_Found">發現新版本</sys:String>
+    <sys:String x:Key="MainWindow_Update_Message">偵測到新版本：{0} 當前版本：{1}，請前往 GitHub 下載最新版本。</sys:String>
 
-    <sys:String x:Key="MC0">[錯誤] 檢查更新失敗。</sys:String>
-    <sys:String x:Key="MC1">錯誤</sys:String>
-    <sys:String x:Key="MC2">有新版本可用</sys:String>
-    <sys:String x:Key="MC3">檢測到新版本：{0}
-當前版本：{1}
-請前往 GitHub 下載最新版本。</sys:String>
-    <sys:String x:Key="MC4">更新</sys:String>
-    <sys:String x:Key="MC5">忽略此版本</sys:String>
-    <sys:String x:Key="MC6">[錯誤] 打開瀏覽器失敗。</sys:String>
-
-    <!-- Translator (runtime status) strings -->
-    <sys:String x:Key="T0">[警告] LiveCaptions 意外關閉，正在重新啟動...</sys:String>
-    <sys:String x:Key="T1">[暫停]</sys:String>
-    <sys:String x:Key="T2">錯誤！</sys:String>
-    <sys:String x:Key="T3">記錄歷史失敗：{0}</sys:String>
+    <!-- Translator -->
+    <sys:String x:Key="Translator_Status_Restarting">[警告] 即時字幕意外關閉，正在重啟…</sys:String>
+    <sys:String x:Key="Translator_Status_Paused">[暫停]</sys:String>
+    <sys:String x:Key="Translator_Status_Error">錯誤！</sys:String>
+    <sys:String x:Key="Translator_Status_WriteHistoryFailed">寫入歷史失敗：{0}</sys:String>
 
     <!-- CaptionPage strings -->
-    <sys:String x:Key="C0">點擊複製</sys:String>
-    <sys:String x:Key="C1">已複製</sys:String>
-    <sys:String x:Key="C2">複製失敗</sys:String>
+    <sys:String x:Key="CaptionPage_Tooltip_ClickToCopy">點擊以複製</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_Copied">已複製</sys:String>
+    <sys:String x:Key="CaptionPage_Toast_CopyFailed">複製失敗</sys:String>
 
 </ResourceDictionary>

--- a/src/models/Caption.cs
+++ b/src/models/Caption.cs
@@ -23,11 +23,12 @@ namespace LiveCaptionsTranslator.models
         public string TranslatedCaption { get; set; } = string.Empty;
 
         public Queue<TranslationHistoryEntry> Contexts { get; } = new(MAX_CONTEXTS);
-        public string ContextPreviousCaption => GetPreviousCaption(
-            Math.Min(Translator.Setting.NumContexts, Contexts.Count));
 
-        public IEnumerable<TranslationHistoryEntry> DisplayLogCards => Contexts.Reverse().Take(
-            Math.Min(Translator.Setting.DisplaySentences, Contexts.Count));
+        public IEnumerable<TranslationHistoryEntry> AwareContexts => GetPreviousContexts(Translator.Setting.NumContexts);
+        public string AwareContextsCaption => GetPreviousText(Translator.Setting.NumContexts, TextType.Caption);
+
+        public IEnumerable<TranslationHistoryEntry> DisplayLogCards =>
+            GetPreviousContexts(Translator.Setting.DisplaySentences).Reverse();
 
         public string DisplayOriginalCaption
         {
@@ -75,8 +76,9 @@ namespace LiveCaptionsTranslator.models
                 OnPropertyChanged("OverlayCurrentTranslation");
             }
         }
-        public string OverlayPreviousTranslation => GetPreviousTranslation(
-            Math.Min(Translator.Setting.DisplaySentences, Contexts.Count));
+
+        public string OverlayPreviousTranslation =>
+            GetPreviousText(Translator.Setting.DisplaySentences, TextType.Translation);
 
         private Caption()
         {
@@ -90,14 +92,16 @@ namespace LiveCaptionsTranslator.models
             return instance;
         }
 
-        public string GetPreviousCaption(int count)
+        public string GetPreviousText(int count, TextType textType)
         {
-            if (count <= 0)
+            if (count <= 0 || Contexts.Count == 0)
                 return string.Empty;
 
             var prev = Contexts
                 .Reverse().Take(count).Reverse()
-                .Select(entry => entry.SourceText)
+                .Select(entry => entry == null || string.CompareOrdinal(entry.TranslatedText, "N/A") == 0 ||
+                                 entry.TranslatedText.Contains("[ERROR]") || entry.TranslatedText.Contains("[WARNING]") ?
+                    "" : (textType == TextType.Caption ? entry.SourceText : entry.TranslatedText))
                 .Aggregate((accu, cur) =>
                 {
                     if (!string.IsNullOrEmpty(accu))
@@ -111,6 +115,8 @@ namespace LiveCaptionsTranslator.models
                     return accu + cur;
                 });
 
+            if (textType == TextType.Translation)
+                prev = RegexPatterns.NoticePrefix().Replace(prev, "");
             if (!string.IsNullOrEmpty(prev) && Array.IndexOf(TextUtil.PUNC_EOS, prev[^1]) == -1)
                 prev += TextUtil.isCJChar(prev[^1]) ? "。" : ".";
             if (!string.IsNullOrEmpty(prev) && Encoding.UTF8.GetByteCount(prev[^1].ToString()) < 2)
@@ -118,39 +124,27 @@ namespace LiveCaptionsTranslator.models
             return prev;
         }
 
-        public string GetPreviousTranslation(int count)
+        public IEnumerable<TranslationHistoryEntry> GetPreviousContexts(int count)
         {
-            if (count <= 0)
-                return string.Empty;
+            if (count <= 0 || Contexts.Count == 0)
+                return [];
 
-            var prev = Contexts
+            return Contexts
                 .Reverse().Take(count).Reverse()
-                .Select(entry => entry.TranslatedText.Contains("[ERROR]") || entry.TranslatedText.Contains("[WARNING]") ?
-                    "" : entry.TranslatedText)
-                .Aggregate((accu, cur) =>
-                {
-                    if (!string.IsNullOrEmpty(accu))
-                    {
-                        if (Array.IndexOf(TextUtil.PUNC_EOS, accu[^1]) == -1)
-                            accu += TextUtil.isCJChar(accu[^1]) ? "。" : ". ";
-                        else
-                            accu += TextUtil.isCJChar(accu[^1]) ? "" : " ";
-                    }
-                    cur = RegexPatterns.NoticePrefix().Replace(cur, "");
-                    return accu + cur;
-                });
-
-            prev = RegexPatterns.NoticePrefix().Replace(prev, "");
-            if (!string.IsNullOrEmpty(prev) && Array.IndexOf(TextUtil.PUNC_EOS, prev[^1]) == -1)
-                prev += TextUtil.isCJChar(prev[^1]) ? "。" : ".";
-            if (!string.IsNullOrEmpty(prev) && Encoding.UTF8.GetByteCount(prev[^1].ToString()) < 2)
-                prev += " ";
-            return prev;
+                .Where(entry => entry != null && string.CompareOrdinal(entry.TranslatedText, "N/A") != 0 &&
+                                !entry.TranslatedText.Contains("[ERROR]") &&
+                                !entry.TranslatedText.Contains("[WARNING]"));
         }
 
         public void OnPropertyChanged([CallerMemberName] string propName = "")
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
         }
+    }
+
+    public enum TextType
+    {
+        Caption,
+        Translation
     }
 }

--- a/src/models/LanguageCatalog.cs
+++ b/src/models/LanguageCatalog.cs
@@ -1,0 +1,40 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+
+namespace LiveCaptionsTranslator.models
+{
+    public class LanguageItem
+    {
+        public string DisplayName { get; set; }
+        public string CultureCode { get; set; }
+    }
+
+    public static class LanguageCatalog
+    {
+
+        public static readonly ReadOnlyCollection<LanguageItem> SupportedUiLanguages = new(new List<LanguageItem>
+        {
+            new() { DisplayName = "English", CultureCode = "en-us" },
+            new() { DisplayName = "\u7B80\u4F53\u4E2D\u6587", CultureCode = "zh-cn" },
+            new() { DisplayName = "\u0627\u0644\u0639\u0631\u0628\u064A\u0629", CultureCode = "ar" },
+            new() { DisplayName = "\u09AC\u09BE\u0982\u09B2\u09BE", CultureCode = "bn" },
+            new() { DisplayName = "\u010Ce\u0161tina", CultureCode = "cs-cz" },
+            new() { DisplayName = "Deutsch", CultureCode = "de-de" },
+            new() { DisplayName = "Espa\u00F1ol (M\u00E9xico)", CultureCode = "es-mx" },
+            new() { DisplayName = "Fran\u00E7ais", CultureCode = "fr-fr" },
+            new() { DisplayName = "Italiano", CultureCode = "it-it" },
+            new() { DisplayName = "\u65E5\u672C\u8A9E", CultureCode = "ja-jp" },
+            new() { DisplayName = "\uD55C\uAD6D\uC5B4", CultureCode = "ko-kr" },
+            new() { DisplayName = "Lietuvi\u0173", CultureCode = "lt-lt" },
+            new() { DisplayName = "Nederlands", CultureCode = "nl-nl" },
+            new() { DisplayName = "Polski", CultureCode = "pl-pl" },
+            new() { DisplayName = "Portugu\u00EAs (Brasil)", CultureCode = "pt-br" },
+            new() { DisplayName = "Portugu\u00EAs (Portugal)", CultureCode = "pt-pt" },
+            new() { DisplayName = "\u0420\u0443\u0441\u0441\u043A\u0438\u0439", CultureCode = "ru-ru" },
+            new() { DisplayName = "Svenska", CultureCode = "sv-se" },
+            new() { DisplayName = "T\u00FCrk\u00E7e", CultureCode = "tr-tr" },
+            new() { DisplayName = "Ti\u1EBFng Vi\u1EC7t", CultureCode = "vi-vn" },
+            new() { DisplayName = "\u7E41\u9AD4\u4E2D\u6587 (\u53F0\u7063)", CultureCode = "zh-tw" },
+        });
+    }
+}

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -21,17 +21,29 @@ namespace LiveCaptionsTranslator.models
         private int displaySentences = 1;
         private bool contextAware = false;
 
+        private string uiLanguageFileName = "en-us.xaml";
+
         private string apiName;
         private string targetLanguage;
         private string prompt;
         private string? ignoredUpdateVersion;
-        
+
         private MainWindowState mainWindowState;
         private OverlayWindowState overlayWindowState;
         private Dictionary<string, string> windowBounds;
 
         private Dictionary<string, List<TranslateAPIConfig>> configs;
         private Dictionary<string, int> configIndices;
+
+        public string UiLanguageFileName
+        {
+            get => uiLanguageFileName;
+            set
+            {
+                uiLanguageFileName = value;
+                OnPropertyChanged();
+            }
+        }
 
         public int MaxIdleInterval => maxIdleInterval;
         public int MaxSyncInterval
@@ -173,6 +185,8 @@ namespace LiveCaptionsTranslator.models
                      "You can only provide the translated sentence; Any explanation or other text is not permitted. " +
                      "REMOVE all 🔤 when you output.";
 
+            uiLanguageFileName = "en-us.xaml";
+
             mainWindowState = new MainWindowState();
             overlayWindowState = new OverlayWindowState();
 
@@ -237,7 +251,6 @@ namespace LiveCaptionsTranslator.models
         {
             Setting setting;
 
-            // Load from JSON file if it exists
             if (File.Exists(jsonPath))
             {
                 using (FileStream fileStream = File.Open(jsonPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
@@ -253,7 +266,16 @@ namespace LiveCaptionsTranslator.models
             else
                 setting = new Setting();
 
-            // Ensure all required API configs are present
+            setting.uiLanguageFileName = setting.uiLanguageFileName switch
+            {
+                "zh-cn.xaml" or "ar.xaml" or "bn.xaml" or "en-us.xaml" or
+                "zh-tw.xaml" or "cs-cz.xaml" or "de-de.xaml" or "es-mx.xaml" or "fr-fr.xaml" or
+                "it-it.xaml" or "ja-jp.xaml" or "ko-kr.xaml" or "lt-lt.xaml" or "nl-nl.xaml" or
+                "pl-pl.xaml" or "pt-br.xaml" or "pt-pt.xaml" or "ru-ru.xaml" or "sv-se.xaml" or
+                "tr-tr.xaml" or "vi-vn.xaml" => setting.uiLanguageFileName,
+                _ => "en-us.xaml"
+            };
+
             foreach (string key in TranslateAPI.TRANSLATE_FUNCTIONS.Keys)
             {
                 if (setting.Configs.ContainsKey(key))

--- a/src/models/Setting.cs
+++ b/src/models/Setting.cs
@@ -4,8 +4,10 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Windows;
+using System.Linq;
 
 using LiveCaptionsTranslator.apis;
+using LiveCaptionsTranslator.utils;
 
 namespace LiveCaptionsTranslator.models
 {
@@ -266,15 +268,8 @@ namespace LiveCaptionsTranslator.models
             else
                 setting = new Setting();
 
-            setting.uiLanguageFileName = setting.uiLanguageFileName switch
-            {
-                "zh-cn.xaml" or "ar.xaml" or "bn.xaml" or "en-us.xaml" or
-                "zh-tw.xaml" or "cs-cz.xaml" or "de-de.xaml" or "es-mx.xaml" or "fr-fr.xaml" or
-                "it-it.xaml" or "ja-jp.xaml" or "ko-kr.xaml" or "lt-lt.xaml" or "nl-nl.xaml" or
-                "pl-pl.xaml" or "pt-br.xaml" or "pt-pt.xaml" or "ru-ru.xaml" or "sv-se.xaml" or
-                "tr-tr.xaml" or "vi-vn.xaml" => setting.uiLanguageFileName,
-                _ => "en-us.xaml"
-            };
+            if (!LocalizationHelper.SupportedFiles.Contains(setting.uiLanguageFileName, StringComparer.OrdinalIgnoreCase))
+                setting.uiLanguageFileName = "en-us.xaml";
 
             foreach (string key in TranslateAPI.TRANSLATE_FUNCTIONS.Keys)
             {

--- a/src/pages/CaptionPage.xaml
+++ b/src/pages/CaptionPage.xaml
@@ -35,7 +35,7 @@
                 MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                 Style="{StaticResource CaptionBlockStyle}"
                 Text="{Binding DisplayOriginalCaption, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="{DynamicResource C0}" />
+                ToolTip="{DynamicResource CaptionPage_Tooltip_ClickToCopy}" />
         </ui:Card>
 
         <ui:Card
@@ -52,7 +52,7 @@
                 MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                 Style="{StaticResource CaptionBlockStyle}"
                 Text="{Binding DisplayTranslatedCaption, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="{DynamicResource C0}" />
+                ToolTip="{DynamicResource CaptionPage_Tooltip_ClickToCopy}" />
         </ui:Card>
 
         <ui:Card
@@ -93,7 +93,7 @@
                                         MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                                         Style="{StaticResource CaptionBlockStyle}"
                                         Text="{Binding SourceText}"
-                                        ToolTip="{DynamicResource C0}" />
+                                        ToolTip="{DynamicResource CaptionPage_Tooltip_ClickToCopy}" />
                                 </ui:Card>
                                 <ui:Card
                                     Grid.Row="1"
@@ -108,7 +108,7 @@
                                         MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                                         Style="{StaticResource CaptionBlockStyle}"
                                         Text="{Binding TranslatedText}"
-                                        ToolTip="{DynamicResource C0}" />
+                                        ToolTip="{DynamicResource CaptionPage_Tooltip_ClickToCopy}" />
                                 </ui:Card>
                             </Grid>
                         </Border>

--- a/src/pages/CaptionPage.xaml
+++ b/src/pages/CaptionPage.xaml
@@ -35,7 +35,7 @@
                 MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                 Style="{StaticResource CaptionBlockStyle}"
                 Text="{Binding DisplayOriginalCaption, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="Click To Copy" />
+                ToolTip="{DynamicResource C0}" />
         </ui:Card>
 
         <ui:Card
@@ -52,7 +52,7 @@
                 MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                 Style="{StaticResource CaptionBlockStyle}"
                 Text="{Binding DisplayTranslatedCaption, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="Click To Copy" />
+                ToolTip="{DynamicResource C0}" />
         </ui:Card>
 
         <ui:Card
@@ -93,7 +93,7 @@
                                         MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                                         Style="{StaticResource CaptionBlockStyle}"
                                         Text="{Binding SourceText}"
-                                        ToolTip="Click To Copy" />
+                                        ToolTip="{DynamicResource C0}" />
                                 </ui:Card>
                                 <ui:Card
                                     Grid.Row="1"
@@ -108,7 +108,7 @@
                                         MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                                         Style="{StaticResource CaptionBlockStyle}"
                                         Text="{Binding TranslatedText}"
-                                        ToolTip="Click To Copy" />
+                                        ToolTip="{DynamicResource C0}" />
                                 </ui:Card>
                             </Grid>
                         </Border>

--- a/src/pages/CaptionPage.xaml.cs
+++ b/src/pages/CaptionPage.xaml.cs
@@ -43,11 +43,19 @@ namespace LiveCaptionsTranslator
                 try
                 {
                     Clipboard.SetText(textBlock.Text);
-                    SnackbarHost.Show("Copied.", textBlock.Text, SnackbarType.Info, 100);
+                    SnackbarHost.Show(
+                        TryFindResource("C1") as string ?? "Copied",
+                        textBlock.Text,
+                        "info",
+                        1,
+                        100,
+                        false);
                 }
                 catch
                 {
-                    SnackbarHost.Show("Copy Failed.", string.Empty, SnackbarType.Error, 100);
+                    SnackbarHost.Show(
+                        title: TryFindResource("C2") as string ?? "Copy Failed",
+                        type: "error");
                 }
                 await Task.Delay(500);
             }

--- a/src/pages/CaptionPage.xaml.cs
+++ b/src/pages/CaptionPage.xaml.cs
@@ -36,6 +36,8 @@ namespace LiveCaptionsTranslator
             CollapseTranslatedCaption(Translator.Setting.MainWindow.CaptionLogEnabled);
         }
 
+        private static string Res(string key) => Application.Current?.TryFindResource(key)?.ToString() ?? key;
+
         private async void TextBlock_MouseLeftButtonDown(object sender, RoutedEventArgs e)
         {
             if (sender is TextBlock textBlock)
@@ -43,19 +45,11 @@ namespace LiveCaptionsTranslator
                 try
                 {
                     Clipboard.SetText(textBlock.Text);
-                    SnackbarHost.Show(
-                        TryFindResource("C1") as string ?? "Copied",
-                        textBlock.Text,
-                        "info",
-                        1,
-                        100,
-                        false);
+                    SnackbarHost.Show(Res("CaptionPage_Toast_Copied"), textBlock.Text, SnackbarType.Info, 100);
                 }
                 catch
                 {
-                    SnackbarHost.Show(
-                        title: TryFindResource("C2") as string ?? "Copy Failed",
-                        type: "error");
+                    SnackbarHost.Show(Res("CaptionPage_Toast_CopyFailed"), string.Empty, SnackbarType.Error, 100);
                 }
                 await Task.Delay(500);
             }

--- a/src/pages/HistoryPage.xaml
+++ b/src/pages/HistoryPage.xaml
@@ -35,7 +35,7 @@
                     Icon="{ui:SymbolIcon chevronLeft12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="Previous " />
+                    ToolTip="{DynamicResource H0}" />
 
                 <ui:TextBlock
                     x:Name="PageNumber"
@@ -51,7 +51,7 @@
                     Icon="{ui:SymbolIcon chevronRight12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="Next Page" />
+                    ToolTip="{DynamicResource H1}" />
 
                 <ComboBox
                     x:Name="HistoryMaxRow"
@@ -60,10 +60,10 @@
                     Padding="10,4,10,7"
                     VerticalAlignment="Stretch"
                     SelectedIndex="1">
-                    <ComboBoxItem Content="20/page" Tag="20" />
-                    <ComboBoxItem Content="30/page" Tag="30" />
-                    <ComboBoxItem Content="50/page" Tag="50" />
-                    <ComboBoxItem Content="100/page" Tag="100" />
+                    <ComboBoxItem Content="{DynamicResource H10}" Tag="20" />
+                    <ComboBoxItem Content="{DynamicResource H11}" Tag="30" />
+                    <ComboBoxItem Content="{DynamicResource H12}" Tag="50" />
+                    <ComboBoxItem Content="{DynamicResource H13}" Tag="100" />
                 </ComboBox>
 
                 <ui:AutoSuggestBox
@@ -71,7 +71,7 @@
                     MinWidth="200"
                     MaxWidth="200"
                     Margin="5,0,0,0"
-                    PlaceholderText="Search"
+                    PlaceholderText="{DynamicResource H2}"
                     QuerySubmitted="HistorySearchBox_QuerySubmitted"
                     TextChanged="HistorySearchBox_TextChanged" />
 
@@ -92,7 +92,7 @@
                     Icon="{ui:SymbolIcon ArrowDown12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="Export" />
+                    ToolTip="{DynamicResource H3}" />
                 <ui:Button
                     x:Name="Delete"
                     Margin="5,0,0,0"
@@ -102,7 +102,7 @@
                     Icon="{ui:SymbolIcon Delete12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="Delete All" />
+                    ToolTip="{DynamicResource H4}" />
 
                 <ui:Button
                     x:Name="Refresh"
@@ -113,7 +113,7 @@
                     Icon="{ui:SymbolIcon ArrowClockwise12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="Refresh" />
+                    ToolTip="{DynamicResource H5}" />
             </StackPanel>
         </Grid>
 
@@ -148,7 +148,7 @@
                 </LinearGradientBrush>
             </DataGrid.BorderBrush>
             <DataGrid.Columns>
-                <DataGridTemplateColumn Width="0.4*" Header="Time">
+                <DataGridTemplateColumn Width="0.4*" Header="{DynamicResource H6}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock
@@ -159,7 +159,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
 
-                <DataGridTemplateColumn Width="*" Header="Caption">
+                <DataGridTemplateColumn Width="*" Header="{DynamicResource H7}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding SourceText}" TextWrapping="Wrap" />
@@ -167,7 +167,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
 
-                <DataGridTemplateColumn Width="*" Header="Translated">
+                <DataGridTemplateColumn Width="*" Header="{DynamicResource H8}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding TranslatedText}" TextWrapping="Wrap" />
@@ -175,7 +175,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
 
-                <DataGridTemplateColumn Width="0.3*" Header="API">
+                <DataGridTemplateColumn Width="0.3*" Header="{DynamicResource H9}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding ApiUsed}" TextWrapping="Wrap" />

--- a/src/pages/HistoryPage.xaml
+++ b/src/pages/HistoryPage.xaml
@@ -35,7 +35,7 @@
                     Icon="{ui:SymbolIcon chevronLeft12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="{DynamicResource H0}" />
+                    ToolTip="{DynamicResource HistoryPage_Pagination_Previous}" />
 
                 <ui:TextBlock
                     x:Name="PageNumber"
@@ -51,7 +51,7 @@
                     Icon="{ui:SymbolIcon chevronRight12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="{DynamicResource H1}" />
+                    ToolTip="{DynamicResource HistoryPage_Pagination_Next}" />
 
                 <ComboBox
                     x:Name="HistoryMaxRow"
@@ -60,10 +60,10 @@
                     Padding="10,4,10,7"
                     VerticalAlignment="Stretch"
                     SelectedIndex="1">
-                    <ComboBoxItem Content="{DynamicResource H10}" Tag="20" />
-                    <ComboBoxItem Content="{DynamicResource H11}" Tag="30" />
-                    <ComboBoxItem Content="{DynamicResource H12}" Tag="50" />
-                    <ComboBoxItem Content="{DynamicResource H13}" Tag="100" />
+                    <ComboBoxItem Content="{DynamicResource HistoryPage_PageSize_20}" Tag="20" />
+                    <ComboBoxItem Content="{DynamicResource HistoryPage_PageSize_30}" Tag="30" />
+                    <ComboBoxItem Content="{DynamicResource HistoryPage_PageSize_50}" Tag="50" />
+                    <ComboBoxItem Content="{DynamicResource HistoryPage_PageSize_100}" Tag="100" />
                 </ComboBox>
 
                 <ui:AutoSuggestBox
@@ -71,7 +71,7 @@
                     MinWidth="200"
                     MaxWidth="200"
                     Margin="5,0,0,0"
-                    PlaceholderText="{DynamicResource H2}"
+                    PlaceholderText="{DynamicResource HistoryPage_Search_Placeholder}"
                     QuerySubmitted="HistorySearchBox_QuerySubmitted"
                     TextChanged="HistorySearchBox_TextChanged" />
 
@@ -92,7 +92,7 @@
                     Icon="{ui:SymbolIcon ArrowDown12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="{DynamicResource H3}" />
+                    ToolTip="{DynamicResource HistoryPage_Action_Export}" />
                 <ui:Button
                     x:Name="Delete"
                     Margin="5,0,0,0"
@@ -102,7 +102,7 @@
                     Icon="{ui:SymbolIcon Delete12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="{DynamicResource H4}" />
+                    ToolTip="{DynamicResource HistoryPage_Action_DeleteAll}" />
 
                 <ui:Button
                     x:Name="Refresh"
@@ -113,7 +113,7 @@
                     Icon="{ui:SymbolIcon ArrowClockwise12,
                                          Filled=False}"
                     MouseOverBackground="#07000000"
-                    ToolTip="{DynamicResource H5}" />
+                    ToolTip="{DynamicResource HistoryPage_Action_Refresh}" />
             </StackPanel>
         </Grid>
 
@@ -148,7 +148,7 @@
                 </LinearGradientBrush>
             </DataGrid.BorderBrush>
             <DataGrid.Columns>
-                <DataGridTemplateColumn Width="0.4*" Header="{DynamicResource H6}">
+                <DataGridTemplateColumn Width="0.4*" Header="{DynamicResource HistoryPage_Column_Time}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock
@@ -159,7 +159,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
 
-                <DataGridTemplateColumn Width="*" Header="{DynamicResource H7}">
+                <DataGridTemplateColumn Width="*" Header="{DynamicResource HistoryPage_Column_Caption}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding SourceText}" TextWrapping="Wrap" />
@@ -167,7 +167,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
 
-                <DataGridTemplateColumn Width="*" Header="{DynamicResource H8}">
+                <DataGridTemplateColumn Width="*" Header="{DynamicResource HistoryPage_Column_Translation}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding TranslatedText}" TextWrapping="Wrap" />
@@ -175,7 +175,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
 
-                <DataGridTemplateColumn Width="0.3*" Header="{DynamicResource H9}">
+                <DataGridTemplateColumn Width="0.3*" Header="{DynamicResource HistoryPage_Column_Api}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding ApiUsed}" TextWrapping="Wrap" />

--- a/src/pages/HistoryPage.xaml.cs
+++ b/src/pages/HistoryPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Win32;
@@ -21,6 +22,8 @@ namespace LiveCaptionsTranslator
         private int maxRowPerPage = 30;
 
         public string SearchText { get; set; } = string.Empty;
+
+        private string R(string key, string fallback) => TryFindResource(key) as string ?? fallback;
 
         public HistoryPage()
         {
@@ -69,13 +72,13 @@ namespace LiveCaptionsTranslator
             {
                 Title = new TextBlock
                 {
-                    Text = "Do you want to delete all history?",
+                    Text = R("H20", "Do you want to delete all history?"),
                     FontSize = 18,
                     FontWeight = FontWeights.Regular
                 },
-                Content = "This operation cannot be undone!",
-                PrimaryButtonText = "Yes",
-                CloseButtonText = "No",
+                Content = R("H21", "This operation cannot be undone!"),
+                PrimaryButtonText = R("H22", "Yes"),
+                CloseButtonText = R("H23", "No"),
                 DefaultButton = ContentDialogButton.Close,
                 DialogHost = dialogHostContainer,
                 Padding = new Thickness(8, 4, 8, 8),
@@ -116,9 +119,9 @@ namespace LiveCaptionsTranslator
         {
             SaveFileDialog saveFileDialog = new SaveFileDialog
             {
-                Filter = "CSV (*.csv)|*.csv|All file (*.*)|*.*",
+                Filter = R("H24", "CSV (*.csv)|*.csv|All file (*.*)|*.*"),
                 DefaultExt = ".csv",
-                FileName = $"exported_{DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}.csv",
+                FileName = $"exported_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv",
                 InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
             };
 
@@ -127,11 +130,11 @@ namespace LiveCaptionsTranslator
                 try
                 {
                     await SQLiteHistoryLogger.ExportToCSV(saveFileDialog.FileName);
-                    SnackbarHost.Show("Saved Success.", $"File saved to: {saveFileDialog.FileName}", SnackbarType.Success);
+                    SnackbarHost.Show(R("H25", "Saved Success"), string.Format(CultureInfo.CurrentCulture, R("H26", "File saved to: {0}"), saveFileDialog.FileName));
                 }
                 catch (Exception ex)
                 {
-                    SnackbarHost.Show("Save Failed.", $"File saved faild:{ex.Message}", SnackbarType.Error);
+                    SnackbarHost.Show(R("H27", "Save Failed"), string.Format(CultureInfo.CurrentCulture, R("H28", "File saved failed: {0}"), ex.Message), "error");
                 }
             }
         }
@@ -140,13 +143,12 @@ namespace LiveCaptionsTranslator
         {
             string searchText = (sender as AutoSuggestBox)?.Text ?? "";
 
-            // Clear search by Ctrl+A and Delete and Enter
             if (string.IsNullOrEmpty(searchText))
             {
                 SearchText = string.Empty;
                 currentPage = searchPage;
             }
-            else // Submit search
+            else 
             {
                 if (string.IsNullOrEmpty(SearchText))
                 {
@@ -160,7 +162,6 @@ namespace LiveCaptionsTranslator
 
         private async void HistorySearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
         {
-            // Press X to clear search box
             if (args.Reason == AutoSuggestionBoxTextChangeReason.ProgrammaticChange)
             {
                 if (!string.IsNullOrEmpty(SearchText))

--- a/src/pages/InfoPage.xaml
+++ b/src/pages/InfoPage.xaml
@@ -12,34 +12,35 @@
     <Grid Margin="10">
         <StackPanel>
             <TextBlock TextAlignment="Left" TextWrapping="Wrap">
-                <Run Text="We welcome any form of contribution! You can provide suggestions or report bugs via GitHub issues, or contribute code directly by submitting Pull Requests." />
-                <Run Text="&#x0A;If this program is helpful to you, please consider giving us a star ✨!" />
+                <Run Text="{DynamicResource I0}" />
+                <Run Text="&#x0A;" />
+                <Run Text="{DynamicResource I1}" />
             </TextBlock>
             <Separator Margin="0,5,0,5" />
             <TextBlock Margin="0,0,0,3">
-                <Run FontWeight="SemiBold" Text="Repository:" />
+                <Run FontWeight="SemiBold" Text="{DynamicResource I2}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn/LiveCaptions-Translator" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run Text="https://github.com/SakiRinn/LiveCaptions-Translator" />
                 </Hyperlink>
             </TextBlock>
             <TextBlock Margin="0,0,0,3">
-                <Run FontWeight="SemiBold" Text="Wiki:" />
+                <Run FontWeight="SemiBold" Text="{DynamicResource I3}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn/LiveCaptions-Translator/wiki" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run x:Name="Wiki" Text="https://github.com/SakiRinn/LiveCaptions-Translator/wiki" />
                 </Hyperlink>
             </TextBlock>
             <TextBlock Margin="0,0,0,3">
-                <Run FontWeight="SemiBold" Text="Maintainer:" />
+                <Run FontWeight="SemiBold" Text="{DynamicResource I4}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run Text="@SakiRinn" />
                 </Hyperlink>
-                <Run Text="(Author) and" />
+                <Run Text="{DynamicResource I5}" />
                 <Hyperlink NavigateUri="https://github.com/A-nony-mous" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run Text="@A-nony-mous" />
                 </Hyperlink>
             </TextBlock>
             <TextBlock>
-                <Run FontWeight="SemiBold" Text="Version:" />
+                <Run FontWeight="SemiBold" Text="{DynamicResource I6}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn/LiveCaptions-Translator/releases" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run x:Name="Version" Text="1.1.1.1" />
                 </Hyperlink>

--- a/src/pages/InfoPage.xaml
+++ b/src/pages/InfoPage.xaml
@@ -12,35 +12,35 @@
     <Grid Margin="10">
         <StackPanel>
             <TextBlock TextAlignment="Left" TextWrapping="Wrap">
-                <Run Text="{DynamicResource I0}" />
+                <Run Text="{DynamicResource InfoPage_Contrib_Message}" />
                 <Run Text="&#x0A;" />
-                <Run Text="{DynamicResource I1}" />
+                <Run Text="{DynamicResource InfoPage_Contrib_StarHint}" />
             </TextBlock>
             <Separator Margin="0,5,0,5" />
             <TextBlock Margin="0,0,0,3">
-                <Run FontWeight="SemiBold" Text="{DynamicResource I2}" />
+                <Run FontWeight="SemiBold" Text="{DynamicResource InfoPage_Label_Repo}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn/LiveCaptions-Translator" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run Text="https://github.com/SakiRinn/LiveCaptions-Translator" />
                 </Hyperlink>
             </TextBlock>
             <TextBlock Margin="0,0,0,3">
-                <Run FontWeight="SemiBold" Text="{DynamicResource I3}" />
+                <Run FontWeight="SemiBold" Text="{DynamicResource InfoPage_Label_Wiki}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn/LiveCaptions-Translator/wiki" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run x:Name="Wiki" Text="https://github.com/SakiRinn/LiveCaptions-Translator/wiki" />
                 </Hyperlink>
             </TextBlock>
             <TextBlock Margin="0,0,0,3">
-                <Run FontWeight="SemiBold" Text="{DynamicResource I4}" />
+                <Run FontWeight="SemiBold" Text="{DynamicResource InfoPage_Label_Maintainer}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run Text="@SakiRinn" />
                 </Hyperlink>
-                <Run Text="{DynamicResource I5}" />
+                <Run Text="{DynamicResource InfoPage_Label_And}" />
                 <Hyperlink NavigateUri="https://github.com/A-nony-mous" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run Text="@A-nony-mous" />
                 </Hyperlink>
             </TextBlock>
             <TextBlock>
-                <Run FontWeight="SemiBold" Text="{DynamicResource I6}" />
+                <Run FontWeight="SemiBold" Text="{DynamicResource InfoPage_Label_Version}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn/LiveCaptions-Translator/releases" RequestNavigate="Hyperlink_RequestNavigate">
                     <Run x:Name="Version" Text="1.1.1.1" />
                 </Hyperlink>

--- a/src/pages/SettingPage.xaml
+++ b/src/pages/SettingPage.xaml
@@ -4,13 +4,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:LiveCaptionsTranslator"
+    xmlns:models="clr-namespace:LiveCaptionsTranslator.models"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="SettingPage"
-    JournalEntry.KeepAlive="False"
+    JournalEntry.KeepAlive="True"
     mc:Ignorable="d">
 
-    <Grid Margin="15">
+    <Grid Margin="15" Cursor="">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
@@ -19,6 +20,7 @@
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
+        <!-- Column 0: LiveCaptions + API Interval -->
         <StackPanel Grid.Column="0" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
@@ -37,17 +39,16 @@
                         <Border Grid.Row="1" Grid.Column="1" Margin="1,1,0,0" Background="#FF1E9BFA" />
                     </Grid>
 
-                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S0}" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_LiveCaptionsName}" />
                     <ui:Flyout x:Name="LiveCaptionsInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
                             <Run Text="{DynamicResource S1}" />
-                            <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource S2}" />
-                            <Run Text="{DynamicResource S3}" />
-                            <Run FontWeight="Bold" Text="&#x0A;&#x0A;" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S4}" />
-                            <Run Text="{DynamicResource S5}" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S6}" />
-                            <Run Text="{DynamicResource S7}" />
+                            <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource SettingPage_LiveCaptionsInfo_SourceLanguage}" />
+                            <Run Text="{DynamicResource SettingPage_LiveCaptionsInfo_InLiveCaptions}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_LiveCaptionsInfo_NoteLabel}" />
+                            <Run Text="{DynamicResource SettingPage_LiveCaptionsInfo_PleaseClick}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_LiveCaptionsInfo_HideQuoted}" />
+                            <Run Text="{DynamicResource SettingPage_LiveCaptionsInfo_HideInsteadOfClose}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -69,20 +70,20 @@
                     Height="30"
                     Padding="11,4,11,4"
                     Click="LiveCaptionsButton_click">
-                    <TextBlock x:Name="ButtonText" Text="{DynamicResource S8}" />
+                    <TextBlock x:Name="ButtonText" Text="{DynamicResource SettingPage_LiveCaptionsToggle_Show}" />
                 </ui:Button>
             </StackPanel>
 
             <StackPanel Margin="15,10,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S9}" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_ApiInterval_Label}" />
                     <ui:Flyout x:Name="FrequencyInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
-                            <Run Text="{DynamicResource S10}" />
+                            <Run Text="{DynamicResource SettingPage_ApiInterval_Tooltip_Desc}" />
                             <Run Text="&#x0A;" />
-                            <Run Text="{DynamicResource S11}" />
-                            <Run FontWeight="SemiBold" Text="{DynamicResource S12}" />
-                            <Run Text="{DynamicResource S13}" />
+                            <Run Text="{DynamicResource SettingPage_ApiInterval_Tooltip_Line1}" />
+                            <Run FontWeight="SemiBold" Text="{DynamicResource SettingPage_ApiInterval_Tooltip_IntervalName}" />
+                            <Run Text="{DynamicResource SettingPage_ApiInterval_Tooltip_Suffix}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -110,14 +111,15 @@
             </StackPanel>
         </StackPanel>
 
+        <!-- Column 1: Translate API + Target Language -->
         <StackPanel Grid.Column="1" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S14}" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_TranslateApi_Label}" />
                     <ui:Flyout x:Name="TranslateAPIInfoFlyout">
                         <TextBlock
                             Width="300"
-                            Text="{DynamicResource S15}"
+                            Text="{DynamicResource SettingPage_TranslateApi_Tooltip}"
                             TextWrapping="Wrap" />
                     </ui:Flyout>
                     <Button
@@ -148,18 +150,18 @@
                     <TextBlock
                         Margin="2.5,0,0,5"
                         VerticalAlignment="Center"
-                        Text="{DynamicResource S16}" />
+                        Text="{DynamicResource SettingPage_TargetLanguage_Label}" />
                     <ui:Flyout x:Name="TargetLangInfoFlyout">
                         <TextBlock Width="350" TextWrapping="Wrap">
-                            <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource S17}" />
+                            <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource SettingPage_TargetLanguage_Tooltip_Title}" />
                             <Run Text="&#x0A;" />
-                            <Run Text="{DynamicResource S18}" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S19}" />
+                            <Run Text="{DynamicResource SettingPage_TargetLanguage_Tooltip_Line1}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_TargetLanguage_Tooltip_Bcp47}" />
                             <Run FontWeight="Bold" Text="&#x0A;&#x0A;" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S4}" />
-                            <Run Text="{DynamicResource S20}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_LiveCaptionsInfo_NoteLabel}" />
+                            <Run Text="{DynamicResource SettingPage_TargetLanguage_Tooltip_Note1}" />
                             <Run Text="&#x0A;" />
-                            <Run Text="{DynamicResource S21}" />
+                            <Run Text="{DynamicResource SettingPage_TargetLanguage_Tooltip_Note2}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -187,10 +189,11 @@
             </StackPanel>
         </StackPanel>
 
+        <!-- Columns 2-4 unchanged -->
         <StackPanel Grid.Column="2" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S22}" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_ApiSetting_Label}" />
                 </StackPanel>
                 <ui:Button
                     x:Name="APISettingButton"
@@ -198,42 +201,42 @@
                     Height="30"
                     Padding="11,4,11,4"
                     Click="APISettingButton_click">
-                    <TextBlock Text="{DynamicResource S23}" />
+                    <TextBlock Text="{DynamicResource SettingPage_ApiSetting_Open}" />
                 </ui:Button>
             </StackPanel>
             <StackPanel Margin="15,10,0,0" Orientation="Vertical">
-                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S24}" />
+                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_ShowLatency_Label}" />
                 <ui:ToggleSwitch
                     Width="100"
                     Height="30"
                     Padding="10,4,10,7"
                     IsChecked="{Binding MainWindow.LatencyShow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    OffContent="{DynamicResource S25}"
-                    OnContent="{DynamicResource S26}" />
+                    OffContent="{DynamicResource Common_Off}"
+                    OnContent="{DynamicResource Common_On}" />
             </StackPanel>
         </StackPanel>
 
         <StackPanel Grid.Column="3" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S27}" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_Contexts_Label}" />
                     <ui:Flyout x:Name="CaptionLogMaxInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
-                            <Run FontWeight="Bold" Text="{DynamicResource S28}" />
-                            <Run Text="{DynamicResource S29}" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S30}" />
-                            <Run Text="{DynamicResource S31}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_Contexts_Tooltip_Title}" />
+                            <Run Text="{DynamicResource SettingPage_Contexts_Tooltip_Line1}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_Contexts_Tooltip_ContextAware}" />
+                            <Run Text="{DynamicResource SettingPage_Contexts_Tooltip_Line2}" />
                             <Run FontWeight="Bold" Text="&#x0A;" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S32}" />
-                            <Run Text="{DynamicResource S33}" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S34}" />
-                            <Run Text="{DynamicResource S35}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_Contexts_Tooltip_OverlaySentences}" />
+                            <Run Text="{DynamicResource SettingPage_Contexts_Tooltip_Line3}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_Contexts_Tooltip_LogCards}" />
+                            <Run Text="{DynamicResource SettingPage_Contexts_Tooltip_Line4}" />
                             <Run FontWeight="Bold" Text="&#x0A;&#x0A;" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S4}" />
-                            <Run Text="{DynamicResource S36}" />
-                            <Run FontWeight="Bold" Text="{DynamicResource S37}" />
-                            <Run Text="{DynamicResource S38}" />
-                            <Run Text="{DynamicResource S39}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_LiveCaptionsInfo_NoteLabel}" />
+                            <Run Text="{DynamicResource SettingPage_Contexts_Tooltip_Line5}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource SettingPage_Contexts_Tooltip_Line6}" />
+                            <Run Text="{DynamicResource SettingPage_Contexts_Tooltip_DisplaySentences}" />
+                            <Run Text="{DynamicResource SettingPage_Contexts_Tooltip_Line7}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -266,7 +269,7 @@
             </StackPanel>
 
             <StackPanel Margin="15,10,0,0" Orientation="Vertical">
-                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S40}" />
+                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_DisplaySentences_Label}" />
                 <ui:NumberBox
                     Width="135"
                     Height="30"
@@ -286,15 +289,15 @@
 
         <StackPanel Grid.Column="4" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
-                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S30}" />
+                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_Contexts_Tooltip_ContextAware}" />
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                     <ui:ToggleSwitch
                         Width="90"
                         Height="30"
                         Padding="10,4,10,7"
                         IsChecked="{Binding ContextAware, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        OffContent="{DynamicResource S25}"
-                        OnContent="{DynamicResource S26}" />
+                        OffContent="{DynamicResource Common_Off}"
+                        OnContent="{DynamicResource Common_On}" />
                     <Button
                         x:Name="ContextAwareInfo"
                         Width="15"
@@ -309,9 +312,9 @@
                     </Button>
                     <ui:Flyout x:Name="ContextAwareInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
-                            <Run Text="{DynamicResource S41}" />
+                            <Run Text="{DynamicResource SettingPage_ContextAware_Tooltip_Line1}" />
                             <Run Text="&#x0A;" />
-                            <Run Text="{DynamicResource S42}" />
+                            <Run Text="{DynamicResource SettingPage_ContextAware_Tooltip_Line2}" />
                         </TextBlock>
                     </ui:Flyout>
                 </StackPanel>
@@ -320,12 +323,12 @@
             <StackPanel Margin="15,10,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                     <ui:SymbolIcon Symbol="Globe20" Margin="0,0,6,0" />
-                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S43}" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource SettingPage_UiLanguage_Label}" />
                     <ui:Flyout x:Name="UILanguageInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
-                            <Run Text="{DynamicResource S44}" />
+                            <Run Text="{DynamicResource SettingPage_UiLanguage_Tooltip}" />
                             <Run Text="&#x0A;&#x0A;" />
-                            <Run Text="Changes take effect immediately and are saved automatically." />
+                            <Run Text="{DynamicResource SettingPage_UiLanguage_Tooltip_ImmediateSave}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -341,29 +344,16 @@
                         <ui:SymbolIcon Symbol="Info16" />
                     </Button>
                 </StackPanel>
-                <ComboBox x:Name="UILanguageBox" Width="150" Height="30" Padding="10,4,10,7" FontSize="13.3" SelectionChanged="UILanguageBox_SelectionChanged">
-                    <ComboBoxItem Content="English" />
-                    <ComboBoxItem Content="&#x7B80;&#x4F53;&#x4E2D;&#x6587;" />
-                    <ComboBoxItem Content="&#x627;&#x644;&#x639;&#x631;&#x628;&#x64A;&#x629;" />
-                    <ComboBoxItem Content="&#x9AC;&#x9BE;&#x982;&#x9B2;&#x9BE;" />
-                    <ComboBoxItem Content="&#x10C;e&#x161;tina" />
-                    <ComboBoxItem Content="Deutsch" />
-                    <ComboBoxItem Content="Espa&#xF1;ol (M&#xE9;xico)" />
-                    <ComboBoxItem Content="Fran&#xE7;ais" />
-                    <ComboBoxItem Content="Italiano" />
-                    <ComboBoxItem Content="&#x65E5;&#x672C;&#x8A9E;" />
-                    <ComboBoxItem Content="&#xD55C;&#xAD6D;&#xC5B4;" />
-                    <ComboBoxItem Content="Lietuvi&#x173;" />
-                    <ComboBoxItem Content="Nederlands" />
-                    <ComboBoxItem Content="Polski" />
-                    <ComboBoxItem Content="Portugu&#xEA;s (Brasil)" />
-                    <ComboBoxItem Content="Portugu&#xEA;s (Portugal)" />
-                    <ComboBoxItem Content="&#x420;&#x443;&#x441;&#x441;&#x43A;&#x438;&#x439;" />
-                    <ComboBoxItem Content="Svenska" />
-                    <ComboBoxItem Content="T&#xFC;rk&#xE7;e" />
-                    <ComboBoxItem Content="Ti&#x1EBF;ng Vi&#x1EC7;t" />
-                    <ComboBoxItem Content="&#x7E41;&#x9AD4;&#x4E2D;&#x6587; (&#x53F0;&#x7063;)" />
-                </ComboBox>
+                <ComboBox
+                    x:Name="UILanguageBox"
+                    Width="150"
+                    Height="30"
+                    Padding="10,4,10,7"
+                    FontSize="13.3"
+                    ItemsSource="{x:Static models:LanguageCatalog.SupportedUiLanguages}"
+                    DisplayMemberPath="DisplayName"
+                    SelectedValuePath="CultureCode"
+                    SelectionChanged="UILanguageBox_SelectionChanged" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/src/pages/SettingPage.xaml
+++ b/src/pages/SettingPage.xaml
@@ -22,16 +22,32 @@
         <StackPanel Grid.Column="0" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="LiveCaptions" />
+                    <Grid Width="14" Height="14" Margin="0,0,6,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <Border Grid.Row="0" Grid.Column="0" Margin="0,0,1,1" Background="#FF1E9BFA" />
+                        <Border Grid.Row="0" Grid.Column="1" Margin="1,0,0,1" Background="#FF1E9BFA" />
+                        <Border Grid.Row="1" Grid.Column="0" Margin="0,1,1,0" Background="#FF1E9BFA" />
+                        <Border Grid.Row="1" Grid.Column="1" Margin="1,1,0,0" Background="#FF1E9BFA" />
+                    </Grid>
+
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S0}" />
                     <ui:Flyout x:Name="LiveCaptionsInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
-                            <Run Text="After Windows 11 version 24H2, you can only change the" />
-                            <Run FontWeight="DemiBold" TextDecorations="Underline" Text="Source Language" />
-                            <Run Text="in LiveCaptions." />
-                            <Run FontWeight="Bold" Text="&#x0A;&#x0A;Note:" />
-                            <Run Text="Please click" />
-                            <Run FontWeight="Bold" Text="&quot;Hide&quot;" />
-                            <Run Text="to hide LiveCaptions instead of closing it directly." />
+                            <Run Text="{DynamicResource S1}" />
+                            <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource S2}" />
+                            <Run Text="{DynamicResource S3}" />
+                            <Run FontWeight="Bold" Text="&#x0A;&#x0A;" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S4}" />
+                            <Run Text="{DynamicResource S5}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S6}" />
+                            <Run Text="{DynamicResource S7}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -53,19 +69,20 @@
                     Height="30"
                     Padding="11,4,11,4"
                     Click="LiveCaptionsButton_click">
-                    <TextBlock x:Name="ButtonText" Text="Show" />
+                    <TextBlock x:Name="ButtonText" Text="{DynamicResource S8}" />
                 </ui:Button>
             </StackPanel>
 
             <StackPanel Margin="15,10,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="API Interval" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S9}" />
                     <ui:Flyout x:Name="FrequencyInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
-                            <Run Text="Determines the frequency of translate API calls. The smaller it is, the more frequent API calls." />
-                            <Run Text="&#x0A;The translate API is called once after the caption changes" />
-                            <Run FontWeight="SemiBold" Text="[API Interval]" />
-                            <Run Text="times." />
+                            <Run Text="{DynamicResource S10}" />
+                            <Run Text="&#x0A;" />
+                            <Run Text="{DynamicResource S11}" />
+                            <Run FontWeight="SemiBold" Text="{DynamicResource S12}" />
+                            <Run Text="{DynamicResource S13}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -96,11 +113,11 @@
         <StackPanel Grid.Column="1" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="Translate API" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S14}" />
                     <ui:Flyout x:Name="TranslateAPIInfoFlyout">
                         <TextBlock
                             Width="300"
-                            Text="Except for Google and Google2, all other APIs require configuring before they can be used."
+                            Text="{DynamicResource S15}"
                             TextWrapping="Wrap" />
                     </ui:Flyout>
                     <Button
@@ -131,15 +148,18 @@
                     <TextBlock
                         Margin="2.5,0,0,5"
                         VerticalAlignment="Center"
-                        Text="Target Language" />
+                        Text="{DynamicResource S16}" />
                     <ui:Flyout x:Name="TargetLangInfoFlyout">
                         <TextBlock Width="350" TextWrapping="Wrap">
-                            <Run FontWeight="DemiBold" TextDecorations="Underline" Text="&quot;There isn’t the target language I expect!&quot;" />
-                            <Run Text="&#x0A;You can directly edit the content of this combobox to customize the language, and it is recommended to follow the" />
-                            <Run FontWeight="Bold" Text="BCP 47 language tag." />
-                            <Run FontWeight="Bold" Text="&#x0A;&#x0A;Note:" />
-                            <Run Text="Some of APIs (such as DeepL) needs another way to define target language, see their official docs for more details." />
-                            <Run Text="&#x0A;No need to consider this for included target languages, since we've built in tag mappings. But if your expected language isn't in the list, keep this in mind." />
+                            <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource S17}" />
+                            <Run Text="&#x0A;" />
+                            <Run Text="{DynamicResource S18}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S19}" />
+                            <Run FontWeight="Bold" Text="&#x0A;&#x0A;" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S4}" />
+                            <Run Text="{DynamicResource S20}" />
+                            <Run Text="&#x0A;" />
+                            <Run Text="{DynamicResource S21}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -170,7 +190,7 @@
         <StackPanel Grid.Column="2" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="API Setting" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S22}" />
                 </StackPanel>
                 <ui:Button
                     x:Name="APISettingButton"
@@ -178,39 +198,42 @@
                     Height="30"
                     Padding="11,4,11,4"
                     Click="APISettingButton_click">
-                    <TextBlock Text="Open" />
+                    <TextBlock Text="{DynamicResource S23}" />
                 </ui:Button>
             </StackPanel>
             <StackPanel Margin="15,10,0,0" Orientation="Vertical">
-                <TextBlock Margin="2.5,0,0,5" Text="Show Latency" />
+                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S24}" />
                 <ui:ToggleSwitch
                     Width="100"
                     Height="30"
                     Padding="10,4,10,7"
                     IsChecked="{Binding MainWindow.LatencyShow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    OffContent="Off"
-                    OnContent="On" />
+                    OffContent="{DynamicResource S25}"
+                    OnContent="{DynamicResource S26}" />
             </StackPanel>
         </StackPanel>
 
         <StackPanel Grid.Column="3" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="2.5,0,0,5" Text="Contexts" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S27}" />
                     <ui:Flyout x:Name="CaptionLogMaxInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
-                            <Run FontWeight="Bold" Text="Contexts:" />
-                            <Run Text="Determines the number of context sentences when" />
-                            <Run FontWeight="Bold" Text="Context Aware" />
-                            <Run Text="is enabled." />
-                            <Run FontWeight="Bold" Text="&#x0A;Overlay Sentences:" />
-                            <Run Text="Determines the number of displayed cards when" />
-                            <Run FontWeight="Bold" Text="Log Cards" />
-                            <Run Text="is enabled, as well as the max number of sentences displayed in the Overlay Window." />
-                            <Run FontWeight="Bold" Text="&#x0A;&#x0A;Note:" />
-                            <Run Text="Contexts must be" />
-                            <Run FontWeight="Bold" Text="greater than or equal" />
-                            <Run Text="Display Sentences. If not met, the program will automatically adjust them." />
+                            <Run FontWeight="Bold" Text="{DynamicResource S28}" />
+                            <Run Text="{DynamicResource S29}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S30}" />
+                            <Run Text="{DynamicResource S31}" />
+                            <Run FontWeight="Bold" Text="&#x0A;" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S32}" />
+                            <Run Text="{DynamicResource S33}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S34}" />
+                            <Run Text="{DynamicResource S35}" />
+                            <Run FontWeight="Bold" Text="&#x0A;&#x0A;" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S4}" />
+                            <Run Text="{DynamicResource S36}" />
+                            <Run FontWeight="Bold" Text="{DynamicResource S37}" />
+                            <Run Text="{DynamicResource S38}" />
+                            <Run Text="{DynamicResource S39}" />
                         </TextBlock>
                     </ui:Flyout>
                     <Button
@@ -243,7 +266,7 @@
             </StackPanel>
 
             <StackPanel Margin="15,10,0,0" Orientation="Vertical">
-                <TextBlock Margin="2.5,0,0,5" Text="Display Sentences" />
+                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S40}" />
                 <ui:NumberBox
                     Width="135"
                     Height="30"
@@ -263,15 +286,15 @@
 
         <StackPanel Grid.Column="4" Orientation="Vertical">
             <StackPanel Margin="15,0,0,0" Orientation="Vertical">
-                <TextBlock Margin="2.5,0,0,5" Text="Context Aware" />
+                <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S30}" />
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                     <ui:ToggleSwitch
                         Width="90"
                         Height="30"
                         Padding="10,4,10,7"
                         IsChecked="{Binding ContextAware, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        OffContent="Off"
-                        OnContent="On" />
+                        OffContent="{DynamicResource S25}"
+                        OnContent="{DynamicResource S26}" />
                     <Button
                         x:Name="ContextAwareInfo"
                         Width="15"
@@ -286,11 +309,61 @@
                     </Button>
                     <ui:Flyout x:Name="ContextAwareInfoFlyout">
                         <TextBlock Width="300" TextWrapping="Wrap">
-                            <Run Text="Translate in context." />
-                            <Run Text="&#x0A;It can improve translation accuracy, but will consume more tokens." />
+                            <Run Text="{DynamicResource S41}" />
+                            <Run Text="&#x0A;" />
+                            <Run Text="{DynamicResource S42}" />
                         </TextBlock>
                     </ui:Flyout>
                 </StackPanel>
+            </StackPanel>
+
+            <StackPanel Margin="15,10,0,0" Orientation="Vertical">
+                <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                    <ui:SymbolIcon Symbol="Globe20" Margin="0,0,6,0" />
+                    <TextBlock Margin="2.5,0,0,5" Text="{DynamicResource S43}" />
+                    <ui:Flyout x:Name="UILanguageInfoFlyout">
+                        <TextBlock Width="300" TextWrapping="Wrap">
+                            <Run Text="{DynamicResource S44}" />
+                            <Run Text="&#x0A;&#x0A;" />
+                            <Run Text="Changes take effect immediately and are saved automatically." />
+                        </TextBlock>
+                    </ui:Flyout>
+                    <Button
+                        x:Name="UILanguageInfo"
+                        Width="15"
+                        Height="15"
+                        Margin="-5,-3,0,0"
+                        Padding="0"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        MouseEnter="UILanguageInfo_MouseEnter"
+                        MouseLeave="UILanguageInfo_MouseLeave">
+                        <ui:SymbolIcon Symbol="Info16" />
+                    </Button>
+                </StackPanel>
+                <ComboBox x:Name="UILanguageBox" Width="150" Height="30" Padding="10,4,10,7" FontSize="13.3" SelectionChanged="UILanguageBox_SelectionChanged">
+                    <ComboBoxItem Content="English" />
+                    <ComboBoxItem Content="&#x7B80;&#x4F53;&#x4E2D;&#x6587;" />
+                    <ComboBoxItem Content="&#x627;&#x644;&#x639;&#x631;&#x628;&#x64A;&#x629;" />
+                    <ComboBoxItem Content="&#x9AC;&#x9BE;&#x982;&#x9B2;&#x9BE;" />
+                    <ComboBoxItem Content="&#x10C;e&#x161;tina" />
+                    <ComboBoxItem Content="Deutsch" />
+                    <ComboBoxItem Content="Espa&#xF1;ol (M&#xE9;xico)" />
+                    <ComboBoxItem Content="Fran&#xE7;ais" />
+                    <ComboBoxItem Content="Italiano" />
+                    <ComboBoxItem Content="&#x65E5;&#x672C;&#x8A9E;" />
+                    <ComboBoxItem Content="&#xD55C;&#xAD6D;&#xC5B4;" />
+                    <ComboBoxItem Content="Lietuvi&#x173;" />
+                    <ComboBoxItem Content="Nederlands" />
+                    <ComboBoxItem Content="Polski" />
+                    <ComboBoxItem Content="Portugu&#xEA;s (Brasil)" />
+                    <ComboBoxItem Content="Portugu&#xEA;s (Portugal)" />
+                    <ComboBoxItem Content="&#x420;&#x443;&#x441;&#x441;&#x43A;&#x438;&#x439;" />
+                    <ComboBoxItem Content="Svenska" />
+                    <ComboBoxItem Content="T&#xFC;rk&#xE7;e" />
+                    <ComboBoxItem Content="Ti&#x1EBF;ng Vi&#x1EC7;t" />
+                    <ComboBoxItem Content="&#x7E41;&#x9AD4;&#x4E2D;&#x6587; (&#x53F0;&#x7063;)" />
+                </ComboBox>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/src/pages/SettingPage.xaml.cs
+++ b/src/pages/SettingPage.xaml.cs
@@ -1,9 +1,14 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Markup;
 using Wpf.Ui.Appearance;
 
+using LiveCaptionsTranslator.apis;
 using LiveCaptionsTranslator.models;
 using LiveCaptionsTranslator.utils;
 using Wpf.Ui.Controls;
@@ -13,23 +18,81 @@ namespace LiveCaptionsTranslator
     public partial class SettingPage : Page
     {
         private static SettingWindow? SettingWindow;
+        private bool _suppressUiLanguageSelectionChanged;
+
+        // Cache non-null references to avoid repeated null-dereference warnings.
+        private readonly Setting _setting;
+        private readonly Caption _caption;
 
         public SettingPage()
         {
             InitializeComponent();
             ApplicationThemeManager.ApplySystemTheme();
-            DataContext = Translator.Setting;
+
+            // Ensure we always have usable instances for bindings and event handlers.
+            _setting = Translator.Setting ?? Setting.Load();
+            _caption = Translator.Caption ?? Caption.GetInstance();
+
+            DataContext = _setting;
 
             Loaded += (s, e) =>
             {
-                (App.Current.MainWindow as MainWindow)?.AutoHeightAdjust(maxHeight: (int)App.Current.MainWindow.MinHeight);
+                var mw = App.Current.MainWindow as MainWindow;
+                if (mw is not null)
+                    mw.AutoHeightAdjust(maxHeight: (int)mw.MinHeight);
+
                 CheckForFirstUse();
+
+                InitializeUILanguageSelection();
             };
 
-            TranslateAPIBox.ItemsSource = Translator.Setting?.Configs.Keys;
+            // Keep selection in sync when user returns to this page.
+            IsVisibleChanged += (_, __) => SyncUILanguageSelectionFromSetting();
+
+            TranslateAPIBox.ItemsSource = _setting.Configs.Keys;
             TranslateAPIBox.SelectedIndex = 0;
 
             LoadAPISetting();
+        }
+
+        public void SyncUILanguageSelectionFromSetting()
+        {
+            if (!IsLoaded)
+                return;
+
+            _suppressUiLanguageSelectionChanged = true;
+            try
+            {
+                var current = _setting.UiLanguageFileName;
+                UILanguageBox.SelectedIndex = current?.ToLowerInvariant() switch
+                {
+                    "zh-cn.xaml" => 1,
+                    "ar.xaml" => 2,
+                    "bn.xaml" => 3,
+                    "cs-cz.xaml" => 4,
+                    "de-de.xaml" => 5,
+                    "es-mx.xaml" => 6,
+                    "fr-fr.xaml" => 7,
+                    "it-it.xaml" => 8,
+                    "ja-jp.xaml" => 9,
+                    "ko-kr.xaml" => 10,
+                    "lt-lt.xaml" => 11,
+                    "nl-nl.xaml" => 12,
+                    "pl-pl.xaml" => 13,
+                    "pt-br.xaml" => 14,
+                    "pt-pt.xaml" => 15,
+                    "ru-ru.xaml" => 16,
+                    "sv-se.xaml" => 17,
+                    "tr-tr.xaml" => 18,
+                    "vi-vn.xaml" => 19,
+                    "zh-tw.xaml" => 20,
+                    _ => 0
+                };
+            }
+            finally
+            {
+                _suppressUiLanguageSelectionChanged = false;
+            }
         }
 
         private void LiveCaptionsButton_click(object sender, RoutedEventArgs e)
@@ -37,19 +100,16 @@ namespace LiveCaptionsTranslator
             if (Translator.Window == null)
                 return;
 
-            var button = sender as Wpf.Ui.Controls.Button;
-            var text = ButtonText.Text;
-
             bool isHide = Translator.Window.Current.BoundingRectangle == Rect.Empty;
             if (isHide)
             {
                 LiveCaptionsHandler.RestoreLiveCaptions(Translator.Window);
-                ButtonText.Text = "Hide";
+                ButtonText.Text = TryFindResource("S45") as string ?? "Hide";
             }
             else
             {
                 LiveCaptionsHandler.HideLiveCaptions(Translator.Window);
-                ButtonText.Text = "Show";
+                ButtonText.Text = TryFindResource("S46") as string ?? "Show";
             }
         }
 
@@ -61,12 +121,12 @@ namespace LiveCaptionsTranslator
         private void TargetLangBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (TargetLangBox.SelectedItem != null)
-                Translator.Setting.TargetLanguage = TargetLangBox.SelectedItem.ToString();
+                _setting.TargetLanguage = TargetLangBox.SelectedItem.ToString() ?? _setting.TargetLanguage;
         }
 
         private void TargetLangBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            Translator.Setting.TargetLanguage = TargetLangBox.Text;
+            _setting.TargetLanguage = TargetLangBox.Text;
         }
 
         private void APISettingButton_click(object sender, RoutedEventArgs e)
@@ -83,16 +143,17 @@ namespace LiveCaptionsTranslator
 
         private void Contexts_ValueChanged(object sender, NumberBoxValueChangedEventArgs args)
         {
-            if (Translator.Setting.DisplaySentences > Translator.Setting.NumContexts)
-                Translator.Setting.DisplaySentences = Translator.Setting.NumContexts;
+            if (_setting.DisplaySentences > _setting.NumContexts)
+                _setting.DisplaySentences = _setting.NumContexts;
         }
 
         private void DisplaySentences_ValueChanged(object sender, NumberBoxValueChangedEventArgs args)
         {
-            if (Translator.Setting.DisplaySentences > Translator.Setting.NumContexts)
-                Translator.Setting.NumContexts = Translator.Setting.DisplaySentences;
-            Translator.Caption.OnPropertyChanged("DisplayLogCards");
-            Translator.Caption.OnPropertyChanged("OverlayPreviousTranslation");
+            if (_setting.DisplaySentences > _setting.NumContexts)
+                _setting.NumContexts = _setting.DisplaySentences;
+
+            _caption.OnPropertyChanged("DisplayLogCards");
+            _caption.OnPropertyChanged("OverlayPreviousTranslation");
         }
 
         private void LiveCaptionsInfo_MouseEnter(object sender, MouseEventArgs e)
@@ -155,15 +216,30 @@ namespace LiveCaptionsTranslator
             ContextAwareInfoFlyout.Hide();
         }
 
+        private void UILanguageInfo_MouseEnter(object sender, MouseEventArgs e)
+        {
+            UILanguageInfoFlyout.Show();
+        }
+
+        private void UILanguageInfo_MouseLeave(object sender, MouseEventArgs e)
+        {
+            UILanguageInfoFlyout.Hide();
+        }
+
         private void CheckForFirstUse()
         {
             if (Translator.FirstUseFlag)
-                ButtonText.Text = "Hide";
+                ButtonText.Text = TryFindResource("S45") as string ?? "Hide";
         }
 
         public void LoadAPISetting()
         {
-            var configType = Translator.Setting[Translator.Setting.ApiName].GetType();
+            // Guard against unavailable configs.
+            var apiName = _setting.ApiName;
+            if (!_setting.Configs.ContainsKey(apiName))
+                return;
+
+            var configType = _setting[apiName].GetType();
             var languagesProp = configType.GetProperty(
                 "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
 
@@ -171,20 +247,244 @@ namespace LiveCaptionsTranslator
             while (configType != null && languagesProp == null)
             {
                 configType = configType.BaseType;
-                languagesProp = configType.GetProperty(
-                    "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
+                if (configType != null)
+                    languagesProp = configType.GetProperty(
+                        "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
             }
-            if (languagesProp == null)
-                languagesProp = typeof(TranslateAPIConfig).GetProperty(
-                    "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
 
-            var supportedLanguages = (Dictionary<string, string>)languagesProp.GetValue(null);
+            languagesProp ??= typeof(TranslateAPIConfig).GetProperty(
+                "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
+
+            if (languagesProp?.GetValue(null) is not Dictionary<string, string> supportedLanguages)
+                return;
+
             TargetLangBox.ItemsSource = supportedLanguages.Keys;
 
-            string targetLang = Translator.Setting.TargetLanguage;
+            string targetLang = _setting.TargetLanguage;
             if (!supportedLanguages.ContainsKey(targetLang))
-                supportedLanguages[targetLang] = targetLang;    // add custom language to supported languages
+                supportedLanguages[targetLang] = targetLang; // add custom language
+
             TargetLangBox.SelectedItem = targetLang;
+        }
+
+        private void UILanguageBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressUiLanguageSelectionChanged || !IsLoaded)
+                return;
+
+            string fileName = UILanguageBox.SelectedIndex switch
+            {
+                1 => "zh-cn.xaml",
+                2 => "ar.xaml",
+                3 => "bn.xaml",
+                4 => "cs-cz.xaml",
+                5 => "de-de.xaml",
+                6 => "es-mx.xaml",
+                7 => "fr-fr.xaml",
+                8 => "it-it.xaml",
+                9 => "ja-jp.xaml",
+                10 => "ko-kr.xaml",
+                11 => "lt-lt.xaml",
+                12 => "nl-nl.xaml",
+                13 => "pl-pl.xaml",
+                14 => "pt-br.xaml",
+                15 => "pt-pt.xaml",
+                16 => "ru-ru.xaml",
+                17 => "sv-se.xaml",
+                18 => "tr-tr.xaml",
+                19 => "vi-vn.xaml",
+                20 => "zh-tw.xaml",
+                _ => "en-us.xaml"
+            };
+
+            ActivateLocalizationDictionary(fileName);
+            ApplyFlowDirectionForLocalization(fileName);
+
+            _setting.UiLanguageFileName = fileName;
+
+            // Sync other open windows' language dropdowns.
+            foreach (Window w in Application.Current.Windows)
+            {
+                if (w is WelcomeWindow ww)
+                    ww.SyncLanguageSelectionFromSetting();
+            }
+
+            var content = Content;
+            Content = null;
+            Content = content;
+
+            RequestAutoFitWidth();
+        }
+
+        private static void ActivateLocalizationDictionary(string fileName)
+        {
+            var merged = Application.Current.Resources.MergedDictionaries;
+
+            int? index = null;
+            for (int i = 0; i < merged.Count; i++)
+            {
+                var src = merged[i].Source?.ToString();
+                if (src is null)
+                    continue;
+
+                if (src.Contains($"localization/{fileName}", StringComparison.OrdinalIgnoreCase))
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index is null)
+                throw new IOException($"Cannot locate resource 'localization/{fileName}'.");
+
+            var target = merged[index.Value];
+            merged.RemoveAt(index.Value);
+            merged.Add(target);
+        }
+
+        private void InitializeUILanguageSelection()
+        {
+            _suppressUiLanguageSelectionChanged = true;
+            try
+            {
+                var current = _setting.UiLanguageFileName;
+                if (string.IsNullOrWhiteSpace(current))
+                    current = GetActiveLocalizationFileName();
+
+                UILanguageBox.SelectedIndex = current.ToLowerInvariant() switch
+                {
+                    "zh-cn.xaml" => 1,
+                    "ar.xaml" => 2,
+                    "bn.xaml" => 3,
+                    "cs-cz.xaml" => 4,
+                    "de-de.xaml" => 5,
+                    "es-mx.xaml" => 6,
+                    "fr-fr.xaml" => 7,
+                    "it-it.xaml" => 8,
+                    "ja-jp.xaml" => 9,
+                    "ko-kr.xaml" => 10,
+                    "lt-lt.xaml" => 11,
+                    "nl-nl.xaml" => 12,
+                    "pl-pl.xaml" => 13,
+                    "pt-br.xaml" => 14,
+                    "pt-pt.xaml" => 15,
+                    "ru-ru.xaml" => 16,
+                    "sv-se.xaml" => 17,
+                    "tr-tr.xaml" => 18,
+                    "vi-vn.xaml" => 19,
+                    "zh-tw.xaml" => 20,
+                    _ => 0
+                };
+
+                ActivateLocalizationDictionary(current);
+                ApplyFlowDirectionForLocalization(current);
+            }
+            finally
+            {
+                _suppressUiLanguageSelectionChanged = false;
+            }
+        }
+
+        private static string GetActiveLocalizationFileName()
+        {
+            for (int i = Application.Current.Resources.MergedDictionaries.Count - 1; i >= 0; i--)
+            {
+                var src = Application.Current.Resources.MergedDictionaries[i].Source?.ToString();
+                if (src is null)
+                    continue;
+
+                if (src.Contains("localization/zh-cn.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "zh-cn.xaml";
+                if (src.Contains("localization/ar.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "ar.xaml";
+                if (src.Contains("localization/bn.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "bn.xaml";
+
+                if (src.Contains("localization/zh-tw.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "zh-tw.xaml";
+                if (src.Contains("localization/cs-cz.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "cs-cz.xaml";
+                if (src.Contains("localization/de-de.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "de-de.xaml";
+                if (src.Contains("localization/es-mx.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "es-mx.xaml";
+                if (src.Contains("localization/fr-fr.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "fr-fr.xaml";
+                if (src.Contains("localization/it-it.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "it-it.xaml";
+                if (src.Contains("localization/ja-jp.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "ja-jp.xaml";
+                if (src.Contains("localization/ko-kr.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "ko-kr.xaml";
+                if (src.Contains("localization/lt-lt.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "lt-lt.xaml";
+                if (src.Contains("localization/nl-nl.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "nl-nl.xaml";
+                if (src.Contains("localization/pl-pl.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "pl-pl.xaml";
+                if (src.Contains("localization/pt-br.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "pt-br.xaml";
+                if (src.Contains("localization/pt-pt.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "pt-pt.xaml";
+                if (src.Contains("localization/ru-ru.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "ru-ru.xaml";
+                if (src.Contains("localization/sv-se.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "sv-se.xaml";
+                if (src.Contains("localization/tr-tr.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "tr-tr.xaml";
+                if (src.Contains("localization/vi-vn.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "vi-vn.xaml";
+
+                if (src.Contains("localization/en-us.xaml", StringComparison.OrdinalIgnoreCase))
+                    return "en-us.xaml";
+            }
+
+            return "en-us.xaml";
+        }
+
+        private static void ApplyFlowDirectionForLocalization(string fileName)
+        {
+            bool isArabic = string.Equals(fileName, "ar.xaml", StringComparison.OrdinalIgnoreCase);
+
+            if (Application.Current.MainWindow is FrameworkElement fe)
+            {
+                fe.FlowDirection = isArabic ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+                fe.Language = XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
+            }
+
+            // Overlay window stays LTR.
+            if ((Application.Current.MainWindow as MainWindow)?.OverlayWindow is { } overlay)
+            {
+                if (overlay.Content is FrameworkElement overlayContent)
+                {
+                    overlayContent.FlowDirection = FlowDirection.LeftToRight;
+                    overlayContent.Language = XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Re-measure SettingPage content and auto-fit the MainWindow width.
+        /// Intended to be called after localization changes initiated outside this page (e.g., WelcomeWindow).
+        /// </summary>
+        public void RequestAutoFitWidth()
+        {
+            // Auto-size main window width to fit SettingPage content.
+            if (Application.Current.MainWindow is MainWindow mw)
+            {
+                mw.Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    var prev = mw.SizeToContent;
+                    mw.SizeToContent = SizeToContent.Width;
+                    mw.UpdateLayout();
+
+                    const double minW = 860;
+                    const double maxW = 1200;
+                    mw.Width = Math.Max(minW, Math.Min(maxW, mw.ActualWidth));
+
+                    mw.SizeToContent = prev;
+                }), System.Windows.Threading.DispatcherPriority.Loaded);
+            }
         }
     }
 }

--- a/src/pages/SettingPage.xaml.cs
+++ b/src/pages/SettingPage.xaml.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Markup;
 using Wpf.Ui.Appearance;
 
-using LiveCaptionsTranslator.apis;
 using LiveCaptionsTranslator.models;
 using LiveCaptionsTranslator.utils;
 using Wpf.Ui.Controls;
@@ -19,37 +16,30 @@ namespace LiveCaptionsTranslator
     {
         private static SettingWindow? SettingWindow;
         private bool _suppressUiLanguageSelectionChanged;
-
-        // Cache non-null references to avoid repeated null-dereference warnings.
-        private readonly Setting _setting;
-        private readonly Caption _caption;
+        private bool _autoFitWidthDone; // ensure width auto-fit runs once at startup
 
         public SettingPage()
         {
             InitializeComponent();
             ApplicationThemeManager.ApplySystemTheme();
-
-            // Ensure we always have usable instances for bindings and event handlers.
-            _setting = Translator.Setting ?? Setting.Load();
-            _caption = Translator.Caption ?? Caption.GetInstance();
-
-            DataContext = _setting;
+            DataContext = Translator.Setting;
 
             Loaded += (s, e) =>
             {
-                var mw = App.Current.MainWindow as MainWindow;
-                if (mw is not null)
-                    mw.AutoHeightAdjust(maxHeight: (int)mw.MinHeight);
-
+                (App.Current.MainWindow as MainWindow)?.AutoHeightAdjust(maxHeight: (int)App.Current.MainWindow.MinHeight);
                 CheckForFirstUse();
-
                 InitializeUILanguageSelection();
+
+                if (!_autoFitWidthDone)
+                {
+                    _autoFitWidthDone = true;
+                    RequestAutoFitWidth();
+                }
             };
 
-            // Keep selection in sync when user returns to this page.
             IsVisibleChanged += (_, __) => SyncUILanguageSelectionFromSetting();
 
-            TranslateAPIBox.ItemsSource = _setting.Configs.Keys;
+            TranslateAPIBox.ItemsSource = Translator.Setting?.Configs.Keys;
             TranslateAPIBox.SelectedIndex = 0;
 
             LoadAPISetting();
@@ -63,35 +53,78 @@ namespace LiveCaptionsTranslator
             _suppressUiLanguageSelectionChanged = true;
             try
             {
-                var current = _setting.UiLanguageFileName;
-                UILanguageBox.SelectedIndex = current?.ToLowerInvariant() switch
-                {
-                    "zh-cn.xaml" => 1,
-                    "ar.xaml" => 2,
-                    "bn.xaml" => 3,
-                    "cs-cz.xaml" => 4,
-                    "de-de.xaml" => 5,
-                    "es-mx.xaml" => 6,
-                    "fr-fr.xaml" => 7,
-                    "it-it.xaml" => 8,
-                    "ja-jp.xaml" => 9,
-                    "ko-kr.xaml" => 10,
-                    "lt-lt.xaml" => 11,
-                    "nl-nl.xaml" => 12,
-                    "pl-pl.xaml" => 13,
-                    "pt-br.xaml" => 14,
-                    "pt-pt.xaml" => 15,
-                    "ru-ru.xaml" => 16,
-                    "sv-se.xaml" => 17,
-                    "tr-tr.xaml" => 18,
-                    "vi-vn.xaml" => 19,
-                    "zh-tw.xaml" => 20,
-                    _ => 0
-                };
+                UILanguageBox.SelectedIndex = LocalizationHelper.GetComboIndexFromFileName(Translator.Setting?.UiLanguageFileName);
             }
             finally
             {
                 _suppressUiLanguageSelectionChanged = false;
+            }
+        }
+
+        private void InitializeUILanguageSelection()
+        {
+            _suppressUiLanguageSelectionChanged = true;
+            try
+            {
+                var current = Translator.Setting?.UiLanguageFileName;
+                if (string.IsNullOrWhiteSpace(current))
+                    current = LocalizationHelper.GetActiveLocalizationFileName();
+
+                UILanguageBox.SelectedIndex = LocalizationHelper.GetComboIndexFromFileName(current);
+                LocalizationHelper.ActivateLocalizationDictionary(current);
+                LocalizationHelper.ApplyFlowDirectionForLocalization(current, keepOverlayWindowLtr: true);
+            }
+            finally
+            {
+                _suppressUiLanguageSelectionChanged = false;
+            }
+        }
+
+        private void UILanguageBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressUiLanguageSelectionChanged || !IsLoaded)
+                return;
+
+            string fileName = LocalizationHelper.GetFileNameFromComboIndex(UILanguageBox.SelectedIndex);
+
+            LocalizationHelper.ActivateLocalizationDictionary(fileName);
+            LocalizationHelper.ApplyFlowDirectionForLocalization(fileName, keepOverlayWindowLtr: true);
+
+            if (Translator.Setting is not null)
+                Translator.Setting.UiLanguageFileName = fileName;
+
+            foreach (Window w in Application.Current.Windows)
+            {
+                if (w is WelcomeWindow ww)
+                {
+                    ww.SyncLanguageSelectionFromSetting();
+                    ww.RequestAutoFitHeight(); // trigger welcome window height auto-fit on setting change
+                }
+            }
+
+            var content = Content;
+            Content = null;
+            Content = content;
+
+            RequestAutoFitWidth();
+        }
+
+        public void RequestAutoFitWidth()
+        {
+            if (Application.Current.MainWindow is MainWindow mw)
+            {
+                mw.Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    var prev = mw.SizeToContent;
+                    mw.SizeToContent = SizeToContent.Width;
+                    mw.UpdateLayout();
+
+                    const double minW = 860;
+                    const double maxW = 1200;
+                    mw.Width = Math.Max(minW, Math.Min(maxW, mw.ActualWidth));
+
+                    mw.SizeToContent = prev;
+                }), System.Windows.Threading.DispatcherPriority.Loaded);
             }
         }
 
@@ -100,16 +133,19 @@ namespace LiveCaptionsTranslator
             if (Translator.Window == null)
                 return;
 
+            var button = sender as Wpf.Ui.Controls.Button;
+            var text = ButtonText.Text;
+
             bool isHide = Translator.Window.Current.BoundingRectangle == Rect.Empty;
             if (isHide)
             {
                 LiveCaptionsHandler.RestoreLiveCaptions(Translator.Window);
-                ButtonText.Text = TryFindResource("S45") as string ?? "Hide";
+                ButtonText.Text = (string)Application.Current.TryFindResource("SettingPage_LiveCaptionsToggle_Hide");
             }
             else
             {
                 LiveCaptionsHandler.HideLiveCaptions(Translator.Window);
-                ButtonText.Text = TryFindResource("S46") as string ?? "Show";
+                ButtonText.Text = (string)Application.Current.TryFindResource("SettingPage_LiveCaptionsToggle_Show");
             }
         }
 
@@ -121,12 +157,12 @@ namespace LiveCaptionsTranslator
         private void TargetLangBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (TargetLangBox.SelectedItem != null)
-                _setting.TargetLanguage = TargetLangBox.SelectedItem.ToString() ?? _setting.TargetLanguage;
+                Translator.Setting.TargetLanguage = TargetLangBox.SelectedItem.ToString();
         }
 
         private void TargetLangBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            _setting.TargetLanguage = TargetLangBox.Text;
+            Translator.Setting.TargetLanguage = TargetLangBox.Text;
         }
 
         private void APISettingButton_click(object sender, RoutedEventArgs e)
@@ -143,17 +179,16 @@ namespace LiveCaptionsTranslator
 
         private void Contexts_ValueChanged(object sender, NumberBoxValueChangedEventArgs args)
         {
-            if (_setting.DisplaySentences > _setting.NumContexts)
-                _setting.DisplaySentences = _setting.NumContexts;
+            if (Translator.Setting.DisplaySentences > Translator.Setting.NumContexts)
+                Translator.Setting.DisplaySentences = Translator.Setting.NumContexts;
         }
 
         private void DisplaySentences_ValueChanged(object sender, NumberBoxValueChangedEventArgs args)
         {
-            if (_setting.DisplaySentences > _setting.NumContexts)
-                _setting.NumContexts = _setting.DisplaySentences;
-
-            _caption.OnPropertyChanged("DisplayLogCards");
-            _caption.OnPropertyChanged("OverlayPreviousTranslation");
+            if (Translator.Setting.DisplaySentences > Translator.Setting.NumContexts)
+                Translator.Setting.NumContexts = Translator.Setting.DisplaySentences;
+            Translator.Caption.OnPropertyChanged("DisplayLogCards");
+            Translator.Caption.OnPropertyChanged("OverlayPreviousTranslation");
         }
 
         private void LiveCaptionsInfo_MouseEnter(object sender, MouseEventArgs e)
@@ -229,262 +264,32 @@ namespace LiveCaptionsTranslator
         private void CheckForFirstUse()
         {
             if (Translator.FirstUseFlag)
-                ButtonText.Text = TryFindResource("S45") as string ?? "Hide";
+                ButtonText.Text = (string)Application.Current.TryFindResource("SettingPage_LiveCaptionsToggle_Hide");
         }
 
         public void LoadAPISetting()
         {
-            // Guard against unavailable configs.
-            var apiName = _setting.ApiName;
-            if (!_setting.Configs.ContainsKey(apiName))
-                return;
-
-            var configType = _setting[apiName].GetType();
+            var configType = Translator.Setting[Translator.Setting.ApiName].GetType();
             var languagesProp = configType.GetProperty(
                 "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
 
-            // Traverse base classes to find `SupportedLanguages`
             while (configType != null && languagesProp == null)
             {
                 configType = configType.BaseType;
-                if (configType != null)
-                    languagesProp = configType.GetProperty(
-                        "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
+                languagesProp = configType.GetProperty(
+                    "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
             }
+            if (languagesProp == null)
+                languagesProp = typeof(TranslateAPIConfig).GetProperty(
+                    "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
 
-            languagesProp ??= typeof(TranslateAPIConfig).GetProperty(
-                "SupportedLanguages", BindingFlags.Public | BindingFlags.Static);
-
-            if (languagesProp?.GetValue(null) is not Dictionary<string, string> supportedLanguages)
-                return;
-
+            var supportedLanguages = (Dictionary<string, string>)languagesProp.GetValue(null);
             TargetLangBox.ItemsSource = supportedLanguages.Keys;
 
-            string targetLang = _setting.TargetLanguage;
+            string targetLang = Translator.Setting.TargetLanguage;
             if (!supportedLanguages.ContainsKey(targetLang))
-                supportedLanguages[targetLang] = targetLang; // add custom language
-
+                supportedLanguages[targetLang] = targetLang;
             TargetLangBox.SelectedItem = targetLang;
-        }
-
-        private void UILanguageBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (_suppressUiLanguageSelectionChanged || !IsLoaded)
-                return;
-
-            string fileName = UILanguageBox.SelectedIndex switch
-            {
-                1 => "zh-cn.xaml",
-                2 => "ar.xaml",
-                3 => "bn.xaml",
-                4 => "cs-cz.xaml",
-                5 => "de-de.xaml",
-                6 => "es-mx.xaml",
-                7 => "fr-fr.xaml",
-                8 => "it-it.xaml",
-                9 => "ja-jp.xaml",
-                10 => "ko-kr.xaml",
-                11 => "lt-lt.xaml",
-                12 => "nl-nl.xaml",
-                13 => "pl-pl.xaml",
-                14 => "pt-br.xaml",
-                15 => "pt-pt.xaml",
-                16 => "ru-ru.xaml",
-                17 => "sv-se.xaml",
-                18 => "tr-tr.xaml",
-                19 => "vi-vn.xaml",
-                20 => "zh-tw.xaml",
-                _ => "en-us.xaml"
-            };
-
-            ActivateLocalizationDictionary(fileName);
-            ApplyFlowDirectionForLocalization(fileName);
-
-            _setting.UiLanguageFileName = fileName;
-
-            // Sync other open windows' language dropdowns.
-            foreach (Window w in Application.Current.Windows)
-            {
-                if (w is WelcomeWindow ww)
-                    ww.SyncLanguageSelectionFromSetting();
-            }
-
-            var content = Content;
-            Content = null;
-            Content = content;
-
-            RequestAutoFitWidth();
-        }
-
-        private static void ActivateLocalizationDictionary(string fileName)
-        {
-            var merged = Application.Current.Resources.MergedDictionaries;
-
-            int? index = null;
-            for (int i = 0; i < merged.Count; i++)
-            {
-                var src = merged[i].Source?.ToString();
-                if (src is null)
-                    continue;
-
-                if (src.Contains($"localization/{fileName}", StringComparison.OrdinalIgnoreCase))
-                {
-                    index = i;
-                    break;
-                }
-            }
-
-            if (index is null)
-                throw new IOException($"Cannot locate resource 'localization/{fileName}'.");
-
-            var target = merged[index.Value];
-            merged.RemoveAt(index.Value);
-            merged.Add(target);
-        }
-
-        private void InitializeUILanguageSelection()
-        {
-            _suppressUiLanguageSelectionChanged = true;
-            try
-            {
-                var current = _setting.UiLanguageFileName;
-                if (string.IsNullOrWhiteSpace(current))
-                    current = GetActiveLocalizationFileName();
-
-                UILanguageBox.SelectedIndex = current.ToLowerInvariant() switch
-                {
-                    "zh-cn.xaml" => 1,
-                    "ar.xaml" => 2,
-                    "bn.xaml" => 3,
-                    "cs-cz.xaml" => 4,
-                    "de-de.xaml" => 5,
-                    "es-mx.xaml" => 6,
-                    "fr-fr.xaml" => 7,
-                    "it-it.xaml" => 8,
-                    "ja-jp.xaml" => 9,
-                    "ko-kr.xaml" => 10,
-                    "lt-lt.xaml" => 11,
-                    "nl-nl.xaml" => 12,
-                    "pl-pl.xaml" => 13,
-                    "pt-br.xaml" => 14,
-                    "pt-pt.xaml" => 15,
-                    "ru-ru.xaml" => 16,
-                    "sv-se.xaml" => 17,
-                    "tr-tr.xaml" => 18,
-                    "vi-vn.xaml" => 19,
-                    "zh-tw.xaml" => 20,
-                    _ => 0
-                };
-
-                ActivateLocalizationDictionary(current);
-                ApplyFlowDirectionForLocalization(current);
-            }
-            finally
-            {
-                _suppressUiLanguageSelectionChanged = false;
-            }
-        }
-
-        private static string GetActiveLocalizationFileName()
-        {
-            for (int i = Application.Current.Resources.MergedDictionaries.Count - 1; i >= 0; i--)
-            {
-                var src = Application.Current.Resources.MergedDictionaries[i].Source?.ToString();
-                if (src is null)
-                    continue;
-
-                if (src.Contains("localization/zh-cn.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "zh-cn.xaml";
-                if (src.Contains("localization/ar.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "ar.xaml";
-                if (src.Contains("localization/bn.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "bn.xaml";
-
-                if (src.Contains("localization/zh-tw.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "zh-tw.xaml";
-                if (src.Contains("localization/cs-cz.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "cs-cz.xaml";
-                if (src.Contains("localization/de-de.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "de-de.xaml";
-                if (src.Contains("localization/es-mx.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "es-mx.xaml";
-                if (src.Contains("localization/fr-fr.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "fr-fr.xaml";
-                if (src.Contains("localization/it-it.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "it-it.xaml";
-                if (src.Contains("localization/ja-jp.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "ja-jp.xaml";
-                if (src.Contains("localization/ko-kr.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "ko-kr.xaml";
-                if (src.Contains("localization/lt-lt.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "lt-lt.xaml";
-                if (src.Contains("localization/nl-nl.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "nl-nl.xaml";
-                if (src.Contains("localization/pl-pl.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "pl-pl.xaml";
-                if (src.Contains("localization/pt-br.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "pt-br.xaml";
-                if (src.Contains("localization/pt-pt.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "pt-pt.xaml";
-                if (src.Contains("localization/ru-ru.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "ru-ru.xaml";
-                if (src.Contains("localization/sv-se.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "sv-se.xaml";
-                if (src.Contains("localization/tr-tr.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "tr-tr.xaml";
-                if (src.Contains("localization/vi-vn.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "vi-vn.xaml";
-
-                if (src.Contains("localization/en-us.xaml", StringComparison.OrdinalIgnoreCase))
-                    return "en-us.xaml";
-            }
-
-            return "en-us.xaml";
-        }
-
-        private static void ApplyFlowDirectionForLocalization(string fileName)
-        {
-            bool isArabic = string.Equals(fileName, "ar.xaml", StringComparison.OrdinalIgnoreCase);
-
-            if (Application.Current.MainWindow is FrameworkElement fe)
-            {
-                fe.FlowDirection = isArabic ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
-                fe.Language = XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
-            }
-
-            // Overlay window stays LTR.
-            if ((Application.Current.MainWindow as MainWindow)?.OverlayWindow is { } overlay)
-            {
-                if (overlay.Content is FrameworkElement overlayContent)
-                {
-                    overlayContent.FlowDirection = FlowDirection.LeftToRight;
-                    overlayContent.Language = XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
-                }
-            }
-        }
-
-        /// <summary>
-        /// Re-measure SettingPage content and auto-fit the MainWindow width.
-        /// Intended to be called after localization changes initiated outside this page (e.g., WelcomeWindow).
-        /// </summary>
-        public void RequestAutoFitWidth()
-        {
-            // Auto-size main window width to fit SettingPage content.
-            if (Application.Current.MainWindow is MainWindow mw)
-            {
-                mw.Dispatcher.BeginInvoke(new Action(() =>
-                {
-                    var prev = mw.SizeToContent;
-                    mw.SizeToContent = SizeToContent.Width;
-                    mw.UpdateLayout();
-
-                    const double minW = 860;
-                    const double maxW = 1200;
-                    mw.Width = Math.Max(minW, Math.Min(maxW, mw.ActualWidth));
-
-                    mw.SizeToContent = prev;
-                }), System.Windows.Threading.DispatcherPriority.Loaded);
-            }
         }
     }
 }

--- a/src/utils/LocalizationHelper.cs
+++ b/src/utils/LocalizationHelper.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Markup;
+using LiveCaptionsTranslator.models;
+
+namespace LiveCaptionsTranslator.utils
+{
+    internal static class LocalizationHelper
+    {
+        // Derive supported file list from LanguageCatalog to keep a single source of truth
+        internal static readonly IReadOnlyList<string> SupportedFiles = LanguageCatalog.SupportedUiLanguages
+            .Select(l => l.CultureCode + ".xaml")
+            .ToList();
+
+        private static readonly Dictionary<string, int> FileToIndex = SupportedFiles
+            .Select((f, i) => new { f, i })
+            .ToDictionary(x => x.f, x => x.i, StringComparer.OrdinalIgnoreCase);
+
+        internal static int GetComboIndexFromFileName(string? fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+                return 0;
+
+            return FileToIndex.TryGetValue(fileName.Trim(), out var idx) ? idx : 0;
+        }
+
+        internal static string GetFileNameFromComboIndex(int selectedIndex)
+        {
+            if (selectedIndex < 0 || selectedIndex >= SupportedFiles.Count)
+                return SupportedFiles[0];
+
+            return SupportedFiles[selectedIndex];
+        }
+
+        internal static void ActivateLocalizationDictionary(string? fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+                fileName = "en-us.xaml";
+
+            var merged = Application.Current.Resources.MergedDictionaries;
+
+            // Ensure fallback en-us is present somewhere
+            int? enIndex = null;
+            for (int i = 0; i < merged.Count; i++)
+            {
+                var src = merged[i].Source?.ToString();
+                if (src is null)
+                    continue;
+                if (src.Contains("localization/en-us.xaml", StringComparison.OrdinalIgnoreCase))
+                {
+                    enIndex = i;
+                    break;
+                }
+            }
+            if (enIndex is null)
+            {
+                merged.Add(new ResourceDictionary
+                {
+                    Source = new Uri("localization/en-us.xaml", UriKind.Relative)
+                });
+            }
+
+            // Locate the target language dictionary if already merged
+            int? langIndex = null;
+            for (int i = 0; i < merged.Count; i++)
+            {
+                var src = merged[i].Source?.ToString();
+                if (src is null)
+                    continue;
+
+                if (src.Contains($"localization/{fileName}", StringComparison.OrdinalIgnoreCase))
+                {
+                    langIndex = i;
+                    break;
+                }
+            }
+
+            // If selecting en-us, just make sure it's last so it takes precedence
+            if (fileName.Equals("en-us.xaml", StringComparison.OrdinalIgnoreCase))
+            {
+                // Move en-us to the end
+                int? findEn = null;
+                for (int i = 0; i < merged.Count; i++)
+                {
+                    var src = merged[i].Source?.ToString();
+                    if (src is null)
+                        continue;
+                    if (src.Contains("localization/en-us.xaml", StringComparison.OrdinalIgnoreCase))
+                    {
+                        findEn = i;
+                        break;
+                    }
+                }
+                if (findEn is not null)
+                {
+                    var enDict = merged[findEn.Value];
+                    merged.RemoveAt(findEn.Value);
+                    merged.Add(enDict);
+                }
+                return;
+            }
+
+            // Add or move the selected dictionary to be the LAST one, so it overrides fallback
+            if (langIndex is not null)
+            {
+                var dict = merged[langIndex.Value];
+                merged.RemoveAt(langIndex.Value);
+                merged.Add(dict);
+            }
+            else
+            {
+                merged.Add(new ResourceDictionary
+                {
+                    Source = new Uri($"localization/{fileName}", UriKind.Relative)
+                });
+            }
+        }
+
+        internal static string GetActiveLocalizationFileName()
+        {
+            for (int i = Application.Current.Resources.MergedDictionaries.Count - 1; i >= 0; i--)
+            {
+                var src = Application.Current.Resources.MergedDictionaries[i].Source?.ToString();
+                if (src is null)
+                    continue;
+
+                foreach (var file in SupportedFiles)
+                {
+                    if (src.Contains($"localization/{file}", StringComparison.OrdinalIgnoreCase))
+                        return file;
+                }
+            }
+
+            return SupportedFiles[0];
+        }
+
+        internal static void ApplyFlowDirectionForLocalization(string? fileName, bool keepOverlayWindowLtr)
+        {
+            bool isArabic = string.Equals(fileName, "ar.xaml", StringComparison.OrdinalIgnoreCase);
+
+            if (keepOverlayWindowLtr)
+            {
+                // Apply to MainWindow
+                if (Application.Current.MainWindow is FrameworkElement fe)
+                {
+                    fe.FlowDirection = isArabic ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+                    fe.Language = XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
+                }
+
+                // Ensure OverlayWindow content stays LTR
+                if ((Application.Current.MainWindow as MainWindow)?.OverlayWindow is { } overlay)
+                {
+                    if (overlay.Content is FrameworkElement overlayContent)
+                    {
+                        overlayContent.FlowDirection = FlowDirection.LeftToRight;
+                        overlayContent.Language = XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
+                    }
+                }
+
+                // Also apply to WelcomeWindow if present to mirror MainWindow behavior
+                foreach (Window w in Application.Current.Windows)
+                {
+                    if (w is WelcomeWindow ww)
+                    {
+                        ww.FlowDirection = isArabic ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+                        if (ww.Content is FrameworkElement wwc)
+                        {
+                            wwc.Language = XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
+                        }
+                    }
+                }
+
+                return;
+            }
+
+            // Apply globally to all open windows
+            foreach (Window w in Application.Current.Windows)
+            {
+                if (w is FrameworkElement fe)
+                {
+                    fe.FlowDirection = isArabic ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+                    fe.Language = XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
+                }
+            }
+        }
+
+        internal static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject
+        {
+            int count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+            {
+                var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+                if (child is T typed)
+                    return typed;
+
+                var found = FindDescendant<T>(child);
+                if (found is not null)
+                    return found;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/utils/RegexPatterns.cs
+++ b/src/utils/RegexPatterns.cs
@@ -37,8 +37,8 @@ namespace LiveCaptionsTranslator.utils
 
         [GeneratedRegex(@"[^0-9.]")]
         public static partial Regex VersionNumber();
-
-        [GeneratedRegex(@"🔤\s*(.+?)\s*🔤")]
+        
+        [GeneratedRegex(@"🔤(.*)🔤")]
         public static partial Regex TargetSentence();
     }
 }

--- a/src/utils/TextUtil.cs
+++ b/src/utils/TextUtil.cs
@@ -12,7 +12,7 @@ namespace LiveCaptionsTranslator.utils
         public const int LONG_THRESHOLD = 160;
         public const int VERYLONG_THRESHOLD = 220;
 
-        public const double SIM_THRESHOLD = 0.6;
+        public const double SIM_THRESHOLD = 0.7;
 
         public static string ShortenDisplaySentence(string text, int maxByteLength)
         {

--- a/src/windows/MainWindow.xaml
+++ b/src/windows/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:LiveCaptionsTranslator"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    Title="{DynamicResource M0}"
+    Title="{DynamicResource MainWindow_Title}"
     Width="750"
     Height="170"
     MinWidth="750"
@@ -35,7 +35,7 @@
                 ShowMaximize="False">
                 <ui:TitleBar.Header>
                     <ui:TextBlock Padding="15,0,0,0" VerticalAlignment="Center" FontFamily="Segoe UI">
-                        <Run Text="{DynamicResource M0}" />
+                        <Run Text="{DynamicResource MainWindow_Title}" />
                     </ui:TextBlock>
                 </ui:TitleBar.Header>
                 <ui:TitleBar.TrailingContent>
@@ -47,7 +47,7 @@
                             Click="CaptionLogButton_Click"
                             Icon="{ui:SymbolIcon History16,
                                                  Filled=False}"
-                            ToolTip="{DynamicResource M20}"
+                            ToolTip="{DynamicResource MainWindow_Tooltip_CaptionLog}"
                             Visibility="Collapsed" />
                         <ui:Button
                             x:Name="LogOnlyButton"
@@ -56,7 +56,7 @@
                             Click="LogOnlyButton_Click"
                             Icon="{ui:SymbolIcon Pause16,
                                                  Filled=False}"
-                            ToolTip="{DynamicResource M21}" />
+                            ToolTip="{DynamicResource MainWindow_Tooltip_LogOnly}" />
                         <ui:Button
                             x:Name="OverlayModeButton"
                             Margin="0,0,5,0"
@@ -64,7 +64,7 @@
                             Click="OverlayModeButton_Click"
                             Icon="{ui:SymbolIcon ClosedCaptionOff24,
                                                  Filled=False}"
-                            ToolTip="{DynamicResource M22}" />
+                            ToolTip="{DynamicResource MainWindow_Tooltip_Overlay}" />
                         <ui:Button
                             x:Name="TopmostButton"
                             Margin="0,0,5,0"
@@ -72,7 +72,7 @@
                             Click="TopmostButton_Click"
                             Icon="{ui:SymbolIcon Pin16,
                                                  Filled=True}"
-                            ToolTip="{DynamicResource M23}" />
+                            ToolTip="{DynamicResource MainWindow_Tooltip_Topmost}" />
                     </StackPanel>
                 </ui:TitleBar.TrailingContent>
             </ui:TitleBar>
@@ -89,14 +89,14 @@
                 <ui:NavigationView.MenuItems>
                     <ui:NavigationViewItem
                         Margin="0,6,0,3"
-                        Content="{DynamicResource M10}"
+                        Content="{DynamicResource Navigation_Captions}"
                         FontFamily="Segoe UI"
                         Icon="{ui:SymbolIcon Home24}"
                         NavigationCacheMode="Enabled"
                         TargetPageType="{x:Type local:CaptionPage}" />
                     <ui:NavigationViewItem
                         Margin="0,3,0,0"
-                        Content="{DynamicResource M11}"
+                        Content="{DynamicResource Navigation_Settings}"
                         FontFamily="Segoe UI"
                         Icon="{ui:SymbolIcon Settings24}"
                         NavigationCacheMode="Required"
@@ -104,14 +104,14 @@
                         Click="SettingNavItem_Click" />
                     <ui:NavigationViewItem
                         Margin="0,3,0,0"
-                        Content="{DynamicResource M12}"
+                        Content="{DynamicResource Navigation_History}"
                         FontFamily="Segoe UI"
                         Icon="{ui:SymbolIcon History24}"
                         NavigationCacheMode="Disabled"
                         TargetPageType="{x:Type local:HistoryPage}" />
                     <ui:NavigationViewItem
                         Margin="0,3,0,0"
-                        Content="{DynamicResource M13}"
+                        Content="{DynamicResource Navigation_Info}"
                         FontFamily="Segoe UI"
                         Icon="{ui:SymbolIcon Info24}"
                         NavigationCacheMode="Required"

--- a/src/windows/MainWindow.xaml
+++ b/src/windows/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:LiveCaptionsTranslator"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    Title="LiveCaptions Translator"
+    Title="{DynamicResource M0}"
     Width="750"
     Height="170"
     MinWidth="750"
@@ -23,7 +23,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <Grid x:Name="MainContent">
+        <Grid x:Name="MainContent" MouseLeftButtonDown="MainContent_MouseLeftButtonDown">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -34,7 +34,9 @@
                 Height="27"
                 ShowMaximize="False">
                 <ui:TitleBar.Header>
-                    <ui:TextBlock Padding="15,0,0,0" VerticalAlignment="Center">LiveCaptions Translator</ui:TextBlock>
+                    <ui:TextBlock Padding="15,0,0,0" VerticalAlignment="Center" FontFamily="Segoe UI">
+                        <Run Text="{DynamicResource M0}" />
+                    </ui:TextBlock>
                 </ui:TitleBar.Header>
                 <ui:TitleBar.TrailingContent>
                     <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
@@ -45,7 +47,7 @@
                             Click="CaptionLogButton_Click"
                             Icon="{ui:SymbolIcon History16,
                                                  Filled=False}"
-                            ToolTip="Log Cards of Captions"
+                            ToolTip="{DynamicResource M20}"
                             Visibility="Collapsed" />
                         <ui:Button
                             x:Name="LogOnlyButton"
@@ -54,7 +56,7 @@
                             Click="LogOnlyButton_Click"
                             Icon="{ui:SymbolIcon Pause16,
                                                  Filled=False}"
-                            ToolTip="Pause Translation (Log Only)" />
+                            ToolTip="{DynamicResource M21}" />
                         <ui:Button
                             x:Name="OverlayModeButton"
                             Margin="0,0,5,0"
@@ -62,7 +64,7 @@
                             Click="OverlayModeButton_Click"
                             Icon="{ui:SymbolIcon ClosedCaptionOff24,
                                                  Filled=False}"
-                            ToolTip="Overlay Window" />
+                            ToolTip="{DynamicResource M22}" />
                         <ui:Button
                             x:Name="TopmostButton"
                             Margin="0,0,5,0"
@@ -70,7 +72,7 @@
                             Click="TopmostButton_Click"
                             Icon="{ui:SymbolIcon Pin16,
                                                  Filled=True}"
-                            ToolTip="Always on Top" />
+                            ToolTip="{DynamicResource M23}" />
                     </StackPanel>
                 </ui:TitleBar.TrailingContent>
             </ui:TitleBar>
@@ -87,29 +89,30 @@
                 <ui:NavigationView.MenuItems>
                     <ui:NavigationViewItem
                         Margin="0,6,0,3"
-                        Content="Caption"
-                        FontFamily="Bahnschrift"
+                        Content="{DynamicResource M10}"
+                        FontFamily="Segoe UI"
                         Icon="{ui:SymbolIcon Home24}"
                         NavigationCacheMode="Enabled"
                         TargetPageType="{x:Type local:CaptionPage}" />
                     <ui:NavigationViewItem
                         Margin="0,3,0,0"
-                        Content="Setting"
-                        FontFamily="Bahnschrift"
+                        Content="{DynamicResource M11}"
+                        FontFamily="Segoe UI"
                         Icon="{ui:SymbolIcon Settings24}"
                         NavigationCacheMode="Required"
-                        TargetPageType="{x:Type local:SettingPage}" />
+                        TargetPageType="{x:Type local:SettingPage}"
+                        Click="SettingNavItem_Click" />
                     <ui:NavigationViewItem
                         Margin="0,3,0,0"
-                        Content="History"
-                        FontFamily="Bahnschrift"
+                        Content="{DynamicResource M12}"
+                        FontFamily="Segoe UI"
                         Icon="{ui:SymbolIcon History24}"
                         NavigationCacheMode="Disabled"
                         TargetPageType="{x:Type local:HistoryPage}" />
                     <ui:NavigationViewItem
                         Margin="0,3,0,0"
-                        Content="Info"
-                        FontFamily="Bahnschrift"
+                        Content="{DynamicResource M13}"
+                        FontFamily="Segoe UI"
                         Icon="{ui:SymbolIcon Info24}"
                         NavigationCacheMode="Required"
                         TargetPageType="{x:Type local:InfoPage}" />

--- a/src/windows/OverlayWindow.xaml
+++ b/src/windows/OverlayWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:LiveCaptionsTranslator"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    Title="Overlay Window"
+    Title="{DynamicResource O0}"
     Width="650"
     Height="135"
     MinWidth="650"
@@ -47,6 +47,8 @@
                     <Style x:Key="CaptionBlockStyle" TargetType="TextBlock">
                         <Setter Property="TextWrapping" Value="Wrap" />
                         <Setter Property="VerticalAlignment" Value="Stretch" />
+                        <!-- Use default UI font for better Unicode coverage (Arabic, etc.) -->
+                        <Setter Property="FontFamily" Value="Segoe UI" />
                     </Style>
                 </Grid.Resources>
 
@@ -66,7 +68,7 @@
                             x:Name="TranslatedCaption"
                             FontSize="18"
                             Style="{StaticResource CaptionBlockStyle}">
-                            <Run x:Name="NoticePrefixRun" Text="{Binding OverlayNoticePrefix, UpdateSourceTrigger=PropertyChanged}" FontFamily="Consolas" />
+                            <Run x:Name="NoticePrefixRun" Text="{Binding OverlayNoticePrefix, UpdateSourceTrigger=PropertyChanged}" />
                             <Run x:Name="PreviousTranslationRun" Text="{Binding OverlayPreviousTranslation, Mode=OneWay}" />
                             <Run x:Name="CurrentTranslationRun" Text="{Binding OverlayCurrentTranslation, UpdateSourceTrigger=PropertyChanged}" />
                         </TextBlock>
@@ -107,7 +109,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon fontIncrease20,
                                              Filled=False}"
-                        ToolTip="Font Size Increase" />
+                        ToolTip="{DynamicResource O1}" />
                     <ui:Button
                         x:Name="FontSizeDecrease"
                         Background="#FFAAAAAA"
@@ -115,7 +117,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon fontDecrease20,
                                              Filled=False}"
-                        ToolTip="Font Size Decrease" />
+                        ToolTip="{DynamicResource O2}" />
                     <ui:Button
                         x:Name="FontStrokeIncrease"
                         Background="#FFAAAAAA"
@@ -123,7 +125,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon InkStroke20,
                                              Filled=True}"
-                        ToolTip="Font Stroke Increase" />
+                        ToolTip="{DynamicResource O3}" />
                     <ui:Button
                         x:Name="FontStrokeDecrease"
                         Background="#FFAAAAAA"
@@ -131,7 +133,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon InkStrokeArrowDown20,
                                              Filled=False}"
-                        ToolTip="Font Stroke Decrease" />
+                        ToolTip="{DynamicResource O4}" />
                     <ui:Button
                         x:Name="FontBold"
                         Background="#FFAAAAAA"
@@ -139,7 +141,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon textBold16,
                                              Filled=False}"
-                        ToolTip="Font Bold" />
+                        ToolTip="{DynamicResource O5}" />
                     <ui:Button
                         x:Name="FontColorCycle"
                         Background="#FFAAAAAA"
@@ -147,7 +149,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon color16,
                                              Filled=False}"
-                        ToolTip="Font Color" />
+                        ToolTip="{DynamicResource O6}" />
 
                     <ui:Button
                         x:Name="OpacityIncrease"
@@ -157,7 +159,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon arrowAutofitUp20,
                                              Filled=False}"
-                        ToolTip="Background Opacity Increase" />
+                        ToolTip="{DynamicResource O7}" />
                     <ui:Button
                         x:Name="OpacityDecrease"
                         Background="#FFAAAAAA"
@@ -165,7 +167,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon arrowAutofitDown20,
                                              Filled=False}"
-                        ToolTip="Background Opacity Decrease" />
+                        ToolTip="{DynamicResource O8}" />
                     <ui:Button
                         x:Name="BackgroundColorCycle"
                         Background="#FFAAAAAA"
@@ -173,7 +175,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon color16,
                                              Filled=False}"
-                        ToolTip="Background Color" />
+                        ToolTip="{DynamicResource O9}" />
 
                     <ui:Button
                         x:Name="OnlyModeButton"
@@ -183,7 +185,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon PanelBottom20,
                                              Filled=False}"
-                        ToolTip="Show only subtitles or translations" />
+                        ToolTip="{DynamicResource O10}" />
                     <ui:Button
                         x:Name="SwitchModeButton"
                         Background="#FFAAAAAA"
@@ -191,7 +193,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon ArrowSyncCircle20,
                                              Filled=False}"
-                        ToolTip="Show only subtitles or translations" />
+                        ToolTip="{DynamicResource O11}" />
                     <ui:Button
                         x:Name="ClickThrough"
                         Background="#FFAAAAAA"
@@ -199,7 +201,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon lockClosed16,
                                              Filled=False}"
-                        ToolTip="Click Through" />
+                        ToolTip="{DynamicResource O12}" />
                 </StackPanel>
             </Grid>
         </Border>

--- a/src/windows/OverlayWindow.xaml
+++ b/src/windows/OverlayWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:LiveCaptionsTranslator"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    Title="{DynamicResource O0}"
+    Title="{DynamicResource OverlayWindow_Title}"
     Width="650"
     Height="135"
     MinWidth="650"
@@ -109,7 +109,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon fontIncrease20,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O1}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_IncreaseFontSize}" />
                     <ui:Button
                         x:Name="FontSizeDecrease"
                         Background="#FFAAAAAA"
@@ -117,7 +117,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon fontDecrease20,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O2}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_DecreaseFontSize}" />
                     <ui:Button
                         x:Name="FontStrokeIncrease"
                         Background="#FFAAAAAA"
@@ -125,7 +125,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon InkStroke20,
                                              Filled=True}"
-                        ToolTip="{DynamicResource O3}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_IncreaseStroke}" />
                     <ui:Button
                         x:Name="FontStrokeDecrease"
                         Background="#FFAAAAAA"
@@ -133,7 +133,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon InkStrokeArrowDown20,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O4}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_DecreaseStroke}" />
                     <ui:Button
                         x:Name="FontBold"
                         Background="#FFAAAAAA"
@@ -141,7 +141,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon textBold16,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O5}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_Bold}" />
                     <ui:Button
                         x:Name="FontColorCycle"
                         Background="#FFAAAAAA"
@@ -149,7 +149,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon color16,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O6}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_FontColor}" />
 
                     <ui:Button
                         x:Name="OpacityIncrease"
@@ -159,7 +159,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon arrowAutofitUp20,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O7}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_IncreaseBackgroundOpacity}" />
                     <ui:Button
                         x:Name="OpacityDecrease"
                         Background="#FFAAAAAA"
@@ -167,7 +167,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon arrowAutofitDown20,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O8}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_DecreaseBackgroundOpacity}" />
                     <ui:Button
                         x:Name="BackgroundColorCycle"
                         Background="#FFAAAAAA"
@@ -175,7 +175,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon color16,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O9}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_BackgroundColor}" />
 
                     <ui:Button
                         x:Name="OnlyModeButton"
@@ -185,7 +185,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon PanelBottom20,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O10}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_OnlyMode}" />
                     <ui:Button
                         x:Name="SwitchModeButton"
                         Background="#FFAAAAAA"
@@ -193,7 +193,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon ArrowSyncCircle20,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O11}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_SwitchPosition}" />
                     <ui:Button
                         x:Name="ClickThrough"
                         Background="#FFAAAAAA"
@@ -201,7 +201,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon lockClosed16,
                                              Filled=False}"
-                        ToolTip="{DynamicResource O12}" />
+                        ToolTip="{DynamicResource OverlayWindow_Button_ClickThrough}" />
                 </StackPanel>
             </Grid>
         </Border>

--- a/src/windows/OverlayWindow.xaml.cs
+++ b/src/windows/OverlayWindow.xaml.cs
@@ -9,7 +9,6 @@ using System.Windows.Threading;
 using Wpf.Ui.Controls;
 
 using LiveCaptionsTranslator.apis;
-using LiveCaptionsTranslator.models;
 using LiveCaptionsTranslator.Utils;
 using Button = Wpf.Ui.Controls.Button;
 using Color = System.Windows.Media.Color;
@@ -19,7 +18,7 @@ namespace LiveCaptionsTranslator
 {
     public partial class OverlayWindow : Window
     {
-        private readonly Dictionary<ColorEnum, SolidColorBrush> colorMap = new ()
+        private readonly Dictionary<ColorEnum, SolidColorBrush> colorMap = new()
         {
             {ColorEnum.White, Brushes.White},
             {ColorEnum.Yellow, Brushes.Yellow},
@@ -43,42 +42,27 @@ namespace LiveCaptionsTranslator
         }
         public CaptionLocation SwitchMode { get; set; } = CaptionLocation.TranslationTop;
 
-        private readonly Setting _setting;
-        private readonly Caption _caption;
-
         public OverlayWindow()
         {
             InitializeComponent();
+            DataContext = Translator.Caption;
 
-            // Keep overlay captions readable even when app UI is RTL.
-            FlowDirection = FlowDirection.LeftToRight;
+            Loaded += (s, e) => Translator.Caption.PropertyChanged += TranslatedChanged;
+            Unloaded += (s, e) => Translator.Caption.PropertyChanged -= TranslatedChanged;
 
-            _setting = Translator.Setting ?? Setting.Load();
-            _caption = Translator.Caption ?? Caption.GetInstance();
-
-            DataContext = _caption;
-
-            // Default: Translation on top, Subtitle on bottom
-            Grid.SetRow(TranslatedCaptionCard, 0);
-            Grid.SetRow(OriginalCaptionCard, 1);
-            SwitchMode = CaptionLocation.TranslationTop;
-
-            Loaded += (_, __) => _caption.PropertyChanged += TranslatedChanged;
-            Unloaded += (_, __) => _caption.PropertyChanged -= TranslatedChanged;
-
-            OriginalCaption.FontWeight = _setting.OverlayWindow.FontBold == Utils.FontBold.Both ?
+            OriginalCaption.FontWeight = Translator.Setting.OverlayWindow.FontBold == Utils.FontBold.Both ?
                 FontWeights.Bold : FontWeights.Regular;
-            TranslatedCaption.FontWeight = _setting.OverlayWindow.FontBold >= Utils.FontBold.TranslationOnly ?
+            TranslatedCaption.FontWeight = Translator.Setting.OverlayWindow.FontBold >= Utils.FontBold.TranslationOnly ?
                 FontWeights.Bold : FontWeights.Regular;
 
-            OriginalCaptionDecorator.StrokeThickness = _setting.OverlayWindow.FontStroke;
-            TranslatedCaptionDecorator.StrokeThickness = _setting.OverlayWindow.FontStroke;
+            OriginalCaptionDecorator.StrokeThickness = Translator.Setting.OverlayWindow.FontStroke;
+            TranslatedCaptionDecorator.StrokeThickness = Translator.Setting.OverlayWindow.FontStroke;
 
-            OriginalCaption.Foreground = colorMap[_setting.OverlayWindow.FontColor];
-            UpdateTranslationColor(colorMap[_setting.OverlayWindow.FontColor]);
+            OriginalCaption.Foreground = colorMap[Translator.Setting.OverlayWindow.FontColor];
+            UpdateTranslationColor(colorMap[Translator.Setting.OverlayWindow.FontColor]);
 
-            BorderBackground.Background = colorMap[_setting.OverlayWindow.BackgroundColor];
-            BorderBackground.Opacity = _setting.OverlayWindow.Opacity;
+            BorderBackground.Background = colorMap[Translator.Setting.OverlayWindow.BackgroundColor];
+            BorderBackground.Opacity = Translator.Setting.OverlayWindow.Opacity;
 
             ApplyFontSize();
             ApplyBackgroundOpacity();
@@ -156,7 +140,7 @@ namespace LiveCaptionsTranslator
             RightThumb_OnDragDelta(sender, e);
         }
 
-        private void TranslatedChanged(object? sender, PropertyChangedEventArgs e)
+        private void TranslatedChanged(object sender, PropertyChangedEventArgs e)
         {
             ApplyFontSize();
         }
@@ -173,29 +157,28 @@ namespace LiveCaptionsTranslator
 
         private void FontIncrease_Click(object sender, RoutedEventArgs e)
         {
-            if (_setting.OverlayWindow.FontSize + StyleConsts.DELTA_FONT_SIZE < StyleConsts.MAX_FONT_SIZE)
+            if (Translator.Setting.OverlayWindow.FontSize + StyleConsts.DELTA_FONT_SIZE < StyleConsts.MAX_FONT_SIZE)
             {
-                _setting.OverlayWindow.FontSize += StyleConsts.DELTA_FONT_SIZE;
+                Translator.Setting.OverlayWindow.FontSize += StyleConsts.DELTA_FONT_SIZE;
                 ApplyFontSize();
             }
         }
 
         private void FontDecrease_Click(object sender, RoutedEventArgs e)
         {
-            if (_setting.OverlayWindow.FontSize - StyleConsts.DELTA_FONT_SIZE > StyleConsts.MIN_FONT_SIZE)
+            if (Translator.Setting.OverlayWindow.FontSize - StyleConsts.DELTA_FONT_SIZE > StyleConsts.MIN_FONT_SIZE)
             {
-                _setting.OverlayWindow.FontSize -= StyleConsts.DELTA_FONT_SIZE;
+                Translator.Setting.OverlayWindow.FontSize -= StyleConsts.DELTA_FONT_SIZE;
                 ApplyFontSize();
             }
         }
 
         private void FontBold_Click(object sender, RoutedEventArgs e)
         {
-            _setting.OverlayWindow.FontBold++;
-            if (_setting.OverlayWindow.FontBold > Utils.FontBold.Both)
-                _setting.OverlayWindow.FontBold = Utils.FontBold.None;
-
-            switch (_setting.OverlayWindow.FontBold)
+            Translator.Setting.OverlayWindow.FontBold++;
+            if (Translator.Setting.OverlayWindow.FontBold > Utils.FontBold.Both)
+                Translator.Setting.OverlayWindow.FontBold = Utils.FontBold.None;
+            switch (Translator.Setting.OverlayWindow.FontBold)
             {
                 case Utils.FontBold.None:
                     OriginalCaption.FontWeight = FontWeights.Regular;
@@ -218,57 +201,56 @@ namespace LiveCaptionsTranslator
 
         private void FontStrokeIncrease_Click(object sender, RoutedEventArgs e)
         {
-            if (_setting.OverlayWindow.FontStroke + StyleConsts.DELTA_STROKE > StyleConsts.MAX_STROKE)
+            if (Translator.Setting.OverlayWindow.FontStroke + StyleConsts.DELTA_STROKE > StyleConsts.MAX_STROKE)
                 return;
-            _setting.OverlayWindow.FontStroke += StyleConsts.DELTA_STROKE;
+            Translator.Setting.OverlayWindow.FontStroke += StyleConsts.DELTA_STROKE;
             ApplyFontStroke();
         }
 
         private void FontStrokeDecrease_Click(object sender, RoutedEventArgs e)
         {
-            if (_setting.OverlayWindow.FontStroke - StyleConsts.DELTA_STROKE < StyleConsts.MIN_STROKE)
+            if (Translator.Setting.OverlayWindow.FontStroke - StyleConsts.DELTA_STROKE < StyleConsts.MIN_STROKE)
                 return;
-            _setting.OverlayWindow.FontStroke -= StyleConsts.DELTA_STROKE;
+            Translator.Setting.OverlayWindow.FontStroke -= StyleConsts.DELTA_STROKE;
             ApplyFontStroke();
         }
 
         private void FontColorCycle_Click(object sender, RoutedEventArgs e)
         {
-            _setting.OverlayWindow.FontColor++;
-            if (_setting.OverlayWindow.FontColor > ColorEnum.Black)
-                _setting.OverlayWindow.FontColor = ColorEnum.White;
-
-            OriginalCaption.Foreground = colorMap[_setting.OverlayWindow.FontColor];
-            TranslatedCaption.Foreground = colorMap[_setting.OverlayWindow.FontColor];
-            UpdateTranslationColor(colorMap[_setting.OverlayWindow.FontColor]);
+            Translator.Setting.OverlayWindow.FontColor++;
+            if (Translator.Setting.OverlayWindow.FontColor > ColorEnum.Black)
+                Translator.Setting.OverlayWindow.FontColor = ColorEnum.White;
+            OriginalCaption.Foreground = colorMap[Translator.Setting.OverlayWindow.FontColor];
+            TranslatedCaption.Foreground = colorMap[Translator.Setting.OverlayWindow.FontColor];
+            UpdateTranslationColor(colorMap[Translator.Setting.OverlayWindow.FontColor]);
         }
 
         private void BackgroundOpacityIncrease_Click(object sender, RoutedEventArgs e)
         {
-            if (_setting.OverlayWindow.Opacity + StyleConsts.DELTA_OPACITY < StyleConsts.MAX_OPACITY)
-                _setting.OverlayWindow.Opacity += StyleConsts.DELTA_OPACITY;
+            if (Translator.Setting.OverlayWindow.Opacity + StyleConsts.DELTA_OPACITY < StyleConsts.MAX_OPACITY)
+                Translator.Setting.OverlayWindow.Opacity += StyleConsts.DELTA_OPACITY;
             else
-                _setting.OverlayWindow.Opacity = StyleConsts.MAX_OPACITY;
+                Translator.Setting.OverlayWindow.Opacity = StyleConsts.MAX_OPACITY;
             ApplyBackgroundOpacity();
         }
 
         private void BackgroundOpacityDecrease_Click(object sender, RoutedEventArgs e)
         {
-            if (_setting.OverlayWindow.Opacity - StyleConsts.DELTA_OPACITY > StyleConsts.MIN_OPACITY)
-                _setting.OverlayWindow.Opacity -= StyleConsts.DELTA_OPACITY;
+            if (Translator.Setting.OverlayWindow.Opacity - StyleConsts.DELTA_OPACITY > StyleConsts.MIN_OPACITY)
+                Translator.Setting.OverlayWindow.Opacity -= StyleConsts.DELTA_OPACITY;
             else
-                _setting.OverlayWindow.Opacity = StyleConsts.MIN_OPACITY;
+                Translator.Setting.OverlayWindow.Opacity = StyleConsts.MIN_OPACITY;
             ApplyBackgroundOpacity();
         }
 
         private void BackgroundColorCycle_Click(object sender, RoutedEventArgs e)
         {
-            _setting.OverlayWindow.BackgroundColor++;
-            if (_setting.OverlayWindow.BackgroundColor > ColorEnum.Black)
-                _setting.OverlayWindow.BackgroundColor = ColorEnum.White;
-            BorderBackground.Background = colorMap[_setting.OverlayWindow.BackgroundColor];
+            Translator.Setting.OverlayWindow.BackgroundColor++;
+            if (Translator.Setting.OverlayWindow.BackgroundColor > ColorEnum.Black)
+                Translator.Setting.OverlayWindow.BackgroundColor = ColorEnum.White;
+            BorderBackground.Background = colorMap[Translator.Setting.OverlayWindow.BackgroundColor];
 
-            BorderBackground.Opacity = _setting.OverlayWindow.Opacity;
+            BorderBackground.Opacity = Translator.Setting.OverlayWindow.Opacity;
             ApplyBackgroundOpacity();
         }
 
@@ -280,19 +262,19 @@ namespace LiveCaptionsTranslator
             if (onlyMode == CaptionVisible.SubtitleOnly)
             {
                 // (0) Subtitle + Translation
-                symbolIcon!.Symbol = SymbolRegular.PanelBottom20;
+                symbolIcon.Symbol = SymbolRegular.PanelBottom20;
                 OnlyMode = CaptionVisible.Both;
             }
             else if (onlyMode == CaptionVisible.Both)
             {
                 // (1) Translation Only
-                symbolIcon!.Symbol = SymbolRegular.PanelTopExpand20;
+                symbolIcon.Symbol = SymbolRegular.PanelTopExpand20;
                 OnlyMode = CaptionVisible.TranslationOnly;
             }
             else
             {
                 // (2) Subtitle Only
-                symbolIcon!.Symbol = SymbolRegular.PanelTopContract20;
+                symbolIcon.Symbol = SymbolRegular.PanelTopContract20;
                 OnlyMode = CaptionVisible.SubtitleOnly;
             }
         }
@@ -357,22 +339,22 @@ namespace LiveCaptionsTranslator
         {
             Dispatcher.BeginInvoke(new Action(() =>
             {
-                OriginalCaption.FontSize = _setting.OverlayWindow.FontSize;
+                OriginalCaption.FontSize = Translator.Setting.OverlayWindow.FontSize;
                 TranslatedCaption.FontSize = (int)(OriginalCaption.FontSize * 1.25);
             }), DispatcherPriority.Background);
         }
 
         public void ApplyFontStroke()
         {
-            OriginalCaptionDecorator.StrokeThickness = _setting.OverlayWindow.FontStroke;
-            TranslatedCaptionDecorator.StrokeThickness = _setting.OverlayWindow.FontStroke;
+            OriginalCaptionDecorator.StrokeThickness = Translator.Setting.OverlayWindow.FontStroke;
+            TranslatedCaptionDecorator.StrokeThickness = Translator.Setting.OverlayWindow.FontStroke;
         }
 
         public void ApplyBackgroundOpacity()
         {
             Color color = ((SolidColorBrush)BorderBackground.Background).Color;
             BorderBackground.Background = new SolidColorBrush(Color.FromArgb(
-                (byte)_setting.OverlayWindow.Opacity, color.R, color.G, color.B));
+                (byte)Translator.Setting.OverlayWindow.Opacity, color.R, color.G, color.B));
         }
 
         private void UpdateTranslationColor(SolidColorBrush brush)

--- a/src/windows/WelcomeWindow.xaml
+++ b/src/windows/WelcomeWindow.xaml
@@ -4,9 +4,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:LiveCaptionsTranslator"
+    xmlns:models="clr-namespace:LiveCaptionsTranslator.models"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    Title="{DynamicResource W0}"
+    Title="{DynamicResource WelcomeWindow_GetStarted}"
     Width="700"
     MaxWidth="800"
     Height="540"
@@ -31,7 +32,7 @@
             ShowMinimize="False">
             <ui:TitleBar.Header>
                 <ui:TextBlock Padding="15,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap">
-                    <Run Text="{DynamicResource W0}" />
+                    <Run Text="{DynamicResource WelcomeWindow_GetStarted}" />
                 </ui:TextBlock>
             </ui:TitleBar.Header>
         </ui:TitleBar>
@@ -42,7 +43,7 @@
                 HorizontalAlignment="Left"
                 FontSize="24"
                 FontWeight="Bold"
-                Text="{DynamicResource W1}"
+                Text="{DynamicResource WelcomeWindow_Title}"
                 TextAlignment="Left"
                 TextWrapping="Wrap" />
 
@@ -50,52 +51,52 @@
                 Margin="20,0,20,0"
                 TextAlignment="Left"
                 TextWrapping="Wrap">
-                <Run Text="{DynamicResource W2}" />
+                <Run Text="{DynamicResource WelcomeWindow_Intro_Base}" />
                 <Run Text="&#x0A;" />
-                <Run Text="{DynamicResource W3}" />
+                <Run Text="{DynamicResource WelcomeWindow_Intro_StepsLead}" />
                 <Run Text="&#x0A;" />
 
                 <!-- Step 1 -->
-                <Run Text="{DynamicResource W4}" />
+                <Run Text="{DynamicResource WelcomeWindow_Step1}" />
                 <Run Text="&#x0A;" />
 
                 <!-- Step 2 -->
-                <Run Text="{DynamicResource W5}" />
+                <Run Text="{DynamicResource WelcomeWindow_Step2_Click}" />
                 <Run Text="&#xA0;" />
-                <Run FontWeight="Bold" Text="{DynamicResource W6}" />
+                <Run FontWeight="Bold" Text="{DynamicResource WelcomeWindow_Step2_Gear}" />
                 <Run Text="&#xA0;" />
-                <Run Text="{DynamicResource W7}" />
+                <Run Text="{DynamicResource WelcomeWindow_Step2_Instruction}" />
                 <Run Text="&#xA0;" />
-                <Run FontWeight="Bold" Text="{DynamicResource W8}" />
+                <Run FontWeight="Bold" Text="{DynamicResource WelcomeWindow_Step2_Position}" />
                 <Run Text=".&#x0A;" />
 
                 <!-- Step 3 -->
-                <Run Text="{DynamicResource W9}" />
+                <Run Text="{DynamicResource WelcomeWindow_Step3_Click}" />
                 <Run Text="&#xA0;" />
-                <Run FontWeight="Bold" Text="{DynamicResource W10}" />
+                <Run FontWeight="Bold" Text="{DynamicResource WelcomeWindow_Step3_HideQuoted}" />
                 <Run Text="&#xA0;" />
-                <Run Text="{DynamicResource W11}" />
+                <Run Text="{DynamicResource WelcomeWindow_Step3_Instruction}" />
                 <Run Text="&#x0A;" />
 
                 <Run Text="&#x0A;" />
-                <Run Text="{DynamicResource W12}" />
+                <Run Text="{DynamicResource WelcomeWindow_AutoOpen}" />
                 <Run Text="&#x0A;" />
-                <Run Text="{DynamicResource W13}" />
+                <Run Text="{DynamicResource WelcomeWindow_Enjoy}" />
                 <Run Text="&#x0A;" />
 
                 <Run Text="&#x0A;" />
-                <Run Text="{DynamicResource W14}" />
+                <Run Text="{DynamicResource WelcomeWindow_WikiLead}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn/LiveCaptions-Translator/wiki" RequestNavigate="Hyperlink_RequestNavigate">
-                    <Run Text="{DynamicResource W15}" />
+                    <Run Text="{DynamicResource WelcomeWindow_WikiUrl}" />
                 </Hyperlink>
 
                 <Run Text="&#x0A;" />
                 <Run Text="&#x0A;" />
-                <Run FontWeight="Bold" Text="{DynamicResource W16}" />
+                <Run FontWeight="Bold" Text="{DynamicResource WelcomeWindow_TipLead}" />
                 <Run Text="&#x0A;" />
-                <Run Text="{DynamicResource W17}" />
-                <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource W18}" />
-                <Run Text="{DynamicResource W19}" />
+                <Run Text="{DynamicResource WelcomeWindow_Tip_IfYouWantToChange}" />
+                <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource WelcomeWindow_Tip_SourceLanguage}" />
+                <Run Text="{DynamicResource WelcomeWindow_Tip_Instruction}" />
             </ui:TextBlock>
 
             <!-- Bottom row: language selector (left) + close button (center) -->
@@ -114,30 +115,10 @@
                         Height="30"
                         Padding="10,4,10,7"
                         FontSize="13.3"
-                        SelectionChanged="WelcomeLanguageBox_SelectionChanged">
-                        <ComboBoxItem Content="English" />
-                        <ComboBoxItem Content="&#x7B80;&#x4F53;&#x4E2D;&#x6587;" />
-                        <ComboBoxItem Content="&#x627;&#x644;&#x639;&#x631;&#x628;&#x64A;&#x629;" />
-                        <ComboBoxItem Content="&#x9AC;&#x9BE;&#x982;&#x9B2;&#x9BE;" />
-
-                        <ComboBoxItem Content="&#x10C;e&#x161;tina" />
-                        <ComboBoxItem Content="Deutsch" />
-                        <ComboBoxItem Content="Espa&#xF1;ol (M&#xE9;xico)" />
-                        <ComboBoxItem Content="Fran&#xE7;ais" />
-                        <ComboBoxItem Content="Italiano" />
-                        <ComboBoxItem Content="&#x65E5;&#x672C;&#x8A9E;" />
-                        <ComboBoxItem Content="&#xD55C;&#xAD6D;&#xC5B4;" />
-                        <ComboBoxItem Content="Lietuvi&#x173;" />
-                        <ComboBoxItem Content="Nederlands" />
-                        <ComboBoxItem Content="Polski" />
-                        <ComboBoxItem Content="Portugu&#xEA;s (Brasil)" />
-                        <ComboBoxItem Content="Portugu&#xEA;s (Portugal)" />
-                        <ComboBoxItem Content="&#x420;&#x443;&#x441;&#x441;&#x43A;&#x438;&#x439;" />
-                        <ComboBoxItem Content="Svenska" />
-                        <ComboBoxItem Content="T&#xFC;rk&#xE7;e" />
-                        <ComboBoxItem Content="Ti&#x1EBF;ng Vi&#x1EC7;t" />
-                        <ComboBoxItem Content="&#x7E41;&#x9AD4;&#x4E2D;&#x6587; (&#x53F0;&#x7063;)" />
-                    </ComboBox>
+                        ItemsSource="{x:Static models:LanguageCatalog.SupportedUiLanguages}"
+                        DisplayMemberPath="DisplayName"
+                        SelectedValuePath="CultureCode"
+                        SelectionChanged="WelcomeLanguageBox_SelectionChanged" />
                 </StackPanel>
 
                 <ui:Button
@@ -145,7 +126,7 @@
                     Padding="30,10,30,10"
                     HorizontalAlignment="Center"
                     Click="CloseButton_Click"
-                    Content="{DynamicResource W20}" />
+                    Content="{DynamicResource WelcomeWindow_Button_Confirm}" />
             </Grid>
         </StackPanel>
     </Grid>

--- a/src/windows/WelcomeWindow.xaml
+++ b/src/windows/WelcomeWindow.xaml
@@ -6,9 +6,10 @@
     xmlns:local="clr-namespace:LiveCaptionsTranslator"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    Title="Getting Started"
+    Title="{DynamicResource W0}"
     Width="700"
-    Height="490"
+    MaxWidth="800"
+    Height="540"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     ExtendsContentIntoTitleBar="True"
@@ -29,8 +30,8 @@
             ShowMaximize="False"
             ShowMinimize="False">
             <ui:TitleBar.Header>
-                <ui:TextBlock Padding="15,0,0,0" VerticalAlignment="Center">
-                    Getting Started
+                <ui:TextBlock Padding="15,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap">
+                    <Run Text="{DynamicResource W0}" />
                 </ui:TextBlock>
             </ui:TitleBar.Header>
         </ui:TitleBar>
@@ -41,40 +42,111 @@
                 HorizontalAlignment="Left"
                 FontSize="24"
                 FontWeight="Bold"
-                Text="Welcome to LiveCaptions Translator!"
-                TextAlignment="Left" />
+                Text="{DynamicResource W1}"
+                TextAlignment="Left"
+                TextWrapping="Wrap" />
+
             <ui:TextBlock
-                Margin="20,10,20,10"
+                Margin="20,0,20,0"
                 TextAlignment="Left"
                 TextWrapping="Wrap">
-                <Run Text="LiveCaptions Translator is based on Windows LiveCaptions." />
-                <Run Text="Before your first running, you need to configure it according to the following steps:&#x0A;" />
-                <Run Text="&#x0A;1. Open Windows LiveCaptions and follow the guide to download the necessary files for on-device speech recognition and language packs." />
-                <Run Text="&#x0A;2. Click the" />
-                <Run FontWeight="Bold" Text="⚙️ gear" />
-                <Run Text="icon in Windows LiveCaptions to open the settings menu, and select" />
-                <Run FontWeight="Bold" Text="&quot;Position &gt; Overlaid on screen&quot;" />
-                <Run Text=".&#x0A;3. Click the" />
-                <Run FontWeight="Bold" Text="&quot;Hide&quot;" />
-                <Run Text="button located in the setting page of LiveCaptions Translator to hide Windows LiveCaptions.&#x0A;" />
-                <Run Text="&#x0A;The program has automatically navigated to the setting page and opened Windows LiveCaptions." />
-                <Run Text="After completing the configuration, you can switch back to the main page and enjoy real-time audio translation.&#x0A;" />
-                <Run Text="&#x0A;For more details, visit our wiki: " />
+                <Run Text="{DynamicResource W2}" />
+                <Run Text="&#x0A;" />
+                <Run Text="{DynamicResource W3}" />
+                <Run Text="&#x0A;" />
+
+                <!-- Step 1 -->
+                <Run Text="{DynamicResource W4}" />
+                <Run Text="&#x0A;" />
+
+                <!-- Step 2 -->
+                <Run Text="{DynamicResource W5}" />
+                <Run Text="&#xA0;" />
+                <Run FontWeight="Bold" Text="{DynamicResource W6}" />
+                <Run Text="&#xA0;" />
+                <Run Text="{DynamicResource W7}" />
+                <Run Text="&#xA0;" />
+                <Run FontWeight="Bold" Text="{DynamicResource W8}" />
+                <Run Text=".&#x0A;" />
+
+                <!-- Step 3 -->
+                <Run Text="{DynamicResource W9}" />
+                <Run Text="&#xA0;" />
+                <Run FontWeight="Bold" Text="{DynamicResource W10}" />
+                <Run Text="&#xA0;" />
+                <Run Text="{DynamicResource W11}" />
+                <Run Text="&#x0A;" />
+
+                <Run Text="&#x0A;" />
+                <Run Text="{DynamicResource W12}" />
+                <Run Text="&#x0A;" />
+                <Run Text="{DynamicResource W13}" />
+                <Run Text="&#x0A;" />
+
+                <Run Text="&#x0A;" />
+                <Run Text="{DynamicResource W14}" />
                 <Hyperlink NavigateUri="https://github.com/SakiRinn/LiveCaptions-Translator/wiki" RequestNavigate="Hyperlink_RequestNavigate">
-                    https://github.com/SakiRinn/LiveCaptions-Translator/wiki
+                    <Run Text="{DynamicResource W15}" />
                 </Hyperlink>
-                <Run FontWeight="Bold" Text="&#x0A;&#x0A;Tip:" />
-                <Run Text="To change the" />
-                <Run FontWeight="DemiBold" TextDecorations="Underline" Text="Source Language" />
-                <Run Text=", please [Show] LiveCaptions on the setting page and do it in Windows LiveCaptions." />
+
+                <Run Text="&#x0A;" />
+                <Run Text="&#x0A;" />
+                <Run FontWeight="Bold" Text="{DynamicResource W16}" />
+                <Run Text="&#x0A;" />
+                <Run Text="{DynamicResource W17}" />
+                <Run FontWeight="DemiBold" TextDecorations="Underline" Text="{DynamicResource W18}" />
+                <Run Text="{DynamicResource W19}" />
             </ui:TextBlock>
 
-            <ui:Button
-                Margin="0,10,0,0"
-                Padding="30,10,30,10"
-                HorizontalAlignment="Center"
-                Click="CloseButton_Click"
-                Content="I have fully understood and configured." />
+            <!-- Bottom row: language selector (left) + close button (center) -->
+            <Grid Margin="20,10,20,20">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                    <ui:SymbolIcon Symbol="Globe20" Margin="0,0,8,0" />
+                    <ComboBox
+                        x:Name="WelcomeLanguageBox"
+                        Width="150"
+                        Height="30"
+                        Padding="10,4,10,7"
+                        FontSize="13.3"
+                        SelectionChanged="WelcomeLanguageBox_SelectionChanged">
+                        <ComboBoxItem Content="English" />
+                        <ComboBoxItem Content="&#x7B80;&#x4F53;&#x4E2D;&#x6587;" />
+                        <ComboBoxItem Content="&#x627;&#x644;&#x639;&#x631;&#x628;&#x64A;&#x629;" />
+                        <ComboBoxItem Content="&#x9AC;&#x9BE;&#x982;&#x9B2;&#x9BE;" />
+
+                        <ComboBoxItem Content="&#x10C;e&#x161;tina" />
+                        <ComboBoxItem Content="Deutsch" />
+                        <ComboBoxItem Content="Espa&#xF1;ol (M&#xE9;xico)" />
+                        <ComboBoxItem Content="Fran&#xE7;ais" />
+                        <ComboBoxItem Content="Italiano" />
+                        <ComboBoxItem Content="&#x65E5;&#x672C;&#x8A9E;" />
+                        <ComboBoxItem Content="&#xD55C;&#xAD6D;&#xC5B4;" />
+                        <ComboBoxItem Content="Lietuvi&#x173;" />
+                        <ComboBoxItem Content="Nederlands" />
+                        <ComboBoxItem Content="Polski" />
+                        <ComboBoxItem Content="Portugu&#xEA;s (Brasil)" />
+                        <ComboBoxItem Content="Portugu&#xEA;s (Portugal)" />
+                        <ComboBoxItem Content="&#x420;&#x443;&#x441;&#x441;&#x43A;&#x438;&#x439;" />
+                        <ComboBoxItem Content="Svenska" />
+                        <ComboBoxItem Content="T&#xFC;rk&#xE7;e" />
+                        <ComboBoxItem Content="Ti&#x1EBF;ng Vi&#x1EC7;t" />
+                        <ComboBoxItem Content="&#x7E41;&#x9AD4;&#x4E2D;&#x6587; (&#x53F0;&#x7063;)" />
+                    </ComboBox>
+                </StackPanel>
+
+                <ui:Button
+                    Grid.Column="1"
+                    Padding="30,10,30,10"
+                    HorizontalAlignment="Center"
+                    Click="CloseButton_Click"
+                    Content="{DynamicResource W20}" />
+            </Grid>
         </StackPanel>
     </Grid>
 </ui:FluentWindow>

--- a/src/windows/WelcomeWindow.xaml.cs
+++ b/src/windows/WelcomeWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Navigation;
 using Wpf.Ui.Controls;
 using Wpf.Ui.Appearance;
+using LiveCaptionsTranslator.utils;
 
 namespace LiveCaptionsTranslator
 {
@@ -21,23 +22,7 @@ namespace LiveCaptionsTranslator
                 SystemThemeWatcher.Watch(this, WindowBackdropType.Mica, true);
                 InitializeLanguageSelection();
 
-                // Auto-size on first show to match current localization (startup).
-                Dispatcher.BeginInvoke(new Action(() =>
-                {
-                    var prev = SizeToContent;
-                    SizeToContent = SizeToContent.WidthAndHeight;
-                    UpdateLayout();
-
-                    const double minW = 650;
-                    const double maxW = 980;
-                    const double minH = 420;
-                    const double maxH = 800;
-
-                    Width = Math.Max(minW, Math.Min(maxW, ActualWidth));
-                    Height = Math.Max(minH, Math.Min(maxH, ActualHeight));
-
-                    SizeToContent = prev;
-                }), System.Windows.Threading.DispatcherPriority.Loaded);
+                RequestAutoFitHeight();
             };
 
             Closed += (_, __) =>
@@ -46,184 +31,14 @@ namespace LiveCaptionsTranslator
             };
         }
 
-        public void SyncLanguageSelectionFromSetting()
+        public void RequestAutoFitHeight()
         {
-            if (!IsLoaded)
-                return;
-
-            _suppressLanguageSelectionChanged = true;
-            try
-            {
-                var current = Translator.Setting?.UiLanguageFileName;
-                WelcomeLanguageBox.SelectedIndex = current?.ToLowerInvariant() switch
-                {
-                    "zh-cn.xaml" => 1,
-                    "ar.xaml" => 2,
-                    "bn.xaml" => 3,
-                    "cs-cz.xaml" => 4,
-                    "de-de.xaml" => 5,
-                    "es-mx.xaml" => 6,
-                    "fr-fr.xaml" => 7,
-                    "it-it.xaml" => 8,
-                    "ja-jp.xaml" => 9,
-                    "ko-kr.xaml" => 10,
-                    "lt-lt.xaml" => 11,
-                    "nl-nl.xaml" => 12,
-                    "pl-pl.xaml" => 13,
-                    "pt-br.xaml" => 14,
-                    "pt-pt.xaml" => 15,
-                    "ru-ru.xaml" => 16,
-                    "sv-se.xaml" => 17,
-                    "tr-tr.xaml" => 18,
-                    "vi-vn.xaml" => 19,
-                    "zh-tw.xaml" => 20,
-                    _ => 0
-                };
-            }
-            finally
-            {
-                _suppressLanguageSelectionChanged = false;
-            }
-        }
-
-        private void PersistCurrentUiLanguage()
-        {
-            var fileName = WelcomeLanguageBox.SelectedIndex switch
-            {
-                1 => "zh-cn.xaml",
-                2 => "ar.xaml",
-                3 => "bn.xaml",
-                4 => "cs-cz.xaml",
-                5 => "de-de.xaml",
-                6 => "es-mx.xaml",
-                7 => "fr-fr.xaml",
-                8 => "it-it.xaml",
-                9 => "ja-jp.xaml",
-                10 => "ko-kr.xaml",
-                11 => "lt-lt.xaml",
-                12 => "nl-nl.xaml",
-                13 => "pl-pl.xaml",
-                14 => "pt-br.xaml",
-                15 => "pt-pt.xaml",
-                16 => "ru-ru.xaml",
-                17 => "sv-se.xaml",
-                18 => "tr-tr.xaml",
-                19 => "vi-vn.xaml",
-                20 => "zh-tw.xaml",
-                _ => "en-us.xaml"
-            };
-
-            if (Translator.Setting is not null)
-                Translator.Setting.UiLanguageFileName = fileName;
-        }
-
-        private void InitializeLanguageSelection()
-        {
-            _suppressLanguageSelectionChanged = true;
-            try
-            {
-                var current = Translator.Setting?.UiLanguageFileName;
-                if (string.IsNullOrWhiteSpace(current))
-                    current = GetActiveLocalizationFileName();
-
-                // Ensure current dictionary is active for this window
-                ActivateLocalizationDictionary(current);
-
-                WelcomeLanguageBox.SelectedIndex = current.ToLowerInvariant() switch
-                {
-                    "zh-cn.xaml" => 1,
-                    "ar.xaml" => 2,
-                    "bn.xaml" => 3,
-                    "cs-cz.xaml" => 4,
-                    "de-de.xaml" => 5,
-                    "es-mx.xaml" => 6,
-                    "fr-fr.xaml" => 7,
-                    "it-it.xaml" => 8,
-                    "ja-jp.xaml" => 9,
-                    "ko-kr.xaml" => 10,
-                    "lt-lt.xaml" => 11,
-                    "nl-nl.xaml" => 12,
-                    "pl-pl.xaml" => 13,
-                    "pt-br.xaml" => 14,
-                    "pt-pt.xaml" => 15,
-                    "ru-ru.xaml" => 16,
-                    "sv-se.xaml" => 17,
-                    "tr-tr.xaml" => 18,
-                    "vi-vn.xaml" => 19,
-                    "zh-tw.xaml" => 20,
-                    _ => 0
-                };
-            }
-            finally
-            {
-                _suppressLanguageSelectionChanged = false;
-            }
-        }
-
-        private void WelcomeLanguageBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (_suppressLanguageSelectionChanged || !IsLoaded)
-                return;
-
-            string fileName = WelcomeLanguageBox.SelectedIndex switch
-            {
-                1 => "zh-cn.xaml",
-                2 => "ar.xaml",
-                3 => "bn.xaml",
-                4 => "cs-cz.xaml",
-                5 => "de-de.xaml",
-                6 => "es-mx.xaml",
-                7 => "fr-fr.xaml",
-                8 => "it-it.xaml",
-                9 => "ja-jp.xaml",
-                10 => "ko-kr.xaml",
-                11 => "lt-lt.xaml",
-                12 => "nl-nl.xaml",
-                13 => "pl-pl.xaml",
-                14 => "pt-br.xaml",
-                15 => "pt-pt.xaml",
-                16 => "ru-ru.xaml",
-                17 => "sv-se.xaml",
-                18 => "tr-tr.xaml",
-                19 => "vi-vn.xaml",
-                20 => "zh-tw.xaml",
-                _ => "en-us.xaml"
-            };
-
-            ActivateLocalizationDictionary(fileName);
-            ApplyFlowDirectionForLocalization(fileName);
-
-            if (Translator.Setting is not null)
-                Translator.Setting.UiLanguageFileName = fileName;
-
-            // Sync SettingPage dropdown if it exists anywhere in open windows.
-            foreach (Window w in Application.Current.Windows)
-            {
-                if (w is not FrameworkElement root)
-                    continue;
-
-                var sp = FindDescendant<SettingPage>(root);
-                if (sp is null)
-                    continue;
-
-                sp.SyncUILanguageSelectionFromSetting();
-                // Also request SettingPage/MainWindow to re-measure and auto-fit width.
-                sp.RequestAutoFitWidth();
-            }
-
-            // Refresh visual tree so DynamicResource re-evaluates for this window.
-            var content = Content;
-            Content = null;
-            Content = content;
-
-            // Auto-size like SettingPage: measure both width and height and clamp.
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 var prev = SizeToContent;
                 SizeToContent = SizeToContent.WidthAndHeight;
                 UpdateLayout();
 
-                // Clamp to avoid extreme resize.
                 const double minW = 650;
                 const double maxW = 980;
                 const double minH = 420;
@@ -236,119 +51,79 @@ namespace LiveCaptionsTranslator
             }), System.Windows.Threading.DispatcherPriority.Loaded);
         }
 
-        private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject
+        public void SyncLanguageSelectionFromSetting()
         {
-            int count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
-            for (int i = 0; i < count; i++)
+            if (!IsLoaded)
+                return;
+
+            _suppressLanguageSelectionChanged = true;
+            try
             {
-                var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
-                if (child is T typed)
-                    return typed;
-
-                var found = FindDescendant<T>(child);
-                if (found is not null)
-                    return found;
+                var current = Translator.Setting?.UiLanguageFileName;
+                WelcomeLanguageBox.SelectedIndex = LocalizationHelper.GetComboIndexFromFileName(current);
             }
-
-            return null;
+            finally
+            {
+                _suppressLanguageSelectionChanged = false;
+            }
         }
 
-        private static void ActivateLocalizationDictionary(string fileName)
+        private void PersistCurrentUiLanguage()
         {
-            var merged = Application.Current.Resources.MergedDictionaries;
-
-            int? index = null;
-            for (int i = 0; i < merged.Count; i++)
-            {
-                var src = merged[i].Source?.ToString();
-                if (src is null)
-                    continue;
-
-                if (src.Contains($"localization/{fileName}", System.StringComparison.OrdinalIgnoreCase))
-                {
-                    index = i;
-                    break;
-                }
-            }
-
-            if (index is null)
-                throw new System.IO.IOException($"Cannot locate resource 'localization/{fileName}'.");
-
-            var target = merged[index.Value];
-            merged.RemoveAt(index.Value);
-            merged.Add(target);
+            var fileName = LocalizationHelper.GetFileNameFromComboIndex(WelcomeLanguageBox.SelectedIndex);
+            if (Translator.Setting is not null)
+                Translator.Setting.UiLanguageFileName = fileName;
         }
 
-        private static string GetActiveLocalizationFileName()
+        private void InitializeLanguageSelection()
         {
-            for (int i = Application.Current.Resources.MergedDictionaries.Count - 1; i >= 0; i--)
+            _suppressLanguageSelectionChanged = true;
+            try
             {
-                var src = Application.Current.Resources.MergedDictionaries[i].Source?.ToString();
-                if (src is null)
-                    continue;
+                var current = Translator.Setting?.UiLanguageFileName;
+                if (string.IsNullOrWhiteSpace(current))
+                    current = LocalizationHelper.GetActiveLocalizationFileName();
 
-                if (src.Contains("localization/zh-cn.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "zh-cn.xaml";
-                if (src.Contains("localization/ar.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "ar.xaml";
-                if (src.Contains("localization/bn.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "bn.xaml";
-
-                if (src.Contains("localization/zh-tw.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "zh-tw.xaml";
-                if (src.Contains("localization/cs-cz.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "cs-cz.xaml";
-                if (src.Contains("localization/de-de.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "de-de.xaml";
-                if (src.Contains("localization/es-mx.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "es-mx.xaml";
-                if (src.Contains("localization/fr-fr.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "fr-fr.xaml";
-                if (src.Contains("localization/it-it.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "it-it.xaml";
-                if (src.Contains("localization/ja-jp.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "ja-jp.xaml";
-                if (src.Contains("localization/ko-kr.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "ko-kr.xaml";
-                if (src.Contains("localization/lt-lt.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "lt-lt.xaml";
-                if (src.Contains("localization/nl-nl.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "nl-nl.xaml";
-                if (src.Contains("localization/pl-pl.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "pl-pl.xaml";
-                if (src.Contains("localization/pt-br.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "pt-br.xaml";
-                if (src.Contains("localization/pt-pt.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "pt-pt.xaml";
-                if (src.Contains("localization/ru-ru.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "ru-ru.xaml";
-                if (src.Contains("localization/sv-se.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "sv-se.xaml";
-                if (src.Contains("localization/tr-tr.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "tr-tr.xaml";
-                if (src.Contains("localization/vi-vn.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "vi-vn.xaml";
-
-                if (src.Contains("localization/en-us.xaml", System.StringComparison.OrdinalIgnoreCase))
-                    return "en-us.xaml";
+                LocalizationHelper.ActivateLocalizationDictionary(current);
+                WelcomeLanguageBox.SelectedIndex = LocalizationHelper.GetComboIndexFromFileName(current);
             }
-
-            return "en-us.xaml";
+            finally
+            {
+                _suppressLanguageSelectionChanged = false;
+            }
         }
 
-        private static void ApplyFlowDirectionForLocalization(string fileName)
+        private void WelcomeLanguageBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            bool isArabic = string.Equals(fileName, "ar.xaml", System.StringComparison.OrdinalIgnoreCase);
+            if (_suppressLanguageSelectionChanged || !IsLoaded)
+                return;
 
-            // Apply to all open windows (including FluentWindow title bars) as requested.
+            string fileName = LocalizationHelper.GetFileNameFromComboIndex(WelcomeLanguageBox.SelectedIndex);
+
+            LocalizationHelper.ActivateLocalizationDictionary(fileName);
+            LocalizationHelper.ApplyFlowDirectionForLocalization(fileName, keepOverlayWindowLtr: false);
+
+            if (Translator.Setting is not null)
+                Translator.Setting.UiLanguageFileName = fileName;
+
             foreach (Window w in Application.Current.Windows)
             {
-                if (w is FrameworkElement fe)
-                {
-                    fe.FlowDirection = isArabic ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
-                    fe.Language = System.Windows.Markup.XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
-                }
+                if (w is not FrameworkElement root)
+                    continue;
+
+                var sp = LocalizationHelper.FindDescendant<SettingPage>(root);
+                if (sp is null)
+                    continue;
+
+                sp.SyncUILanguageSelectionFromSetting();
+                sp.RequestAutoFitWidth();
             }
+
+            var content = Content;
+            Content = null;
+            Content = content;
+
+            RequestAutoFitHeight();
         }
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)

--- a/src/windows/WelcomeWindow.xaml.cs
+++ b/src/windows/WelcomeWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Diagnostics;
+using System.Windows.Controls;
 using System.Windows.Navigation;
 using Wpf.Ui.Controls;
 using Wpf.Ui.Appearance;
@@ -8,6 +9,8 @@ namespace LiveCaptionsTranslator
 {
     public partial class WelcomeWindow : FluentWindow
     {
+        private bool _suppressLanguageSelectionChanged;
+
         public WelcomeWindow()
         {
             InitializeComponent();
@@ -15,12 +18,337 @@ namespace LiveCaptionsTranslator
 
             Loaded += (s, e) =>
             {
-                SystemThemeWatcher.Watch(
-                    this,
-                    WindowBackdropType.Mica,
-                    true
-                );
+                SystemThemeWatcher.Watch(this, WindowBackdropType.Mica, true);
+                InitializeLanguageSelection();
+
+                // Auto-size on first show to match current localization (startup).
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    var prev = SizeToContent;
+                    SizeToContent = SizeToContent.WidthAndHeight;
+                    UpdateLayout();
+
+                    const double minW = 650;
+                    const double maxW = 980;
+                    const double minH = 420;
+                    const double maxH = 800;
+
+                    Width = Math.Max(minW, Math.Min(maxW, ActualWidth));
+                    Height = Math.Max(minH, Math.Min(maxH, ActualHeight));
+
+                    SizeToContent = prev;
+                }), System.Windows.Threading.DispatcherPriority.Loaded);
             };
+
+            Closed += (_, __) =>
+            {
+                // No-op: language is persisted immediately when user changes the dropdown.
+            };
+        }
+
+        public void SyncLanguageSelectionFromSetting()
+        {
+            if (!IsLoaded)
+                return;
+
+            _suppressLanguageSelectionChanged = true;
+            try
+            {
+                var current = Translator.Setting?.UiLanguageFileName;
+                WelcomeLanguageBox.SelectedIndex = current?.ToLowerInvariant() switch
+                {
+                    "zh-cn.xaml" => 1,
+                    "ar.xaml" => 2,
+                    "bn.xaml" => 3,
+                    "cs-cz.xaml" => 4,
+                    "de-de.xaml" => 5,
+                    "es-mx.xaml" => 6,
+                    "fr-fr.xaml" => 7,
+                    "it-it.xaml" => 8,
+                    "ja-jp.xaml" => 9,
+                    "ko-kr.xaml" => 10,
+                    "lt-lt.xaml" => 11,
+                    "nl-nl.xaml" => 12,
+                    "pl-pl.xaml" => 13,
+                    "pt-br.xaml" => 14,
+                    "pt-pt.xaml" => 15,
+                    "ru-ru.xaml" => 16,
+                    "sv-se.xaml" => 17,
+                    "tr-tr.xaml" => 18,
+                    "vi-vn.xaml" => 19,
+                    "zh-tw.xaml" => 20,
+                    _ => 0
+                };
+            }
+            finally
+            {
+                _suppressLanguageSelectionChanged = false;
+            }
+        }
+
+        private void PersistCurrentUiLanguage()
+        {
+            var fileName = WelcomeLanguageBox.SelectedIndex switch
+            {
+                1 => "zh-cn.xaml",
+                2 => "ar.xaml",
+                3 => "bn.xaml",
+                4 => "cs-cz.xaml",
+                5 => "de-de.xaml",
+                6 => "es-mx.xaml",
+                7 => "fr-fr.xaml",
+                8 => "it-it.xaml",
+                9 => "ja-jp.xaml",
+                10 => "ko-kr.xaml",
+                11 => "lt-lt.xaml",
+                12 => "nl-nl.xaml",
+                13 => "pl-pl.xaml",
+                14 => "pt-br.xaml",
+                15 => "pt-pt.xaml",
+                16 => "ru-ru.xaml",
+                17 => "sv-se.xaml",
+                18 => "tr-tr.xaml",
+                19 => "vi-vn.xaml",
+                20 => "zh-tw.xaml",
+                _ => "en-us.xaml"
+            };
+
+            if (Translator.Setting is not null)
+                Translator.Setting.UiLanguageFileName = fileName;
+        }
+
+        private void InitializeLanguageSelection()
+        {
+            _suppressLanguageSelectionChanged = true;
+            try
+            {
+                var current = Translator.Setting?.UiLanguageFileName;
+                if (string.IsNullOrWhiteSpace(current))
+                    current = GetActiveLocalizationFileName();
+
+                // Ensure current dictionary is active for this window
+                ActivateLocalizationDictionary(current);
+
+                WelcomeLanguageBox.SelectedIndex = current.ToLowerInvariant() switch
+                {
+                    "zh-cn.xaml" => 1,
+                    "ar.xaml" => 2,
+                    "bn.xaml" => 3,
+                    "cs-cz.xaml" => 4,
+                    "de-de.xaml" => 5,
+                    "es-mx.xaml" => 6,
+                    "fr-fr.xaml" => 7,
+                    "it-it.xaml" => 8,
+                    "ja-jp.xaml" => 9,
+                    "ko-kr.xaml" => 10,
+                    "lt-lt.xaml" => 11,
+                    "nl-nl.xaml" => 12,
+                    "pl-pl.xaml" => 13,
+                    "pt-br.xaml" => 14,
+                    "pt-pt.xaml" => 15,
+                    "ru-ru.xaml" => 16,
+                    "sv-se.xaml" => 17,
+                    "tr-tr.xaml" => 18,
+                    "vi-vn.xaml" => 19,
+                    "zh-tw.xaml" => 20,
+                    _ => 0
+                };
+            }
+            finally
+            {
+                _suppressLanguageSelectionChanged = false;
+            }
+        }
+
+        private void WelcomeLanguageBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressLanguageSelectionChanged || !IsLoaded)
+                return;
+
+            string fileName = WelcomeLanguageBox.SelectedIndex switch
+            {
+                1 => "zh-cn.xaml",
+                2 => "ar.xaml",
+                3 => "bn.xaml",
+                4 => "cs-cz.xaml",
+                5 => "de-de.xaml",
+                6 => "es-mx.xaml",
+                7 => "fr-fr.xaml",
+                8 => "it-it.xaml",
+                9 => "ja-jp.xaml",
+                10 => "ko-kr.xaml",
+                11 => "lt-lt.xaml",
+                12 => "nl-nl.xaml",
+                13 => "pl-pl.xaml",
+                14 => "pt-br.xaml",
+                15 => "pt-pt.xaml",
+                16 => "ru-ru.xaml",
+                17 => "sv-se.xaml",
+                18 => "tr-tr.xaml",
+                19 => "vi-vn.xaml",
+                20 => "zh-tw.xaml",
+                _ => "en-us.xaml"
+            };
+
+            ActivateLocalizationDictionary(fileName);
+            ApplyFlowDirectionForLocalization(fileName);
+
+            if (Translator.Setting is not null)
+                Translator.Setting.UiLanguageFileName = fileName;
+
+            // Sync SettingPage dropdown if it exists anywhere in open windows.
+            foreach (Window w in Application.Current.Windows)
+            {
+                if (w is not FrameworkElement root)
+                    continue;
+
+                var sp = FindDescendant<SettingPage>(root);
+                if (sp is null)
+                    continue;
+
+                sp.SyncUILanguageSelectionFromSetting();
+                // Also request SettingPage/MainWindow to re-measure and auto-fit width.
+                sp.RequestAutoFitWidth();
+            }
+
+            // Refresh visual tree so DynamicResource re-evaluates for this window.
+            var content = Content;
+            Content = null;
+            Content = content;
+
+            // Auto-size like SettingPage: measure both width and height and clamp.
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                var prev = SizeToContent;
+                SizeToContent = SizeToContent.WidthAndHeight;
+                UpdateLayout();
+
+                // Clamp to avoid extreme resize.
+                const double minW = 650;
+                const double maxW = 980;
+                const double minH = 420;
+                const double maxH = 800;
+
+                Width = Math.Max(minW, Math.Min(maxW, ActualWidth));
+                Height = Math.Max(minH, Math.Min(maxH, ActualHeight));
+
+                SizeToContent = prev;
+            }), System.Windows.Threading.DispatcherPriority.Loaded);
+        }
+
+        private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject
+        {
+            int count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+            {
+                var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+                if (child is T typed)
+                    return typed;
+
+                var found = FindDescendant<T>(child);
+                if (found is not null)
+                    return found;
+            }
+
+            return null;
+        }
+
+        private static void ActivateLocalizationDictionary(string fileName)
+        {
+            var merged = Application.Current.Resources.MergedDictionaries;
+
+            int? index = null;
+            for (int i = 0; i < merged.Count; i++)
+            {
+                var src = merged[i].Source?.ToString();
+                if (src is null)
+                    continue;
+
+                if (src.Contains($"localization/{fileName}", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index is null)
+                throw new System.IO.IOException($"Cannot locate resource 'localization/{fileName}'.");
+
+            var target = merged[index.Value];
+            merged.RemoveAt(index.Value);
+            merged.Add(target);
+        }
+
+        private static string GetActiveLocalizationFileName()
+        {
+            for (int i = Application.Current.Resources.MergedDictionaries.Count - 1; i >= 0; i--)
+            {
+                var src = Application.Current.Resources.MergedDictionaries[i].Source?.ToString();
+                if (src is null)
+                    continue;
+
+                if (src.Contains("localization/zh-cn.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "zh-cn.xaml";
+                if (src.Contains("localization/ar.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "ar.xaml";
+                if (src.Contains("localization/bn.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "bn.xaml";
+
+                if (src.Contains("localization/zh-tw.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "zh-tw.xaml";
+                if (src.Contains("localization/cs-cz.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "cs-cz.xaml";
+                if (src.Contains("localization/de-de.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "de-de.xaml";
+                if (src.Contains("localization/es-mx.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "es-mx.xaml";
+                if (src.Contains("localization/fr-fr.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "fr-fr.xaml";
+                if (src.Contains("localization/it-it.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "it-it.xaml";
+                if (src.Contains("localization/ja-jp.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "ja-jp.xaml";
+                if (src.Contains("localization/ko-kr.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "ko-kr.xaml";
+                if (src.Contains("localization/lt-lt.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "lt-lt.xaml";
+                if (src.Contains("localization/nl-nl.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "nl-nl.xaml";
+                if (src.Contains("localization/pl-pl.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "pl-pl.xaml";
+                if (src.Contains("localization/pt-br.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "pt-br.xaml";
+                if (src.Contains("localization/pt-pt.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "pt-pt.xaml";
+                if (src.Contains("localization/ru-ru.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "ru-ru.xaml";
+                if (src.Contains("localization/sv-se.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "sv-se.xaml";
+                if (src.Contains("localization/tr-tr.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "tr-tr.xaml";
+                if (src.Contains("localization/vi-vn.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "vi-vn.xaml";
+
+                if (src.Contains("localization/en-us.xaml", System.StringComparison.OrdinalIgnoreCase))
+                    return "en-us.xaml";
+            }
+
+            return "en-us.xaml";
+        }
+
+        private static void ApplyFlowDirectionForLocalization(string fileName)
+        {
+            bool isArabic = string.Equals(fileName, "ar.xaml", System.StringComparison.OrdinalIgnoreCase);
+
+            // Apply to all open windows (including FluentWindow title bars) as requested.
+            foreach (Window w in Application.Current.Windows)
+            {
+                if (w is FrameworkElement fe)
+                {
+                    fe.FlowDirection = isArabic ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+                    fe.Language = System.Windows.Markup.XmlLanguage.GetLanguage(isArabic ? "ar" : "en");
+                }
+            }
         }
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
> **Note**: This PR follows up on a previously closed PR and focuses only on i18n/localization. Refer to PR [#229](https://github.com/SakiRinn/LiveCaptions-Translator/pull/229) for context.

効果:
[Preview Video](https://github.com/user-attachments/assets/272c7c65-9c7c-4b45-909c-349f9081fe0d)
<img width="819" height="603" alt="image" src="https://github.com/user-attachments/assets/fa4c1f76-f5db-462e-a4ad-95f1eedbbdad" />
<img width="963" height="604" alt="image" src="https://github.com/user-attachments/assets/6e71684d-bd82-480f-abd6-f28bc4abbfc2" />



1. Replaced hardcoded language switching with a data-driven approach.
The language list is now centrally managed in LocalizationHelper.cs.
The en-US language pack is treated as the fallback rather than being strictly equivalent to other language packs. Missing additional language packs or missing keys will not cause the application to break.
Keys that are not present in a selected language will not be updated during language switching and will typically fall back to the English version, improving robustness and long-term maintainability.

2.Language settings are managed via the UiLanguageFileName field in setting.json.
This value is updated at several key points in the application lifecycle and is stored on the first line of the configuration file

3.Experimental: RTL layout support for Arabic is partially implemented.
Due to incorrect mirroring of non-Arabic text and numbers, RTL is intentionally disabled for OverlayWindow to preserve core functionality

4.UI improvements: WelcomeWindow and SettingPage now auto-resize based on localized text length to avoid overflow; added Windows OS logo and a global icon.

5.AI usage disclosure:AI tools were used primarily to assist with localization-related tasks, such as extracting hardcoded strings, generating translations, and creating language resource files.Some AI-assisted null-safety fixes were included in an earlier iteration of this PR, but they have since been reverted to keep this PR focused strictly on i18n/localization.
