### PR TITLE
feat: Add `year` and `second` to `Timestamp` when exporting CSV

### DIFF
--- a/src/utils/HistoryLogger.cs
+++ b/src/utils/HistoryLogger.cs
@@ -231,7 +231,7 @@ namespace LiveCaptionsTranslator.utils
                     history.Add(new TranslationHistoryEntry
                     {
                         Timestamp = localTime.ToString("yyyy-MM-dd HH:mm:ss"),
-                        TimestampFull = localTime.ToString("MM/dd/yy, HH:mm:ss"),
+                        TimestampFull = localTime.ToString("yyyy-MM-dd HH:mm:ss"),
                         SourceText = reader.GetString(reader.GetOrdinal("SourceText")),
                         TranslatedText = reader.GetString(reader.GetOrdinal("TranslatedText")),
                         TargetLanguage = reader.GetString(reader.GetOrdinal("TargetLanguage")),

--- a/src/utils/HistoryLogger.cs
+++ b/src/utils/HistoryLogger.cs
@@ -230,7 +230,7 @@ namespace LiveCaptionsTranslator.utils
                     DateTime localTime = DateTimeOffset.FromUnixTimeSeconds((long)Convert.ToDouble(unixTime)).LocalDateTime;
                     history.Add(new TranslationHistoryEntry
                     {
-                        Timestamp = localTime.ToString("MM/dd HH:mm"),
+                        Timestamp = localTime.ToString("yyyy-MM-dd HH:mm:ss"),
                         TimestampFull = localTime.ToString("MM/dd/yy, HH:mm:ss"),
                         SourceText = reader.GetString(reader.GetOrdinal("SourceText")),
                         TranslatedText = reader.GetString(reader.GetOrdinal("TranslatedText")),

--- a/src/utils/HistoryLogger.cs
+++ b/src/utils/HistoryLogger.cs
@@ -132,8 +132,8 @@ namespace LiveCaptionsTranslator.utils
                         }
                         history.Add(new TranslationHistoryEntry
                         {
-                            Timestamp = localTime.ToString("MM/dd HH:mm"),
-                            TimestampFull = localTime.ToString("MM/dd/yy, HH:mm:ss"),
+                            Timestamp = localTime.ToString("yyyy-MM-dd HH:mm"),
+                            TimestampFull = localTime.ToString("yyyy-MM-dd HH:mm:ss"),
                             SourceText = reader.GetString(reader.GetOrdinal("SourceText")),
                             TranslatedText = reader.GetString(reader.GetOrdinal("TranslatedText")),
                             TargetLanguage = reader.GetString(reader.GetOrdinal("TargetLanguage")),
@@ -189,8 +189,8 @@ namespace LiveCaptionsTranslator.utils
                     DateTime localTime = DateTimeOffset.FromUnixTimeSeconds((long)Convert.ToDouble(unixTime)).LocalDateTime;
                     return new TranslationHistoryEntry
                     {
-                        Timestamp = localTime.ToString("MM/dd HH:mm"),
-                        TimestampFull = localTime.ToString("MM/dd/yy, HH:mm:ss"),
+                        Timestamp = localTime.ToString("yyyy-MM-dd HH:mm"),
+                        TimestampFull = localTime.ToString("yyyy-MM-dd HH:mm:ss"),
                         SourceText = reader.GetString(reader.GetOrdinal("SourceText")),
                         TranslatedText = reader.GetString(reader.GetOrdinal("TranslatedText")),
                         TargetLanguage = reader.GetString(reader.GetOrdinal("TargetLanguage")),


### PR DESCRIPTION
## Description

Previously, when exporting CSV, timestamps were converted to the format `MM/dd HH:mm`, missing the year and second information, which caused confusion when there was cross-year data and made it impossible to accurately distinguish the order of items.

## Change

Change to `yyyy-MM-dd HH:mm:ss` format for clearer time export.