### PR TITLE
Allow main window to be resized narrower (MinWidth 750 -> 320)

### DIFF
--- a/src/windows/MainWindow.xaml
+++ b/src/windows/MainWindow.xaml
@@ -9,7 +9,7 @@
     Title="LiveCaptions Translator"
     Width="750"
     Height="170"
-    MinWidth="750"
+    MinWidth="320"
     MinHeight="170"
     Background="Transparent"
     ExtendsContentIntoTitleBar="True"


### PR DESCRIPTION
Useful when placing the window beside other content, e.g. next to a video player. Caption text already wraps, so narrower widths render fine.