### PR TITLE
Add adjustable caption font sizes on main window (Ctrl+Scroll)

### DIFF
--- a/src/models/WindowState.cs
+++ b/src/models/WindowState.cs
@@ -11,6 +11,8 @@ namespace LiveCaptionsTranslator.models
         private bool topmost = true;
         private bool captionLogEnabled = false;
         private bool latencyShow = false;
+        private int originalFontSize = 15;
+        private int translatedFontSize = 18;
 
         public bool Topmost
         {
@@ -37,6 +39,24 @@ namespace LiveCaptionsTranslator.models
             {
                 latencyShow = value;
                 OnPropertyChanged("LatencyShow");
+            }
+        }
+        public int OriginalFontSize
+        {
+            get => originalFontSize;
+            set
+            {
+                originalFontSize = value;
+                OnPropertyChanged("OriginalFontSize");
+            }
+        }
+        public int TranslatedFontSize
+        {
+            get => translatedFontSize;
+            set
+            {
+                translatedFontSize = value;
+                OnPropertyChanged("TranslatedFontSize");
             }
         }
 

--- a/src/pages/CaptionPage.xaml
+++ b/src/pages/CaptionPage.xaml
@@ -26,7 +26,8 @@
         <ui:Card
             Grid.Row="0"
             Padding="8"
-            VerticalAlignment="Stretch">
+            VerticalAlignment="Stretch"
+            PreviewMouseWheel="OriginalCard_PreviewMouseWheel">
             <TextBlock
                 x:Name="OriginalCaption"
                 Background="Transparent"
@@ -35,7 +36,7 @@
                 MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                 Style="{StaticResource CaptionBlockStyle}"
                 Text="{Binding DisplayOriginalCaption, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="Click To Copy" />
+                ToolTip="Click to Copy, Ctrl+Scroll to Resize Font" />
         </ui:Card>
 
         <ui:Card
@@ -43,7 +44,8 @@
             MinHeight="43"
             Margin="0,3,0,0"
             Padding="8"
-            VerticalAlignment="Stretch">
+            VerticalAlignment="Stretch"
+            PreviewMouseWheel="TranslatedCard_PreviewMouseWheel">
             <TextBlock
                 x:Name="TranslatedCaption"
                 Background="Transparent"
@@ -52,7 +54,7 @@
                 MouseLeftButtonDown="TextBlock_MouseLeftButtonDown"
                 Style="{StaticResource CaptionBlockStyle}"
                 Text="{Binding DisplayTranslatedCaption, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="Click To Copy" />
+                ToolTip="Click to Copy, Ctrl+Scroll to Resize Font" />
         </ui:Card>
 
         <ui:Card

--- a/src/pages/CaptionPage.xaml.cs
+++ b/src/pages/CaptionPage.xaml.cs
@@ -1,10 +1,8 @@
-﻿using System.ComponentModel;
-using System.Text;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Threading;
+using System.Windows.Input;
 
-using LiveCaptionsTranslator.utils;
+using LiveCaptionsTranslator.Utils;
 
 namespace LiveCaptionsTranslator
 {
@@ -25,15 +23,14 @@ namespace LiveCaptionsTranslator
             {
                 AutoHeight();
                 (App.Current.MainWindow as MainWindow).CaptionLogButton.Visibility = Visibility.Visible;
-                Translator.Caption.PropertyChanged += TranslatedChanged;
             };
             Unloaded += (s, e) =>
             {
                 (App.Current.MainWindow as MainWindow).CaptionLogButton.Visibility = Visibility.Collapsed;
-                Translator.Caption.PropertyChanged -= TranslatedChanged;
             };
 
             CollapseTranslatedCaption(Translator.Setting.MainWindow.CaptionLogEnabled);
+            ApplyFontSizes();
         }
 
         private async void TextBlock_MouseLeftButtonDown(object sender, RoutedEventArgs e)
@@ -53,25 +50,36 @@ namespace LiveCaptionsTranslator
             }
         }
 
-        private void TranslatedChanged(object sender, PropertyChangedEventArgs e)
+        private void ApplyFontSizes()
         {
-            if (e.PropertyName == nameof(Translator.Caption.DisplayTranslatedCaption))
-            {
-                if (Encoding.UTF8.GetByteCount(Translator.Caption.DisplayTranslatedCaption) >= TextUtil.LONG_THRESHOLD)
-                {
-                    Dispatcher.BeginInvoke(new Action(() =>
-                    {
-                        this.TranslatedCaption.FontSize = 15;
-                    }), DispatcherPriority.Background);
-                }
-                else
-                {
-                    Dispatcher.BeginInvoke(new Action(() =>
-                    {
-                        this.TranslatedCaption.FontSize = 18;
-                    }), DispatcherPriority.Background);
-                }
-            }
+            OriginalCaption.FontSize = Translator.Setting.MainWindow.OriginalFontSize;
+            TranslatedCaption.FontSize = Translator.Setting.MainWindow.TranslatedFontSize;
+        }
+
+        private void OriginalCard_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if (Keyboard.Modifiers != ModifierKeys.Control)
+                return;
+            Translator.Setting.MainWindow.OriginalFontSize =
+                AdjustFontSize(Translator.Setting.MainWindow.OriginalFontSize, e.Delta);
+            ApplyFontSizes();
+            e.Handled = true;
+        }
+
+        private void TranslatedCard_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if (Keyboard.Modifiers != ModifierKeys.Control)
+                return;
+            Translator.Setting.MainWindow.TranslatedFontSize =
+                AdjustFontSize(Translator.Setting.MainWindow.TranslatedFontSize, e.Delta);
+            ApplyFontSizes();
+            e.Handled = true;
+        }
+
+        private static int AdjustFontSize(int current, int wheelDelta)
+        {
+            int next = current + (wheelDelta > 0 ? StyleConsts.DELTA_FONT_SIZE : -StyleConsts.DELTA_FONT_SIZE);
+            return Math.Clamp(next, StyleConsts.MIN_FONT_SIZE, StyleConsts.MAX_FONT_SIZE);
         }
 
         public void CollapseTranslatedCaption(bool isCollapsed)


### PR DESCRIPTION
Ctrl+Scroll over the original or translated caption card adjusts its font size independently (clamped to StyleConsts MIN/MAX_FONT_SIZE). Sizes persist via MainWindowState (OriginalFontSize/TranslatedFontSize, defaults 15/18 matching previous fixed values).

Useful for language learning: e.g. large original text with a smaller translation below.

The previous auto-shrink of the translated caption (18 -> 15 when text is long) is removed, since it would silently override the user's chosen size.