### PR TITLE
Make original/translated caption panes resizable with a splitter

### DIFF
--- a/src/pages/CaptionPage.xaml
+++ b/src/pages/CaptionPage.xaml
@@ -13,6 +13,7 @@
     <Grid Margin="5,5,15,5">
         <Grid.RowDefinitions>
             <RowDefinition x:Name="OriginalCaption_Row" Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition x:Name="TranslatedCaption_Row" Height="Auto" />
             <RowDefinition x:Name="CaptionLogCard_Row" Height="Auto" />
         </Grid.RowDefinitions>
@@ -38,10 +39,20 @@
                 ToolTip="Click To Copy" />
         </ui:Card>
 
-        <ui:Card
+        <GridSplitter
+            x:Name="CaptionSplitter"
             Grid.Row="1"
+            Height="6"
+            HorizontalAlignment="Stretch"
+            Background="Transparent"
+            Cursor="SizeNS"
+            ResizeBehavior="PreviousAndNext"
+            ResizeDirection="Rows"
+            ToolTip="Drag to Resize" />
+
+        <ui:Card
+            Grid.Row="2"
             MinHeight="43"
-            Margin="0,3,0,0"
             Padding="8"
             VerticalAlignment="Stretch">
             <TextBlock
@@ -57,7 +68,7 @@
 
         <ui:Card
             x:Name="LogCards"
-            Grid.Row="2"
+            Grid.Row="3"
             Margin="0,0,0,5"
             Padding="8"
             VerticalAlignment="Top"

--- a/src/pages/CaptionPage.xaml.cs
+++ b/src/pages/CaptionPage.xaml.cs
@@ -80,12 +80,16 @@ namespace LiveCaptionsTranslator
 
             if (isCollapsed)
             {
+                OriginalCaption_Row.Height = (GridLength)converter.ConvertFromString("Auto");
                 TranslatedCaption_Row.Height = (GridLength)converter.ConvertFromString("Auto");
+                CaptionSplitter.Visibility = Visibility.Collapsed;
                 LogCards.Visibility = Visibility.Visible;
             }
             else
             {
+                OriginalCaption_Row.Height = (GridLength)converter.ConvertFromString("*");
                 TranslatedCaption_Row.Height = (GridLength)converter.ConvertFromString("*");
+                CaptionSplitter.Visibility = Visibility.Visible;
                 LogCards.Visibility = Visibility.Collapsed;
             }
         }


### PR DESCRIPTION
Previously the original caption row was always sized to content (effectively one line) and only the translated row could grow. For language learning, this is not ideal, because a user may want to see more of the original language while still having enough room for the translated language.

In this PR, both caption rows now share available height equally by default, and a GridSplitter between them lets the user drag the boundary, e.g. to give the original caption several lines. 

The splitter is hidden when caption log cards are enabled, where rows are content-sized.