### PR TITLE
Fix Switch Mode Button Tooltip Description

### DIFF
--- a/src/windows/OverlayWindow.xaml
+++ b/src/windows/OverlayWindow.xaml
@@ -191,7 +191,7 @@
                         Cursor="Hand"
                         Icon="{ui:SymbolIcon ArrowSyncCircle20,
                                              Filled=False}"
-                        ToolTip="Show only subtitles or translations" />
+                        ToolTip="Switch the order of subtitles and translations" />
                     <ui:Button
                         x:Name="ClickThrough"
                         Background="#FFAAAAAA"


### PR DESCRIPTION

The feature was recently implemented in https://github.com/SakiRinn/LiveCaptions-Translator/pull/227/commits/c806a6c28e992c0e552cf9ca04c18f98f06c9ae3 and functions well. However, its descriptive message "_Show only subtitles or translations_" is kind of misleading. I assume it's accidentally reusing the text from another button?

![Screenshot.png](https://i.imgur.com/4pubtLk.png)

The PR makes the wording a bit more precise.
